### PR TITLE
✨ feat(planning): replace drag-and-drop board with time-proportional schedule grid

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,13 +13,13 @@
     "export": "vite build && vite export",
     "prettier:check": "prettier  --check \"**/*.{ts,tsx}\"",
     "prettier:write": "prettier --list-different --write \"**/*.{ts,tsx}\"",
-    "test": "tsc && pnpm run prettier:write"
+    "test": "tsc && pnpm run prettier:write && vitest run",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@emotion/react": "11.14.0",
     "@emotion/server": "11.11.0",
     "@hcaptcha/react-hcaptcha": "2.0.2",
-    "@hello-pangea/dnd": "18.0.1",
     "@mantine/core": "8.3.7",
     "@mantine/dates": "8.3.7",
     "@mantine/dropzone": "8.3.7",
@@ -72,6 +72,7 @@
     "prettier": "3.8.0",
     "typescript": "5.9.3",
     "vite": "8.0.8",
-    "vite-plugin-i18next-loader": "3.1.3"
+    "vite-plugin-i18next-loader": "3.1.3",
+    "vitest": "^4.1.8"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@hcaptcha/react-hcaptcha':
         specifier: 2.0.2
         version: 2.0.2
-      '@hello-pangea/dnd':
-        specifier: 18.0.1
-        version: 18.0.1(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@mantine/core':
         specifier: 8.3.7
         version: 8.3.7(@mantine/hooks@8.3.7(react@19.2.0))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -174,6 +171,9 @@ importers:
       vite-plugin-i18next-loader:
         specifier: 3.1.3
         version: 3.1.3(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.0)))
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.5.0)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.0)))
 
 packages:
 
@@ -528,12 +528,6 @@ packages:
   '@hcaptcha/react-hcaptcha@2.0.2':
     resolution: {integrity: sha512-VbuH6VJ6m3BHmVBHs0fL9t+suZd7PQEqCzqL2BiUbBvbHI3XfvSgdiug2QiEPN8zskbPTIV/FfGPF53JCckrow==}
 
-  '@hello-pangea/dnd@18.0.1':
-    resolution: {integrity: sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-
   '@hey-api/codegen-core@0.7.4':
     resolution: {integrity: sha512-DGd9yeSQzflOWO3Y5mt1GRXkXH9O/yIMgbxPjwLI3jwu/3nAjoXXD26lEeFb6tclYlg0JAqTIs5d930G/qxHeA==}
     engines: {node: '>=20.19.0'}
@@ -792,8 +786,14 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -835,9 +835,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/use-sync-external-store@0.0.6':
-    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.55.0':
     resolution: {integrity: sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==}
@@ -1040,6 +1037,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1114,6 +1140,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -1218,6 +1248,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1327,9 +1361,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  css-box-model@1.2.1:
-    resolution: {integrity: sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1483,6 +1514,9 @@ packages:
   es-iterator-helpers@1.3.2:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1653,9 +1687,16 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -2208,6 +2249,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -2487,6 +2531,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -2656,9 +2704,6 @@ packages:
   qr.js@0.0.0:
     resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
 
-  raf-schd@4.0.3:
-    resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
-
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
@@ -2713,18 +2758,6 @@ packages:
     resolution: {integrity: sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==}
     peerDependencies:
       react: '*'
-
-  react-redux@9.2.0:
-    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
-    peerDependencies:
-      '@types/react': ^18.2.25 || ^19
-      react: ^18.0 || ^19
-      redux: ^5.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      redux:
-        optional: true
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -2791,9 +2824,6 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
-
-  redux@5.0.1:
-    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2916,6 +2946,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2934,6 +2967,12 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3039,8 +3078,8 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
-  tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
@@ -3049,6 +3088,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -3278,6 +3321,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -3307,6 +3391,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3705,18 +3794,6 @@ snapshots:
 
   '@hcaptcha/react-hcaptcha@2.0.2': {}
 
-  '@hello-pangea/dnd@18.0.1(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      css-box-model: 1.2.1
-      raf-schd: 4.0.3
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.0)(redux@5.0.1)
-      redux: 5.0.1
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@hey-api/codegen-core@0.7.4':
     dependencies:
       '@hey-api/types': 0.1.4
@@ -3949,9 +4026,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -3990,8 +4074,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4273,6 +4355,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.0))
 
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.0)))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.0))
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4372,6 +4495,8 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
 
@@ -4478,6 +4603,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4579,10 +4706,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  css-box-model@1.2.1:
-    dependencies:
-      tiny-invariant: 1.3.3
 
   cssesc@3.0.0: {}
 
@@ -4781,6 +4904,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -5054,7 +5179,13 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
 
@@ -5578,6 +5709,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   markdown-table@3.0.4: {}
 
   marked-terminal@7.3.0(marked@15.0.12):
@@ -6059,6 +6194,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.2: {}
+
   ohash@2.0.11: {}
 
   open@11.0.0:
@@ -6225,8 +6362,6 @@ snapshots:
 
   qr.js@0.0.0: {}
 
-  raf-schd@4.0.3: {}
-
   rc9@2.1.2:
     dependencies:
       defu: 6.1.7
@@ -6289,15 +6424,6 @@ snapshots:
       prop-types: 15.8.1
       qr.js: 0.0.0
       react: 19.2.0
-
-  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.0)(redux@5.0.1):
-    dependencies:
-      '@types/use-sync-external-store': 0.0.6
-      react: 19.2.0
-      use-sync-external-store: 1.6.0(react@19.2.0)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      redux: 5.0.1
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.0):
     dependencies:
@@ -6372,8 +6498,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@5.0.0: {}
-
-  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6561,6 +6685,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   skin-tone@2.0.0:
@@ -6572,6 +6698,10 @@ snapshots:
   source-map@0.5.7: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -6703,7 +6833,7 @@ snapshots:
 
   through@2.3.8: {}
 
-  tiny-invariant@1.3.3: {}
+  tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
 
@@ -6711,6 +6841,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tr46@0.0.3: {}
 
@@ -6931,6 +7063,33 @@ snapshots:
       jiti: 2.6.1
       sugarss: 5.0.1(postcss@8.5.0)
 
+  vitest@4.1.8(@types/node@25.5.0)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.0))):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.0)))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.0))
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - msw
+
   void-elements@3.1.0: {}
 
   webidl-conversions@3.0.1: {}
@@ -6984,6 +7143,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -149,6 +149,7 @@
     "match_filter_option_current": "Current matches",
     "match_filter_option_past": "Hide past matches",
     "max_results_input_label": "Max results",
