### PR TITLE
⚡️ perf(docker): cache dependency layers and trim build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+docs
+**/node_modules
+**/.venv
+**/dist
+**/build
+**/__pycache__
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,29 +5,35 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+RUN apk add pnpm
+
+# Install dependencies before copying the source so this layer is only
+# rebuilt when the lockfile changes
+COPY frontend/package.json frontend/pnpm-lock.yaml ./
+RUN CI=true pnpm install
+
 COPY frontend .
 
 ARG VITE_API_BASE_URL=/api
-RUN apk add pnpm && \
-    CI=true pnpm install && \
-    VITE_API_BASE_URL=${VITE_API_BASE_URL} pnpm build
+RUN VITE_API_BASE_URL=${VITE_API_BASE_URL} pnpm build
 
 # Build backend image that also serves frontend (stored in `/app/frontend-dist`)
 FROM python:3.14-alpine3.22
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-RUN rm -rf /var/cache/apk/*
-
-COPY backend /app
 WORKDIR /app
 
-# -- Install dependencies:
 RUN addgroup --system bracket && \
     adduser --system bracket --ingroup bracket && \
-    chown -R bracket:bracket /app
+    chown bracket:bracket /app
 USER bracket
 
+# Install dependencies before copying the source so this layer is only
+# rebuilt when the lockfile changes
+COPY --chown=bracket:bracket backend/pyproject.toml backend/uv.lock ./
 RUN uv sync --no-dev --locked
+
+COPY --chown=bracket:bracket backend /app
 
 COPY --from=builder /app/dist /app/frontend-dist
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,18 +1,19 @@
 FROM python:3.14-alpine3.22
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-RUN rm -rf /var/cache/apk/*
-
-COPY . /app
 WORKDIR /app
 
-# -- Install dependencies:
 RUN addgroup --system bracket && \
     adduser --system bracket --ingroup bracket && \
-    chown -R bracket:bracket /app
+    chown bracket:bracket /app
 USER bracket
 
+# Install dependencies before copying the source so this layer is only
+# rebuilt when the lockfile changes
+COPY --chown=bracket:bracket pyproject.toml uv.lock ./
 RUN uv sync --no-dev --locked
+
+COPY --chown=bracket:bracket . /app
 
 EXPOSE 8400
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,11 +5,16 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+RUN apk add pnpm
+
+# Install dependencies before copying the source so this layer is only
+# rebuilt when the lockfile changes
+COPY package.json pnpm-lock.yaml ./
+RUN CI=true pnpm install
+
 COPY . .
 
-RUN apk add pnpm && \
-    CI=true pnpm install && \
-    pnpm build
+RUN pnpm build
 
 # Production image, copy all the static files and run next
 FROM caddy:2-alpine AS runner


### PR DESCRIPTION
Copy only the lockfiles and install dependencies before copying the
rest of the source, so pnpm install and uv sync layers are reused on
every build where the lockfiles didn't change. Previously any source
change re-ran both installs from scratch.

Use COPY --chown instead of a recursive chown so the dependency layer
isn't duplicated, and add a root .dockerignore so the compose build
(context = repo root) no longer ships .git, docs and any local
node_modules/.venv/dist into the daemon on every build.

https://claude.ai/code/session_01DgiqgcnPTGxtByzkiTjmdS