+    "match_scheduled_before_previous_stage_label": "Scheduled before a match of an earlier stage on this court",
     "members_table_header": "Members",
     "minutes": "minutes",
     "miscellaneous_label": "Allow players to be in multiple teams",

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -32,7 +32,9 @@ function MatchCard({
   const entry = matchesLookup[match.id];
   const color = entry != null ? stringToColour(`${entry.stageItem.id}`) : 'gray';
 
-  const cardHeightPx = (block.endMinutes - block.startMinutes) * PX_PER_MINUTE;
+  // The card covers only the playing time; the margin after the match shows as a
+  // calendar-style gap before the next card.
+  const cardHeightPx = block.durationMinutes * PX_PER_MINUTE;
   // Pick the densest layout that still fits: three rows (time / team 1 / team 2),
   // two rows (time + team 1 / team 2), or a single "time team 1 – team 2" row.
   const rows = cardHeightPx >= 52 ? 3 : cardHeightPx >= 34 ? 2 : 1;
@@ -73,27 +75,10 @@ function MatchCard({
         backgroundColor: `var(--mantine-color-${color}-light)`,
       }}
     >
-      {block.marginMinutes > 0 && (
-        <Box
-          style={{
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            height: block.marginMinutes * PX_PER_MINUTE,
-            borderTop: '1px dashed var(--mantine-color-default-border)',
-            background:
-              'repeating-linear-gradient(-45deg, transparent 0 5px, var(--mantine-color-default-border) 5px 7px)',
-            opacity: 0.35,
-            pointerEvents: 'none',
-          }}
-        />
-      )}
       <Box
         px={6}
         pt={rows === 3 ? 2 : 0}
         style={{
-          position: 'relative',
           height: '100%',
           overflow: 'hidden',
           display: 'flex',
@@ -132,7 +117,8 @@ function MatchCard({
 /**
  * Read-only, time-proportional schedule: court columns against a shared vertical time
  * ruler. Card positions and heights are proportional to computed start times and
- * durations; the pause after a match renders as a striped tail on its card.
+ * playing durations; the pause after a match shows as a calendar-style gap before
+ * the next card.
  */
 export default function ScheduleGrid({
   layout,

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -1,0 +1,232 @@
+import { Box, Flex, Text, Tooltip } from '@mantine/core';
+import { AiFillWarning } from '@react-icons/all-files/ai/AiFillWarning';
+import { format } from 'date-fns';
+import { useTranslation } from 'react-i18next';
+
+import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
+import { MatchBlock, ScheduleGridLayout } from '@logic/planning/layout';
+import { Court, MatchWithDetails } from '@openapi';
+import { MatchLookupEntry, getStageItemLookup, stringToColour } from '@services/lookups';
+
+/** Vertical scale of the grid: one minute of schedule time takes this many pixels. */
+const PX_PER_MINUTE = 5;
+const COURT_COLUMN_WIDTH = '14rem';
+const RULER_WIDTH = '3.25rem';
+const HEADER_HEIGHT = '2.5rem';
+
+function MatchCard({
+  block,
+  isViolation,
+  stageItemsLookup,
+  matchesLookup,
+  openMatchModal,
+}: {
+  block: MatchBlock<MatchWithDetails>;
+  isViolation: boolean;
+  stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
+  matchesLookup: Record<number, MatchLookupEntry>;
+  openMatchModal: (m: MatchWithDetails) => void;
+}) {
+  const { t } = useTranslation();
+  const { match } = block;
+  const entry = matchesLookup[match.id];
+  const color = entry != null ? stringToColour(`${entry.stageItem.id}`) : 'gray';
+
+  return (
+    <Box
+      onClick={() => openMatchModal(match)}
+      style={{
+        position: 'absolute',
+        top: block.startMinutes * PX_PER_MINUTE,
+        height: (block.endMinutes - block.startMinutes) * PX_PER_MINUTE,
+        left: 3,
+        right: 3,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        cursor: 'pointer',
+        borderRadius: 6,
+        border: '1px solid var(--mantine-color-default-border)',
+        borderLeft: `4px solid var(--mantine-color-${color}-filled)`,
+        backgroundColor: `var(--mantine-color-${color}-light)`,
+      }}
+    >
+      <Box px={6} pt={2} style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+        <Flex gap={4} justify="space-between" align="center" wrap="nowrap">
+          <Text size="xs" c="dimmed" lh={1.3} style={{ whiteSpace: 'nowrap' }}>
+            {format(block.startTime, 'HH:mm')}
+          </Text>
+          {isViolation && (
+            <Tooltip label={t('match_scheduled_before_previous_stage_label')}>
+              <Box
+                component="span"
+                style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}
+              >
+                <AiFillWarning color="orange" />
+              </Box>
+            </Tooltip>
+          )}
+        </Flex>
+        <Flex gap={4} align="center" wrap="nowrap">
+          {match.stage_item_input1_conflict && <AiFillWarning color="red" />}
+          <Text size="xs" fw={600} lh={1.3} truncate>
+            {formatMatchInput1(t, stageItemsLookup, matchesLookup, match)}
+          </Text>
+        </Flex>
+        <Flex gap={4} align="center" wrap="nowrap">
+          {match.stage_item_input2_conflict && <AiFillWarning color="red" />}
+          <Text size="xs" fw={600} lh={1.3} truncate>
+            {formatMatchInput2(t, stageItemsLookup, matchesLookup, match)}
+          </Text>
+        </Flex>
+      </Box>
+      {block.marginMinutes > 0 && (
+        <Box
+          style={{
+            flex: '0 0 auto',
+            height: block.marginMinutes * PX_PER_MINUTE,
+            borderTop: '1px dashed var(--mantine-color-default-border)',
+            background:
+              'repeating-linear-gradient(-45deg, transparent 0 5px, var(--mantine-color-default-border) 5px 7px)',
+            opacity: 0.35,
+          }}
+        />
+      )}
+    </Box>
+  );
+}
+
+/**
+ * Read-only, time-proportional schedule: court columns against a shared vertical time
+ * ruler. Card positions and heights are proportional to computed start times and
+ * durations; the pause after a match renders as a striped tail on its card.
+ */
+export default function ScheduleGrid({
+  layout,
+  violations,
+  stageItemsLookup,
+  matchesLookup,
+  openMatchModal,
+}: {
+  layout: ScheduleGridLayout<Court, MatchWithDetails>;
+  violations: Set<number>;
+  stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
+  matchesLookup: Record<number, MatchLookupEntry>;
+  openMatchModal: (m: MatchWithDetails) => void;
+}) {
+  const gridHeight = layout.totalMinutes * PX_PER_MINUTE;
+
+  return (
+    <Box
+      style={{
+        overflow: 'auto',
+        maxHeight: 'calc(100dvh - 14rem)',
+        maxWidth: '100%',
+        width: 'fit-content',
+        border: '1px solid var(--mantine-color-default-border)',
+        borderRadius: 8,
+      }}
+    >
+      <Flex wrap="nowrap" style={{ minWidth: 'fit-content' }}>
+        <Box
+          style={{
+            position: 'sticky',
+            left: 0,
+            zIndex: 3,
+            flex: '0 0 auto',
+            width: RULER_WIDTH,
+            backgroundColor: 'var(--mantine-color-body)',
+            borderRight: '1px solid var(--mantine-color-default-border)',
+          }}
+        >
+          <Box
+            style={{
+              position: 'sticky',
+              top: 0,
+              zIndex: 4,
+              height: HEADER_HEIGHT,
+              backgroundColor: 'var(--mantine-color-body)',
+              borderBottom: '1px solid var(--mantine-color-default-border)',
+            }}
+          />
+          <Box style={{ position: 'relative', height: gridHeight }}>
+            {layout.ticks.map((tick) => (
+              <Text
+                key={tick.offsetMinutes}
+                size="xs"
+                c="dimmed"
+                ta="right"
+                pr={6}
+                style={{
+                  position: 'absolute',
+                  top: tick.offsetMinutes * PX_PER_MINUTE,
+                  right: 0,
+                  transform: tick.offsetMinutes === 0 ? undefined : 'translateY(-50%)',
+                  backgroundColor: 'var(--mantine-color-body)',
+                }}
+              >
+                {format(tick.time, 'HH:mm')}
+              </Text>
+            ))}
+          </Box>
+        </Box>
+        {layout.courts.map(({ court, blocks }) => (
+          <Box
+            key={court.id}
+            style={{
+              flex: '0 0 auto',
+              width: COURT_COLUMN_WIDTH,
+              borderRight: '1px solid var(--mantine-color-default-border)',
+            }}
+          >
+            <Box
+              px="xs"
+              style={{
+                position: 'sticky',
+                top: 0,
+                zIndex: 2,
+                height: HEADER_HEIGHT,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: 'var(--mantine-color-body)',
+                borderBottom: '1px solid var(--mantine-color-default-border)',
+              }}
+            >
+              <Text fw={600} truncate>
+                {court.name}
+              </Text>
+            </Box>
+            <Box style={{ position: 'relative', height: gridHeight }}>
+              {layout.ticks.map((tick) =>
+                tick.offsetMinutes === 0 ? null : (
+                  <Box
+                    key={tick.offsetMinutes}
+                    style={{
+                      position: 'absolute',
+                      top: tick.offsetMinutes * PX_PER_MINUTE,
+                      left: 0,
+                      right: 0,
+                      borderTop: '1px dashed var(--mantine-color-default-border)',
+                      opacity: 0.5,
+                    }}
+                  />
+                )
+              )}
+              {blocks.map((block) => (
+                <MatchCard
+                  key={block.match.id}
+                  block={block}
+                  isViolation={violations.has(block.match.id)}
+                  stageItemsLookup={stageItemsLookup}
+                  matchesLookup={matchesLookup}
+                  openMatchModal={openMatchModal}
+                />
+              ))}
+            </Box>
+          </Box>
+        ))}
+      </Flex>
+    </Box>
+  );
+}

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -32,17 +32,39 @@ function MatchCard({
   const entry = matchesLookup[match.id];
   const color = entry != null ? stringToColour(`${entry.stageItem.id}`) : 'gray';
 
+  const cardHeightPx = (block.endMinutes - block.startMinutes) * PX_PER_MINUTE;
+  // Pick the densest layout that still fits: three rows (time / team 1 / team 2),
+  // two rows (time + team 1 / team 2), or a single "time team 1 – team 2" row.
+  const rows = cardHeightPx >= 52 ? 3 : cardHeightPx >= 34 ? 2 : 1;
+
+  const input1 = formatMatchInput1(t, stageItemsLookup, matchesLookup, match);
+  const input2 = formatMatchInput2(t, stageItemsLookup, matchesLookup, match);
+
+  const timeLabel = (
+    <Text size="xs" c="dimmed" lh={1.3} style={{ whiteSpace: 'nowrap' }}>
+      {format(block.startTime, 'HH:mm')}
+    </Text>
+  );
+  const violationIcon = isViolation ? (
+    <Tooltip label={t('match_scheduled_before_previous_stage_label')}>
+      <Box
+        component="span"
+        style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}
+      >
+        <AiFillWarning color="orange" />
+      </Box>
+    </Tooltip>
+  ) : null;
+
   return (
     <Box
       onClick={() => openMatchModal(match)}
       style={{
         position: 'absolute',
         top: block.startMinutes * PX_PER_MINUTE,
-        height: (block.endMinutes - block.startMinutes) * PX_PER_MINUTE,
+        height: cardHeightPx,
         left: 3,
         right: 3,
-        display: 'flex',
-        flexDirection: 'column',
         overflow: 'hidden',
         cursor: 'pointer',
         borderRadius: 6,
@@ -51,47 +73,58 @@ function MatchCard({
         backgroundColor: `var(--mantine-color-${color}-light)`,
       }}
     >
-      <Box px={6} pt={2} style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
-        <Flex gap={4} justify="space-between" align="center" wrap="nowrap">
-          <Text size="xs" c="dimmed" lh={1.3} style={{ whiteSpace: 'nowrap' }}>
-            {format(block.startTime, 'HH:mm')}
-          </Text>
-          {isViolation && (
-            <Tooltip label={t('match_scheduled_before_previous_stage_label')}>
-              <Box
-                component="span"
-                style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}
-              >
-                <AiFillWarning color="orange" />
-              </Box>
-            </Tooltip>
-          )}
-        </Flex>
-        <Flex gap={4} align="center" wrap="nowrap">
-          {match.stage_item_input1_conflict && <AiFillWarning color="red" />}
-          <Text size="xs" fw={600} lh={1.3} truncate>
-            {formatMatchInput1(t, stageItemsLookup, matchesLookup, match)}
-          </Text>
-        </Flex>
-        <Flex gap={4} align="center" wrap="nowrap">
-          {match.stage_item_input2_conflict && <AiFillWarning color="red" />}
-          <Text size="xs" fw={600} lh={1.3} truncate>
-            {formatMatchInput2(t, stageItemsLookup, matchesLookup, match)}
-          </Text>
-        </Flex>
-      </Box>
       {block.marginMinutes > 0 && (
         <Box
           style={{
-            flex: '0 0 auto',
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
             height: block.marginMinutes * PX_PER_MINUTE,
             borderTop: '1px dashed var(--mantine-color-default-border)',
             background:
               'repeating-linear-gradient(-45deg, transparent 0 5px, var(--mantine-color-default-border) 5px 7px)',
             opacity: 0.35,
+            pointerEvents: 'none',
           }}
         />
       )}
+      <Box
+        px={6}
+        pt={rows === 3 ? 2 : 0}
+        style={{
+          position: 'relative',
+          height: '100%',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: rows === 3 ? 'flex-start' : 'center',
+        }}
+      >
+        {rows === 3 && (
+          <Flex gap={4} justify="space-between" align="center" wrap="nowrap">
+            {timeLabel}
+            {violationIcon}
+          </Flex>
+        )}
+        <Flex gap={6} align="center" wrap="nowrap">
+          {rows < 3 && timeLabel}
+          {match.stage_item_input1_conflict && <AiFillWarning color="red" />}
+          {rows === 1 && match.stage_item_input2_conflict && <AiFillWarning color="red" />}
+          <Text size="xs" fw={600} lh={1.3} truncate style={{ flex: 1 }}>
+            {rows === 1 ? `${input1} – ${input2}` : input1}
+          </Text>
+          {rows < 3 && violationIcon}
+        </Flex>
+        {rows > 1 && (
+          <Flex gap={4} align="center" wrap="nowrap">
+            {match.stage_item_input2_conflict && <AiFillWarning color="red" />}
+            <Text size="xs" fw={600} lh={1.3} truncate>
+              {input2}
+            </Text>
+          </Flex>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/frontend/src/components/scheduling/unscheduled_sheet.tsx
+++ b/frontend/src/components/scheduling/unscheduled_sheet.tsx
@@ -1,0 +1,110 @@
+import {
+  Badge,
+  Box,
+  Collapse,
+  Divider,
+  Flex,
+  Group,
+  Paper,
+  ScrollArea,
+  Text,
+  UnstyledButton,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import { Fragment } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
+import { MatchWithDetails } from '@openapi';
+import { MatchLookupEntry, getStageItemLookup, stringToColour } from '@services/lookups';
+
+/**
+ * Collapsible bottom sheet listing matches that are not on the schedule yet.
+ * Read-only flat list; grouping and the tap-to-place flow come in later slices.
+ */
+export default function UnscheduledSheet({
+  unscheduledMatches,
+  stageItemsLookup,
+  matchesLookup,
+  openMatchModal,
+}: {
+  unscheduledMatches: MatchWithDetails[];
+  stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
+  matchesLookup: Record<number, MatchLookupEntry>;
+  openMatchModal: (m: MatchWithDetails) => void;
+}) {
+  const { t } = useTranslation();
+  const [opened, { toggle }] = useDisclosure(false);
+
+  return (
+    <Paper
+      shadow="lg"
+      radius={0}
+      withBorder
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        width: 'min(100%, 30rem)',
+        zIndex: 150,
+        borderTopLeftRadius: 12,
+        borderTopRightRadius: 12,
+        borderBottom: 'none',
+      }}
+    >
+      <UnstyledButton onClick={toggle} w="100%" p="sm" aria-expanded={opened}>
+        <Group justify="space-between" wrap="nowrap">
+          <Group gap="xs" wrap="nowrap">
+            <Text fw={600}>{t('unscheduled_title')}</Text>
+            <Badge color={unscheduledMatches.length > 0 ? 'indigo' : 'green'} variant="filled">
+              {unscheduledMatches.length}
+            </Badge>
+          </Group>
+          {opened ? <IconChevronDown size={20} /> : <IconChevronUp size={20} />}
+        </Group>
+      </UnstyledButton>
+      <Collapse in={opened}>
+        <ScrollArea.Autosize mah="45dvh">
+          <Box px="sm" pb="sm">
+            {unscheduledMatches.length === 0 && (
+              <Text c="dimmed" size="sm" pb="xs">
+                {t('unscheduled_column_empty_description')}
+              </Text>
+            )}
+            {unscheduledMatches.map((match, index) => {
+              const entry = matchesLookup[match.id];
+              return (
+                <Fragment key={match.id}>
+                  {index > 0 && <Divider />}
+                  <UnstyledButton onClick={() => openMatchModal(match)} w="100%" py="xs">
+                    <Flex justify="space-between" align="center" gap="xs" wrap="nowrap">
+                      <Box style={{ minWidth: 0 }}>
+                        <Text size="sm" fw={500} truncate>
+                          {formatMatchInput1(t, stageItemsLookup, matchesLookup, match)}
+                        </Text>
+                        <Text size="sm" fw={500} truncate>
+                          {formatMatchInput2(t, stageItemsLookup, matchesLookup, match)}
+                        </Text>
+                      </Box>
+                      {entry != null && (
+                        <Badge
+                          color={stringToColour(`${entry.stageItem.id}`)}
+                          variant="outline"
+                          style={{ flexShrink: 0 }}
+                        >
+                          {entry.stage.name} · {entry.stageItem.name}
+                        </Badge>
+                      )}
+                    </Flex>
+                  </UnstyledButton>
+                </Fragment>
+              );
+            })}
+          </Box>
+        </ScrollArea.Autosize>
+      </Collapse>
+    </Paper>
+  );
+}

--- a/frontend/src/logic/planning/layout.test.ts
+++ b/frontend/src/logic/planning/layout.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import { LayoutCourt, LayoutMatch, computeScheduleLayout } from './layout';
+
+const TOURNAMENT_START = '2026-06-10T09:00:00Z';
+
+function court(id: number): LayoutCourt {
+  return { id, name: `Court ${id}` };
+}
+
+function match(
+  id: number,
+  position: number | null,
+  durationMinutes = 15,
+  marginMinutes = 5,
+  startTime: string | null = TOURNAMENT_START
+): LayoutMatch {
+  return {
+    id,
+    position_in_schedule: position,
+    duration_minutes: durationMinutes,
+    margin_minutes: marginMinutes,
+    start_time: startTime,
+  };
+}
+
+describe('computeScheduleLayout', () => {
+  it('packs matches sequentially from the tournament start time', () => {
+    const layout = computeScheduleLayout({
+      courts: [court(1)],
+      matchesByCourtId: { 1: [match(10, 0, 15, 5), match(11, 1, 30, 10)] },
+      tournamentStartTime: TOURNAMENT_START,
+    });
+
+    expect(layout.courts).toHaveLength(1);
+    const blocks = layout.courts[0].blocks;
+    expect(blocks.map((b) => b.match.id)).toEqual([10, 11]);
+
+    expect(blocks[0].startMinutes).toBe(0);
+    expect(blocks[0].durationMinutes).toBe(15);
+    expect(blocks[0].marginMinutes).toBe(5);
+    expect(blocks[0].endMinutes).toBe(20);
+    expect(blocks[0].startTime).toEqual(new Date('2026-06-10T09:00:00Z'));
+
+    expect(blocks[1].startMinutes).toBe(20);
+    expect(blocks[1].durationMinutes).toBe(30);
+    expect(blocks[1].marginMinutes).toBe(10);
+    expect(blocks[1].endMinutes).toBe(60);
+    expect(blocks[1].startTime).toEqual(new Date('2026-06-10T09:20:00Z'));
+  });
+
+  it('orders matches by position_in_schedule regardless of input order', () => {
+    const layout = computeScheduleLayout({
+      courts: [court(1)],
+      matchesByCourtId: { 1: [match(12, 2), match(10, 0), match(11, 1)] },
+      tournamentStartTime: TOURNAMENT_START,
+    });
+
+    expect(layout.courts[0].blocks.map((b) => b.match.id)).toEqual([10, 11, 12]);
+    expect(layout.courts[0].blocks.map((b) => b.startMinutes)).toEqual([0, 20, 40]);
+  });
+
+  it('packs each court independently with varying durations and margins', () => {
+    const layout = computeScheduleLayout({
+      courts: [court(1), court(2), court(3)],
+      matchesByCourtId: {
+        1: [match(10, 0, 15, 5), match(11, 1, 15, 5)],
+        2: [match(20, 0, 45, 0), match(21, 1, 10, 20)],
+      },
+      tournamentStartTime: TOURNAMENT_START,
+    });
+
+    expect(layout.courts.map((c) => c.court.id)).toEqual([1, 2, 3]);
+
+    const [c1, c2, c3] = layout.courts;
+    expect(c1.blocks.map((b) => [b.startMinutes, b.endMinutes])).toEqual([
+      [0, 20],
+      [20, 40],
+    ]);
+    expect(c2.blocks.map((b) => [b.startMinutes, b.endMinutes])).toEqual([
+      [0, 45],
+      [45, 75],
+    ]);
+    expect(c3.blocks).toEqual([]);
+  });
+
+  it('excludes unscheduled matches (no start time)', () => {
+    const layout = computeScheduleLayout({
+      courts: [court(1)],
+      matchesByCourtId: { 1: [match(10, 0), match(11, null, 15, 5, null)] },
+      tournamentStartTime: TOURNAMENT_START,
+    });
+
+    expect(layout.courts[0].blocks.map((b) => b.match.id)).toEqual([10]);
+  });
+
+  it('rounds the total height up to a whole tick interval covering the longest court', () => {
+    const layout = computeScheduleLayout({
+      courts: [court(1), court(2)],
+      matchesByCourtId: {
+        1: [match(10, 0, 15, 5)],
+        2: [match(20, 0, 60, 10)],
+      },
+      tournamentStartTime: TOURNAMENT_START,
+      tickIntervalMinutes: 30,
+    });
+
+    // Longest court ends at 70 minutes -> rounded up to 90.
+    expect(layout.totalMinutes).toBe(90);
+  });
+
+  it('uses a minimum total height for an empty schedule', () => {
+    const layout = computeScheduleLayout({
+      courts: [court(1)],
+      matchesByCourtId: {},
+      tournamentStartTime: TOURNAMENT_START,
+      tickIntervalMinutes: 30,
+      minTotalMinutes: 60,
+    });
+
+    expect(layout.totalMinutes).toBe(60);
+    expect(layout.courts[0].blocks).toEqual([]);
+  });
+
+  it('generates ruler ticks at the given interval, including both ends', () => {
+    const layout = computeScheduleLayout({
+      courts: [court(1)],
+      matchesByCourtId: { 1: [match(10, 0, 50, 10)] },
+      tournamentStartTime: TOURNAMENT_START,
+      tickIntervalMinutes: 30,
+    });
+
+    expect(layout.totalMinutes).toBe(60);
+    expect(layout.ticks.map((tick) => tick.offsetMinutes)).toEqual([0, 30, 60]);
+    expect(layout.ticks.map((tick) => tick.time)).toEqual([
+      new Date('2026-06-10T09:00:00Z'),
+      new Date('2026-06-10T09:30:00Z'),
+      new Date('2026-06-10T10:00:00Z'),
+    ]);
+  });
+
+  it('reflects custom (already-resolved) durations in block sizes', () => {
+    // The backend folds custom durations/margins into duration_minutes/margin_minutes,
+    // so the layout only needs to honour the effective values.
+    const layout = computeScheduleLayout({
+      courts: [court(1)],
+      matchesByCourtId: { 1: [match(10, 0, 90, 2), match(11, 1, 5, 0)] },
+      tournamentStartTime: TOURNAMENT_START,
+    });
+
+    const blocks = layout.courts[0].blocks;
+    expect(blocks[0].endMinutes - blocks[0].startMinutes).toBe(92);
+    expect(blocks[1].startMinutes).toBe(92);
+    expect(blocks[1].endMinutes).toBe(97);
+  });
+});

--- a/frontend/src/logic/planning/layout.ts
+++ b/frontend/src/logic/planning/layout.ts
@@ -1,0 +1,122 @@
+/**
+ * Pure, headless layout computation for the time-proportional schedule grid.
+ *
+ * Mirrors the backend packing rule (`reschedule_matches_in_db`): per court, scheduled
+ * matches are sorted by `position_in_schedule` and packed sequentially, gapless, from
+ * the tournament start time, each occupying `duration_minutes + margin_minutes`.
+ * All positions are expressed in minutes from the tournament start; rendering converts
+ * minutes to pixels.
+ */
+
+export interface LayoutCourt {
+  id: number;
+  name: string;
+}
+
+export interface LayoutMatch {
+  id: number;
+  duration_minutes: number;
+  margin_minutes: number;
+  position_in_schedule: number | null;
+  start_time: string | null;
+}
+
+export interface MatchBlock<M extends LayoutMatch = LayoutMatch> {
+  match: M;
+  /** Offset of the match start from the tournament start. */
+  startMinutes: number;
+  /** Playing time (the backend already folds custom durations into this). */
+  durationMinutes: number;
+  /** Pause after the match, rendered as a distinct tail on the card. */
+  marginMinutes: number;
+  /** `startMinutes + durationMinutes + marginMinutes`. */
+  endMinutes: number;
+  /** Absolute computed start time. */
+  startTime: Date;
+}
+
+export interface CourtTimeline<
+  C extends LayoutCourt = LayoutCourt,
+  M extends LayoutMatch = LayoutMatch,
+> {
+  court: C;
+  blocks: MatchBlock<M>[];
+}
+
+export interface RulerTick {
+  offsetMinutes: number;
+  time: Date;
+}
+
+export interface ScheduleGridLayout<
+  C extends LayoutCourt = LayoutCourt,
+  M extends LayoutMatch = LayoutMatch,
+> {
+  courts: CourtTimeline<C, M>[];
+  /** Height of the grid in minutes: the longest court, rounded up to a whole tick. */
+  totalMinutes: number;
+  ticks: RulerTick[];
+}
+
+export interface ScheduleLayoutInput<C extends LayoutCourt, M extends LayoutMatch> {
+  courts: C[];
+  matchesByCourtId: Record<number, M[]>;
+  tournamentStartTime: string | Date;
+  tickIntervalMinutes?: number;
+  minTotalMinutes?: number;
+}
+
+const DEFAULT_TICK_INTERVAL_MINUTES = 30;
+const DEFAULT_MIN_TOTAL_MINUTES = 60;
+
+function addMinutes(date: Date, minutes: number): Date {
+  return new Date(date.getTime() + minutes * 60_000);
+}
+
+export function computeScheduleLayout<C extends LayoutCourt, M extends LayoutMatch>({
+  courts,
+  matchesByCourtId,
+  tournamentStartTime,
+  tickIntervalMinutes = DEFAULT_TICK_INTERVAL_MINUTES,
+  minTotalMinutes = DEFAULT_MIN_TOTAL_MINUTES,
+}: ScheduleLayoutInput<C, M>): ScheduleGridLayout<C, M> {
+  const startTime =
+    tournamentStartTime instanceof Date ? tournamentStartTime : new Date(tournamentStartTime);
+
+  const courtTimelines = courts.map((c) => {
+    const scheduled = (matchesByCourtId[c.id] ?? [])
+      .filter((m) => m.start_time != null)
+      .sort((m1, m2) => (m1.position_in_schedule ?? 0) - (m2.position_in_schedule ?? 0));
+
+    const blocks: MatchBlock<M>[] = [];
+    let currentMinutes = 0;
+    for (const m of scheduled) {
+      const endMinutes = currentMinutes + m.duration_minutes + m.margin_minutes;
+      blocks.push({
+        match: m,
+        startMinutes: currentMinutes,
+        durationMinutes: m.duration_minutes,
+        marginMinutes: m.margin_minutes,
+        endMinutes,
+        startTime: addMinutes(startTime, currentMinutes),
+      });
+      currentMinutes = endMinutes;
+    }
+    return { court: c, blocks };
+  });
+
+  const maxEndMinutes = Math.max(
+    minTotalMinutes,
+    ...courtTimelines.map(
+      (timeline) => timeline.blocks[timeline.blocks.length - 1]?.endMinutes ?? 0
+    )
+  );
+  const totalMinutes = Math.ceil(maxEndMinutes / tickIntervalMinutes) * tickIntervalMinutes;
+
+  const ticks: RulerTick[] = [];
+  for (let offset = 0; offset <= totalMinutes; offset += tickIntervalMinutes) {
+    ticks.push({ offsetMinutes: offset, time: addMinutes(startTime, offset) });
+  }
+
+  return { courts: courtTimelines, totalMinutes, ticks };
+}

--- a/frontend/src/logic/planning/layout.ts
+++ b/frontend/src/logic/planning/layout.ts
@@ -27,7 +27,7 @@ export interface MatchBlock<M extends LayoutMatch = LayoutMatch> {
   startMinutes: number;
   /** Playing time (the backend already folds custom durations into this). */
   durationMinutes: number;
-  /** Pause after the match, rendered as a distinct tail on the card. */
+  /** Pause after the match, rendered as a gap between this card and the next. */
   marginMinutes: number;
   /** `startMinutes + durationMinutes + marginMinutes`. */
   endMinutes: number;

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -1,436 +1,28 @@
-import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
-import {
-  ActionIcon,
-  Alert,
-  Badge,
-  Box,
-  Button,
-  Card,
-  Divider,
-  Grid,
-  Group,
-  Menu,
-  Paper,
-  Stack,
-  Text,
-  Title,
-  alpha,
-  useMantineColorScheme,
-  useMantineTheme,
-} from '@mantine/core';
-import { AiFillWarning } from '@react-icons/all-files/ai/AiFillWarning';
-import { IconAlertCircle, IconCalendarPlus, IconDots, IconTrash } from '@tabler/icons-react';
+import { Box, Button, Grid, Group, Stack, Title } from '@mantine/core';
+import { IconCalendarPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SWRResponse } from 'swr';
 
-import { LevelBadge } from '@components/levels/levels';
 import CourtModal from '@components/modals/create_court_modal';
 import MatchModal from '@components/modals/match_modal';
 import { NoContent } from '@components/no_content/empty_table_info';
-import { assert_not_none } from '@components/utils/assert';
-import { Time } from '@components/utils/datetime';
-import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
-import { TournamentMinimal } from '@components/utils/tournament';
 import { getTournamentIdFromRouter, responseIsValid } from '@components/utils/util';
-import {
-  Court,
-  CourtsResponse,
-  LevelResponse,
-  MatchWithDetails,
-  StageWithStageItems,
-} from '@openapi';
+import { computeScheduleLayout } from '@logic/planning/layout';
+import { Court, MatchWithDetails, StageWithStageItems } from '@openapi';
 import TournamentLayout from '@pages/tournaments/_tournament_layout';
 import { getCourts, getStages, getTournamentById } from '@services/adapter';
-import { deleteCourt } from '@services/court';
 import {
   MatchLookupEntry,
   getMatchLookup,
   getMatchLookupByCourt,
-  getScheduleData,
   getStageItemLookup,
   getStageOrderViolations,
   getUnscheduledMatches,
-  stringToColour,
 } from '@services/lookups';
-import { rescheduleMatch, scheduleMatches, unscheduleMatch } from '@services/match';
+import { scheduleMatches } from '@services/match';
 
-const COL_WIDTH = '25rem';
-
-function unschedLevelDroppableId(levelId: number | null) {
-  return `ul-${levelId ?? 'null'}`;
-}
-
-function courtDroppableId(courtId: number) {
-  return `c-${courtId}`;
-}
-
-function isUnschedDroppableId(droppableId: string) {
-  return droppableId.startsWith('ul-');
-}
-
-function tryParseCourtDroppableId(droppableId: string): number | null {
-  const m = droppableId.match(/^c-(\d+)$/);
-  return m ? parseInt(m[1], 10) : null;
-}
-
-function getMatchStateColor(state: string) {
-  if (state === 'IN_PROGRESS') return 'blue';
-  if (state === 'COMPLETED') return 'green';
-  return 'gray';
-}
-
-function ScheduleRow({
-  index,
-  match,
-  openMatchModal,
-  stageItemsLookup,
-  matchesLookup,
-  levels,
-  isViolation,
-}: {
-  index: number;
-  match: MatchWithDetails;
-  openMatchModal: (m: MatchWithDetails) => void;
-  stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
-  matchesLookup: Record<number, MatchLookupEntry>;
-  levels: LevelResponse[];
-  isViolation?: boolean;
-}) {
-  const { t } = useTranslation();
-  const entry = matchesLookup[match.id];
-  return (
-    <Draggable key={match.id} index={index} draggableId={`${match.id}`}>
-      {(provided) => (
-        <div ref={provided.innerRef} {...provided.draggableProps}>
-          <Card
-            shadow="sm"
-            padding="lg"
-            radius="md"
-            withBorder
-            mt="md"
-            onClick={() => {
-              openMatchModal(match);
-            }}
-            {...provided.dragHandleProps}
-          >
-            <Grid>
-              <Grid.Col span="auto">
-                <Group gap="xs">
-                  {match.stage_item_input1_conflict && <AiFillWarning color="red" />}
-                  <Text fw={500}>
-                    {formatMatchInput1(t, stageItemsLookup, matchesLookup, match)}
-                  </Text>
-                </Group>
-                <Group gap="xs">
-                  {match.stage_item_input2_conflict && <AiFillWarning color="red" />}
-                  <Text fw={500}>
-                    {formatMatchInput2(t, stageItemsLookup, matchesLookup, match)}
-                  </Text>
-                </Group>
-              </Grid.Col>
-              <Grid.Col span="content">
-                <Stack gap="xs" align="end">
-                  {isViolation && <AiFillWarning color="orange" />}
-                  <Badge variant="default" size="lg">
-                    {match.start_time != null ? <Time datetime={match.start_time} /> : null}
-                  </Badge>
-                  <Badge color={getMatchStateColor(match.state)} variant="light">
-                    {t(`match_state_${String(match.state).toLowerCase()}`)}
-                  </Badge>
-                  <LevelBadge levels={levels} levelId={entry.stage.level_id} />
-                  <Badge color={stringToColour(`${entry.stageItem.id}`)} variant="outline">
-                    {entry.stage.name} · {entry.stageItem.name}
-                  </Badge>
-                </Stack>
-              </Grid.Col>
-            </Grid>
-          </Card>
-        </div>
-      )}
-    </Draggable>
-  );
-}
-
-/** One unscheduled column per level (or a single "Unscheduled" column for no-level tournaments). */
-function LevelUnscheduledColumn({
-  levelId,
-  levelName,
-  stages,
-  allUnscheduled,
-  openMatchModal,
-  stageItemsLookup,
-  matchesLookup,
-  levels,
-}: {
-  levelId: number | null;
-  levelName: string;
-  stages: StageWithStageItems[];
-  allUnscheduled: MatchWithDetails[];
-  openMatchModal: (m: MatchWithDetails) => void;
-  stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
-  matchesLookup: Record<number, MatchLookupEntry>;
-  levels: LevelResponse[];
-}) {
-  const { t } = useTranslation();
-  const { colorScheme } = useMantineColorScheme();
-  const theme = useMantineTheme();
-
-  const subtleLaneBg =
-    colorScheme === 'dark' ? alpha(theme.white, 0.045) : alpha(theme.black, 0.022);
-  const subtleLaneBorder =
-    colorScheme === 'dark' ? alpha(theme.colors.dark[2], 0.4) : alpha(theme.colors.gray[6], 0.35);
-
-  const levelMatches = allUnscheduled.filter(
-    (m) => (matchesLookup[m.id]?.stage.level_id ?? null) === levelId
-  );
-
-  // Group by stage; auto-hide stages with no unscheduled matches
-  const levelStages = stages.filter((s) => (s.level_id ?? null) === levelId);
-  const stageGroups = levelStages
-    .map((stage) => ({
-      stage,
-      matches: levelMatches.filter((m) => matchesLookup[m.id]?.stage.id === stage.id),
-    }))
-    .filter((g) => g.matches.length > 0);
-
-  const flatMatches = stageGroups.flatMap((g) => g.matches);
-  const matchIndex = new Map(flatMatches.map((m, i) => [m.id, i]));
-
-  return (
-    <Droppable droppableId={unschedLevelDroppableId(levelId)} direction="vertical">
-      {(provided) => (
-        <div {...provided.droppableProps} ref={provided.innerRef}>
-          <Paper
-            shadow="none"
-            p="md"
-            radius="md"
-            withBorder
-            style={{
-              width: COL_WIDTH,
-              flex: '0 0 auto',
-              borderStyle: 'dashed',
-              borderWidth: 2,
-              borderColor: subtleLaneBorder,
-              backgroundColor: subtleLaneBg,
-              minHeight: 200,
-            }}
-          >
-            <Title order={4} mb="sm" ta="center">
-              {levelName}
-            </Title>
-            {stageGroups.map((group) => (
-              <Box key={group.stage.id}>
-                <Divider
-                  my="xs"
-                  label={group.stage.name}
-                  labelPosition="left"
-                  c="dimmed"
-                  styles={{ label: { color: 'var(--mantine-color-dimmed)', fontSize: '0.75rem' } }}
-                />
-                {group.matches.map((m) => (
-                  <ScheduleRow
-                    key={m.id}
-                    index={matchIndex.get(m.id)!}
-                    stageItemsLookup={stageItemsLookup}
-                    matchesLookup={matchesLookup}
-                    match={m}
-                    openMatchModal={openMatchModal}
-                    levels={levels}
-                  />
-                ))}
-              </Box>
-            ))}
-            {levelMatches.length < 1 && (
-              <Alert
-                icon={<IconAlertCircle size={16} />}
-                title={t('all_matches_scheduled_title')}
-                color="green"
-                radius="md"
-                mt="1rem"
-              >
-                {t('unscheduled_column_empty_description')}
-              </Alert>
-            )}
-            {provided.placeholder}
-          </Paper>
-        </div>
-      )}
-    </Droppable>
-  );
-}
-
-/** Flat court column — no stage dividers; shows stage-order violation warnings on cards. */
-function FlatCourtColumn({
-  tournamentId,
-  court,
-  matches,
-  openMatchModal,
-  stageItemsLookup,
-  swrCourtsResponse,
-  matchesLookup,
-  violations,
-  levels,
-}: {
-  tournamentId: number;
-  court: Court;
-  matches: MatchWithDetails[];
-  openMatchModal: (m: MatchWithDetails) => void;
-  stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
-  swrCourtsResponse: SWRResponse<CourtsResponse>;
-  matchesLookup: Record<number, MatchLookupEntry>;
-  violations: Set<number>;
-  levels: LevelResponse[];
-}) {
-  const { t } = useTranslation();
-
-  return (
-    <Droppable droppableId={courtDroppableId(court.id)} direction="vertical">
-      {(provided) => (
-        <div {...provided.droppableProps} ref={provided.innerRef}>
-          <div style={{ width: COL_WIDTH }}>
-            <Group justify="space-between">
-              <Group>
-                <h4 style={{ marginTop: '0', margin: 'auto' }}>{court.name}</h4>
-              </Group>
-              <Menu withinPortal position="bottom-end" shadow="sm">
-                <Menu.Target>
-                  <ActionIcon variant="transparent" color="gray">
-                    <IconDots size="1.25rem" />
-                  </ActionIcon>
-                </Menu.Target>
-                <Menu.Dropdown>
-                  <Menu.Item
-                    leftSection={<IconTrash size="1.5rem" />}
-                    onClick={async () => {
-                      await deleteCourt(tournamentId, court.id);
-                      await swrCourtsResponse.mutate();
-                    }}
-                    color="red"
-                  >
-                    {t('delete_court_button')}
-                  </Menu.Item>
-                </Menu.Dropdown>
-              </Menu>
-            </Group>
-            {matches.map((m: MatchWithDetails, index: number) => (
-              <ScheduleRow
-                key={m.id}
-                index={index}
-                stageItemsLookup={stageItemsLookup}
-                matchesLookup={matchesLookup}
-                match={m}
-                openMatchModal={openMatchModal}
-                levels={levels}
-                isViolation={violations.has(m.id)}
-              />
-            ))}
-            {matches.length < 1 && (
-              <Alert
-                icon={<IconAlertCircle size={16} />}
-                title={t('no_matches_title')}
-                color="gray"
-                radius="md"
-                mt="1rem"
-              >
-                {t('drop_match_alert_title')}
-              </Alert>
-            )}
-            {provided.placeholder}
-          </div>
-        </div>
-      )}
-    </Droppable>
-  );
-}
-
-/**
- * Renders the planning board: per-level unscheduled columns followed by flat court columns.
- * Single-level and no-level tournaments use one unscheduled column (unified code path).
- */
-function Schedule({
-  stages,
-  tournament,
-  swrCourtsResponse,
-  stageItemsLookup,
-  matchesLookup,
-  schedule,
-  unscheduledMatches,
-  openMatchModal,
-  levels,
-}: {
-  stages: StageWithStageItems[];
-  tournament: TournamentMinimal;
-  swrCourtsResponse: SWRResponse<CourtsResponse>;
-  stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
-  matchesLookup: Record<number, MatchLookupEntry>;
-  schedule: { court: Court; matches: MatchWithDetails[] }[];
-  unscheduledMatches: MatchWithDetails[];
-  openMatchModal: (m: MatchWithDetails) => void;
-  levels: LevelResponse[];
-}) {
-  const { t } = useTranslation();
-
-  if (schedule.length < 1) {
-    return (
-      <Stack align="center">
-        <NoContent title={t('no_courts_title')} description={t('no_courts_description')} />
-        <CourtModal
-          swrCourtsResponse={swrCourtsResponse}
-          tournamentId={tournament.id}
-          buttonSize="lg"
-        />
-      </Stack>
-    );
-  }
-
-  const unschedColumns =
-    levels.length > 0
-      ? levels.map((level) => ({ levelId: level.id as number | null, levelName: level.name }))
-      : [{ levelId: null as number | null, levelName: t('unscheduled_title') }];
-
-  return (
-    <Group wrap="nowrap" align="top">
-      {unschedColumns.map(({ levelId, levelName }) => (
-        <LevelUnscheduledColumn
-          key={`ul-${levelId ?? 'null'}`}
-          levelId={levelId}
-          levelName={levelName}
-          stages={stages}
-          allUnscheduled={unscheduledMatches}
-          openMatchModal={openMatchModal}
-          stageItemsLookup={stageItemsLookup}
-          matchesLookup={matchesLookup}
-          levels={levels}
-        />
-      ))}
-      {schedule.map((item) => {
-        const violations = getStageOrderViolations(item.matches, matchesLookup, stages);
-        return (
-          <FlatCourtColumn
-            key={item.court.id}
-            tournamentId={tournament.id}
-            swrCourtsResponse={swrCourtsResponse}
-            stageItemsLookup={stageItemsLookup}
-            matchesLookup={matchesLookup}
-            court={item.court}
-            matches={item.matches}
-            openMatchModal={openMatchModal}
-            violations={violations}
-            levels={levels}
-          />
-        );
-      })}
-      <div key="add-court" style={{ width: COL_WIDTH }}>
-        <CourtModal
-          swrCourtsResponse={swrCourtsResponse}
-          tournamentId={tournament.id}
-          buttonSize="xs"
-        />
-      </div>
-    </Group>
-  );
-}
+import ScheduleGrid from '@components/scheduling/schedule_grid';
+import UnscheduledSheet from '@components/scheduling/unscheduled_sheet';
 
 export default function SchedulePage() {
   const [modalOpened, modalSetOpened] = useState(false);
@@ -441,7 +33,6 @@ export default function SchedulePage() {
   const swrStagesResponse = getStages(tournamentData.id);
   const swrCourtsResponse = getCourts(tournamentData.id);
   const swrTournamentResponse = getTournamentById(tournamentData.id);
-  const levels = swrTournamentResponse.data?.data.levels ?? [];
 
   const stageItemsLookup = responseIsValid(swrStagesResponse)
     ? getStageItemLookup(swrStagesResponse)
@@ -449,14 +40,9 @@ export default function SchedulePage() {
   const matchesLookup: Record<number, MatchLookupEntry> = responseIsValid(swrStagesResponse)
     ? getMatchLookup(swrStagesResponse)
     : ({} as Record<number, MatchLookupEntry>);
-  const matchesByCourtId = responseIsValid(swrStagesResponse)
+  const matchesByCourtId: Record<number, MatchWithDetails[]> = responseIsValid(swrStagesResponse)
     ? getMatchLookupByCourt(swrStagesResponse)
-    : [];
-
-  const data =
-    responseIsValid(swrCourtsResponse) && responseIsValid(swrStagesResponse)
-      ? getScheduleData(swrCourtsResponse, matchesByCourtId)
-      : [];
+    : {};
 
   const unscheduledMatches = responseIsValid(swrStagesResponse)
     ? getUnscheduledMatches(swrStagesResponse)
@@ -464,48 +50,33 @@ export default function SchedulePage() {
 
   if (!responseIsValid(swrStagesResponse)) return null;
   if (!responseIsValid(swrCourtsResponse)) return null;
+  if (!responseIsValid(swrTournamentResponse)) return null;
 
+  const tournament = swrTournamentResponse.data!.data;
+  const courts: Court[] = swrCourtsResponse.data?.data ?? [];
   const rawStages: StageWithStageItems[] = swrStagesResponse.data?.data ?? [];
+
+  const layout = computeScheduleLayout({
+    courts,
+    matchesByCourtId,
+    tournamentStartTime: tournament.start_time,
+  });
+
+  const violations = new Set<number>();
+  for (const { blocks } of layout.courts) {
+    for (const matchId of getStageOrderViolations(
+      blocks.map((block) => block.match),
+      matchesLookup,
+      rawStages
+    )) {
+      violations.add(matchId);
+    }
+  }
 
   function openMatchModal(matchToOpen: MatchWithDetails) {
     setMatch(matchToOpen);
     modalSetOpened(true);
   }
-
-  const handleDragEnd: Parameters<typeof DragDropContext>[0]['onDragEnd'] = async ({
-    destination,
-    source,
-    draggableId: matchIdStr,
-  }) => {
-    if (destination == null || source == null) return;
-
-    const fromUnsched = isUnschedDroppableId(source.droppableId);
-    const toUnsched = isUnschedDroppableId(destination.droppableId);
-
-    // Drag between unscheduled columns is a no-op (cannot change a match's level via drag)
-    if (fromUnsched && toUnsched) return;
-
-    const matchId = +matchIdStr;
-    const m = matchesLookup[matchId]?.match;
-    if (m == null) return;
-
-    if (toUnsched) {
-      await unscheduleMatch(tournamentData.id, matchId);
-    } else {
-      const destCourtId = tryParseCourtDroppableId(destination.droppableId);
-      if (destCourtId == null) return;
-      await rescheduleMatch(tournamentData.id, matchId, {
-        old_court_id: m.court_id != null && m.start_time != null ? m.court_id : null,
-        old_position:
-          m.court_id != null && m.start_time != null
-            ? assert_not_none(m.position_in_schedule)
-            : null,
-        new_court_id: destCourtId,
-        new_position: destination.index,
-      });
-    }
-    await swrStagesResponse.mutate();
-  };
 
   return (
     <TournamentLayout tournament_id={tournamentData.id}>
@@ -525,7 +96,7 @@ export default function SchedulePage() {
           <Title>{t('planning_title')}</Title>
         </Grid.Col>
         <Grid.Col span={6}>
-          {data.length < 1 ? null : (
+          {courts.length < 1 ? null : (
             <Group justify="right">
               <Button
                 color="indigo"
@@ -544,21 +115,32 @@ export default function SchedulePage() {
           )}
         </Grid.Col>
       </Grid>
-      <Box mt="1rem" style={{ overflowX: 'auto' }}>
-        <DragDropContext onDragEnd={handleDragEnd}>
-          <Schedule
-            stages={rawStages}
-            tournament={tournamentData}
+      {courts.length < 1 ? (
+        <Stack align="center" mt="1rem">
+          <NoContent title={t('no_courts_title')} description={t('no_courts_description')} />
+          <CourtModal
             swrCourtsResponse={swrCourtsResponse}
-            schedule={data}
+            tournamentId={tournamentData.id}
+            buttonSize="lg"
+          />
+        </Stack>
+      ) : (
+        <Box mt="1rem" pb="4rem">
+          <ScheduleGrid
+            layout={layout}
+            violations={violations}
+            stageItemsLookup={stageItemsLookup}
+            matchesLookup={matchesLookup}
+            openMatchModal={openMatchModal}
+          />
+          <UnscheduledSheet
             unscheduledMatches={unscheduledMatches}
             stageItemsLookup={stageItemsLookup}
             matchesLookup={matchesLookup}
             openMatchModal={openMatchModal}
-            levels={levels}
           />
-        </DragDropContext>
-      </Box>
+        </Box>
+      )}
     </TournamentLayout>
   );
 }

--- a/frontend/src/services/lookups.tsx
+++ b/frontend/src/services/lookups.tsx
@@ -1,10 +1,7 @@
 import { SWRResponse } from 'swr';
 
-import { assert_not_none } from '@components/utils/assert';
 import { groupBy, responseIsValid } from '@components/utils/util';
 import {
-  Court,
-  CourtsResponse,
   FullTeamWithPlayers,
   MatchWithDetails,
   StageItemWithRounds,
@@ -212,20 +209,4 @@ export function getStageOrderViolations(
   }
 
   return violations;
-}
-
-export function getScheduleData(
-  swrCourtsResponse: SWRResponse<CourtsResponse>,
-  matchesByCourtId: any
-): { court: Court; matches: MatchWithDetails[] }[] {
-  return (swrCourtsResponse.data?.data || []).map((court: Court) => ({
-    matches: (matchesByCourtId[court.id] || [])
-      .filter((match: MatchWithDetails) => match.start_time != null)
-      .sort((m1: MatchWithDetails, m2: MatchWithDetails) => {
-        return assert_not_none(m1.position_in_schedule) > assert_not_none(m2.position_in_schedule)
-          ? 1
-          : -1 || [];
-      }),
-    court,
-  }));
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});


### PR DESCRIPTION
Rewrite the planning page as a read-only, time-proportional schedule:
court columns are laid out against a shared sticky time ruler starting at
the tournament start time. Each scheduled match renders as a card whose
position and height reflect its computed start time and duration, with
the pause-after-match shown as a striped tail. Cards keep team names
(including placeholder inputs), computed start times, input conflicts,
and stage-order violation warnings (now with a tooltip).

Unscheduled matches move to a collapsible bottom sheet with a count
badge (flat, read-only list). The "schedule all unscheduled matches"
button is kept, as is the match modal on card tap. The @hello-pangea/dnd
dependency is removed entirely; manual moves/unscheduling and court
delete return in later slices of the planning rewrite (#40).

The layout computation (courts + matches + tournament start ->
time-positioned blocks per court plus ruler ticks) lives in a pure,
headless module mirroring the backend packing rule. This also introduces
vitest to the frontend; the layout module is covered by tests which run
via `pnpm test` alongside typecheck and prettier.

Closes #41

https://claude.ai/code/session_01TpXzMoTbbXmNQ9pYtvtwsf