### PR TITLE
✨ feat(planning): add swap, unschedule, and tray placement to tap-to-place

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -263,6 +263,7 @@
     "tournament_setting_title": "Turniereinstellungen",
     "tournament_title": "Turnier",
     "tournaments_title": "Turniere",
+    "unschedule_button": "Aus Plan entfernen",
     "unscheduled_column_empty_description": "Alle geplanten Speile wurden zugeordnet",
     "unscheduled_title": "Ungeplant",
     "unarchive_tournament_button": "Turnierarchivierung aufheben",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -326,6 +326,7 @@
     "tournament_setting_title": "Tournament Settings",
     "tournament_title": "tournament",
     "tournaments_title": "tournaments",
+    "unschedule_button": "Unschedule",
     "unscheduled_column_empty_description": "All matches have been assigned to courts",
     "unscheduled_title": "Unscheduled",
     "unarchive_tournament_button": "Unarchive Tournament",

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -217,6 +217,7 @@ export default function ScheduleGrid({
 }) {
   const gridHeight = layout.totalMinutes * PX_PER_MINUTE;
   const selectedMatch = selection.kind === 'match-selected' ? selection.match : null;
+  const placing = selection.kind !== 'idle';
 
   return (
     <Box
@@ -334,13 +335,14 @@ export default function ScheduleGrid({
                   />
                 );
               })}
-              {selectedMatch != null &&
+              {placing &&
                 computeInsertionLines(blocks).map((line) => (
                   <InsertionLineTarget
                     key={line.index}
                     line={line}
                     gridHeight={gridHeight}
                     isNoop={
+                      selectedMatch != null &&
                       selectedMatch.courtId === court.id &&
                       (line.index === selectedMatch.position ||
                         line.index === selectedMatch.position + 1)
@@ -360,7 +362,7 @@ export default function ScheduleGrid({
       </Flex>
       {/* While placing, add scroll slack so insertion lines near the viewport
           bottom can always be scrolled out from under the floating cancel bar. */}
-      {selectedMatch != null && <Box style={{ height: '10rem' }} />}
+      {placing && <Box style={{ height: '10rem' }} />}
     </Box>
   );
 }

--- a/frontend/src/components/scheduling/unscheduled_sheet.tsx
+++ b/frontend/src/components/scheduling/unscheduled_sheet.tsx
@@ -10,7 +10,6 @@ import {
   Text,
   UnstyledButton,
 } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -21,21 +20,26 @@ import { MatchLookupEntry, getStageItemLookup, stringToColour } from '@services/
 
 /**
  * Collapsible bottom sheet listing matches that are not on the schedule yet.
- * Read-only flat list; grouping and the tap-to-place flow come in later slices.
+ * Tapping a match selects it for tap-to-place placement on the grid; the parent
+ * collapses the sheet while placing, so `opened` is controlled. Grouping by
+ * level/stage comes in a later slice.
  */
 export default function UnscheduledSheet({
   unscheduledMatches,
   stageItemsLookup,
   matchesLookup,
-  openMatchModal,
+  opened,
+  onToggle,
+  onSelectMatch,
 }: {
   unscheduledMatches: MatchWithDetails[];
   stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
   matchesLookup: Record<number, MatchLookupEntry>;
-  openMatchModal: (m: MatchWithDetails) => void;
+  opened: boolean;
+  onToggle: () => void;
+  onSelectMatch: (m: MatchWithDetails) => void;
 }) {
   const { t } = useTranslation();
-  const [opened, { toggle }] = useDisclosure(false);
 
   return (
     <Paper
@@ -54,7 +58,7 @@ export default function UnscheduledSheet({
         borderBottom: 'none',
       }}
     >
-      <UnstyledButton onClick={toggle} w="100%" p="sm" aria-expanded={opened}>
+      <UnstyledButton onClick={onToggle} w="100%" p="sm" aria-expanded={opened}>
         <Group justify="space-between" wrap="nowrap">
           <Group gap="xs" wrap="nowrap">
             <Text fw={600}>{t('unscheduled_title')}</Text>
@@ -78,7 +82,7 @@ export default function UnscheduledSheet({
               return (
                 <Fragment key={match.id}>
                   {index > 0 && <Divider />}
-                  <UnstyledButton onClick={() => openMatchModal(match)} w="100%" py="xs">
+                  <UnstyledButton onClick={() => onSelectMatch(match)} w="100%" py="xs">
                     <Flex justify="space-between" align="center" gap="xs" wrap="nowrap">
                       <Box style={{ minWidth: 0 }}>
                         <Text size="sm" fw={500} truncate>

--- a/frontend/src/logic/planning/selection.test.ts
+++ b/frontend/src/logic/planning/selection.test.ts
@@ -10,144 +10,341 @@ function selected(match: GridMatchRef): SelectionState {
   return { kind: 'match-selected', match };
 }
 
+function traySelected(matchId: number): SelectionState {
+  return { kind: 'tray-match-selected', matchId };
+}
+
 describe('selectionReducer', () => {
   describe('in idle state', () => {
-    it('selects a match on tap without rescheduling', () => {
-      const { state, reschedule } = selectionReducer(IDLE_SELECTION, {
+    it('selects a match on tap without any actions', () => {
+      const { state, actions } = selectionReducer(IDLE_SELECTION, {
         type: 'tap-match',
         match: ref(10, 1, 0),
       });
 
       expect(state).toEqual(selected(ref(10, 1, 0)));
-      expect(reschedule).toBeNull();
+      expect(actions).toEqual([]);
+    });
+
+    it('selects a tray match on tap without any actions', () => {
+      const { state, actions } = selectionReducer(IDLE_SELECTION, {
+        type: 'tap-tray-match',
+        matchId: 30,
+      });
+
+      expect(state).toEqual(traySelected(30));
+      expect(actions).toEqual([]);
     });
 
     it('ignores insertion line taps', () => {
-      const { state, reschedule } = selectionReducer(IDLE_SELECTION, {
+      const { state, actions } = selectionReducer(IDLE_SELECTION, {
         type: 'tap-insertion-line',
         courtId: 1,
         index: 0,
       });
 
       expect(state).toEqual(IDLE_SELECTION);
-      expect(reschedule).toBeNull();
+      expect(actions).toEqual([]);
+    });
+
+    it('ignores unschedule', () => {
+      const { state, actions } = selectionReducer(IDLE_SELECTION, { type: 'unschedule' });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(actions).toEqual([]);
     });
 
     it('ignores cancel', () => {
-      const { state, reschedule } = selectionReducer(IDLE_SELECTION, { type: 'cancel' });
+      const { state, actions } = selectionReducer(IDLE_SELECTION, { type: 'cancel' });
 
       expect(state).toEqual(IDLE_SELECTION);
-      expect(reschedule).toBeNull();
+      expect(actions).toEqual([]);
     });
   });
 
-  describe('with a match selected', () => {
+  describe('with a scheduled match selected', () => {
     // Court 1 has matches at positions 0..3; the selected match sits at position 2.
     const selection = selected(ref(10, 1, 2));
 
-    it('cancel returns to idle without rescheduling', () => {
-      const { state, reschedule } = selectionReducer(selection, { type: 'cancel' });
+    it('cancel returns to idle without any actions', () => {
+      const { state, actions } = selectionReducer(selection, { type: 'cancel' });
 
       expect(state).toEqual(IDLE_SELECTION);
-      expect(reschedule).toBeNull();
+      expect(actions).toEqual([]);
     });
 
     it('tapping the selected match again deselects it', () => {
-      const { state, reschedule } = selectionReducer(selection, {
+      const { state, actions } = selectionReducer(selection, {
         type: 'tap-match',
         match: ref(10, 1, 2),
       });
 
       expect(state).toEqual(IDLE_SELECTION);
-      expect(reschedule).toBeNull();
-    });
-
-    it('tapping a different match selects that match instead', () => {
-      const { state, reschedule } = selectionReducer(selection, {
-        type: 'tap-match',
-        match: ref(20, 2, 0),
-      });
-
-      expect(state).toEqual(selected(ref(20, 2, 0)));
-      expect(reschedule).toBeNull();
+      expect(actions).toEqual([]);
     });
 
     it('placing on another court inserts before the match at that index', () => {
-      const { state, reschedule } = selectionReducer(selection, {
+      const { state, actions } = selectionReducer(selection, {
         type: 'tap-insertion-line',
         courtId: 2,
         index: 1,
       });
 
       expect(state).toEqual(IDLE_SELECTION);
-      expect(reschedule).toEqual({
-        matchId: 10,
-        body: { old_court_id: 1, old_position: 2, new_court_id: 2, new_position: 1 },
-      });
+      expect(actions).toEqual([
+        {
+          type: 'reschedule',
+          matchId: 10,
+          body: { old_court_id: 1, old_position: 2, new_court_id: 2, new_position: 1 },
+        },
+      ]);
     });
 
     it('placing at the start of another court uses position 0', () => {
-      const { reschedule } = selectionReducer(selection, {
+      const { actions } = selectionReducer(selection, {
         type: 'tap-insertion-line',
         courtId: 2,
         index: 0,
       });
 
-      expect(reschedule).toEqual({
-        matchId: 10,
-        body: { old_court_id: 1, old_position: 2, new_court_id: 2, new_position: 0 },
-      });
+      expect(actions).toEqual([
+        {
+          type: 'reschedule',
+          matchId: 10,
+          body: { old_court_id: 1, old_position: 2, new_court_id: 2, new_position: 0 },
+        },
+      ]);
     });
 
     it('placing earlier on the same court keeps the insertion index as the position', () => {
-      const { state, reschedule } = selectionReducer(selection, {
+      const { state, actions } = selectionReducer(selection, {
         type: 'tap-insertion-line',
         courtId: 1,
         index: 0,
       });
 
       expect(state).toEqual(IDLE_SELECTION);
-      expect(reschedule).toEqual({
-        matchId: 10,
-        body: { old_court_id: 1, old_position: 2, new_court_id: 1, new_position: 0 },
-      });
+      expect(actions).toEqual([
+        {
+          type: 'reschedule',
+          matchId: 10,
+          body: { old_court_id: 1, old_position: 2, new_court_id: 1, new_position: 0 },
+        },
+      ]);
     });
 
     it('placing later on the same court accounts for the match leaving its slot', () => {
       // Insertion line 4 means "after the match currently at position 3"; once the
       // selected match vacates position 2, that target becomes position 3.
-      const { reschedule } = selectionReducer(selection, {
+      const { actions } = selectionReducer(selection, {
         type: 'tap-insertion-line',
         courtId: 1,
         index: 4,
       });
 
-      expect(reschedule).toEqual({
-        matchId: 10,
-        body: { old_court_id: 1, old_position: 2, new_court_id: 1, new_position: 3 },
-      });
+      expect(actions).toEqual([
+        {
+          type: 'reschedule',
+          matchId: 10,
+          body: { old_court_id: 1, old_position: 2, new_court_id: 1, new_position: 3 },
+        },
+      ]);
     });
 
     it('placing directly before itself is a no-op that clears the selection', () => {
-      const { state, reschedule } = selectionReducer(selection, {
+      const { state, actions } = selectionReducer(selection, {
         type: 'tap-insertion-line',
         courtId: 1,
         index: 2,
       });
 
       expect(state).toEqual(IDLE_SELECTION);
-      expect(reschedule).toBeNull();
+      expect(actions).toEqual([]);
     });
 
     it('placing directly after itself is a no-op that clears the selection', () => {
-      const { state, reschedule } = selectionReducer(selection, {
+      const { state, actions } = selectionReducer(selection, {
         type: 'tap-insertion-line',
         courtId: 1,
         index: 3,
       });
 
       expect(state).toEqual(IDLE_SELECTION);
-      expect(reschedule).toBeNull();
+      expect(actions).toEqual([]);
+    });
+
+    it('unschedule sends the selected match back to the tray and clears the selection', () => {
+      const { state, actions } = selectionReducer(selection, { type: 'unschedule' });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(actions).toEqual([{ type: 'unschedule', matchId: 10 }]);
+    });
+
+    it('tapping a tray match switches the selection to the tray match', () => {
+      const { state, actions } = selectionReducer(selection, {
+        type: 'tap-tray-match',
+        matchId: 30,
+      });
+
+      expect(state).toEqual(traySelected(30));
+      expect(actions).toEqual([]);
+    });
+  });
+
+  describe('swapping two scheduled matches', () => {
+    it('tapping a match on another court swaps the two', () => {
+      // After the first move, the target gets pushed one position down on its
+      // court (the selected match is inserted before it), so the second move's
+      // old_position is the target's original position + 1.
+      const { state, actions } = selectionReducer(selected(ref(10, 1, 2)), {
+        type: 'tap-match',
+        match: ref(20, 2, 1),
+      });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(actions).toEqual([
+        {
+          type: 'reschedule',
+          matchId: 10,
+          body: { old_court_id: 1, old_position: 2, new_court_id: 2, new_position: 1 },
+        },
+        {
+          type: 'reschedule',
+          matchId: 20,
+          body: { old_court_id: 2, old_position: 2, new_court_id: 1, new_position: 2 },
+        },
+      ]);
+    });
+
+    it('swaps with a later match on the same court', () => {
+      // Moving the selected match (position 1) after the target (position 3)
+      // shifts the target up to position 2 before the second move.
+      const { actions } = selectionReducer(selected(ref(10, 1, 1)), {
+        type: 'tap-match',
+        match: ref(20, 1, 3),
+      });
+
+      expect(actions).toEqual([
+        {
+          type: 'reschedule',
+          matchId: 10,
+          body: { old_court_id: 1, old_position: 1, new_court_id: 1, new_position: 3 },
+        },
+        {
+          type: 'reschedule',
+          matchId: 20,
+          body: { old_court_id: 1, old_position: 2, new_court_id: 1, new_position: 1 },
+        },
+      ]);
+    });
+
+    it('swaps with an earlier match on the same court', () => {
+      // Inserting the selected match before the target pushes the target one
+      // position down before the second move.
+      const { actions } = selectionReducer(selected(ref(10, 1, 3)), {
+        type: 'tap-match',
+        match: ref(20, 1, 1),
+      });
+
+      expect(actions).toEqual([
+        {
+          type: 'reschedule',
+          matchId: 10,
+          body: { old_court_id: 1, old_position: 3, new_court_id: 1, new_position: 1 },
+        },
+        {
+          type: 'reschedule',
+          matchId: 20,
+          body: { old_court_id: 1, old_position: 2, new_court_id: 1, new_position: 3 },
+        },
+      ]);
+    });
+
+    it('swaps adjacent matches on the same court', () => {
+      // The first move alone already swaps adjacent matches; the second move
+      // degenerates into a same-position request the backend treats as a no-op.
+      const { actions } = selectionReducer(selected(ref(10, 1, 1)), {
+        type: 'tap-match',
+        match: ref(20, 1, 2),
+      });
+
+      expect(actions).toEqual([
+        {
+          type: 'reschedule',
+          matchId: 10,
+          body: { old_court_id: 1, old_position: 1, new_court_id: 1, new_position: 2 },
+        },
+        {
+          type: 'reschedule',
+          matchId: 20,
+          body: { old_court_id: 1, old_position: 1, new_court_id: 1, new_position: 1 },
+        },
+      ]);
+    });
+  });
+
+  describe('with a tray match selected', () => {
+    const selection = traySelected(30);
+
+    it('cancel returns to idle without any actions, leaving the match unscheduled', () => {
+      const { state, actions } = selectionReducer(selection, { type: 'cancel' });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(actions).toEqual([]);
+    });
+
+    it('tapping the selected tray match again deselects it', () => {
+      const { state, actions } = selectionReducer(selection, {
+        type: 'tap-tray-match',
+        matchId: 30,
+      });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(actions).toEqual([]);
+    });
+
+    it('tapping a different tray match selects that match instead', () => {
+      const { state, actions } = selectionReducer(selection, {
+        type: 'tap-tray-match',
+        matchId: 31,
+      });
+
+      expect(state).toEqual(traySelected(31));
+      expect(actions).toEqual([]);
+    });
+
+    it('tapping a scheduled match switches the selection to the grid match', () => {
+      const { state, actions } = selectionReducer(selection, {
+        type: 'tap-match',
+        match: ref(10, 1, 2),
+      });
+
+      expect(state).toEqual(selected(ref(10, 1, 2)));
+      expect(actions).toEqual([]);
+    });
+
+    it('placing on an insertion line schedules the tray match there', () => {
+      const { state, actions } = selectionReducer(selection, {
+        type: 'tap-insertion-line',
+        courtId: 2,
+        index: 1,
+      });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(actions).toEqual([
+        {
+          type: 'reschedule',
+          matchId: 30,
+          body: { old_court_id: null, old_position: null, new_court_id: 2, new_position: 1 },
+        },
+      ]);
+    });
+
+    it('ignores unschedule, since the match is already unscheduled', () => {
+      const { state, actions } = selectionReducer(selection, { type: 'unschedule' });
+
+      expect(state).toEqual(selection);
+      expect(actions).toEqual([]);
     });
   });
 });

--- a/frontend/src/logic/planning/selection.ts
+++ b/frontend/src/logic/planning/selection.ts
@@ -1,10 +1,11 @@
 /**
  * Pure, headless state machine for the planning grid's tap-to-place interaction.
  *
- * The UI dispatches events (tap on a match card, tap on an insertion line, cancel)
- * and the reducer returns the next selection state plus, when a tap completes a
- * placement, the reschedule request to send to the backend. Later slices (swap,
- * tray placement, zoom gating, action sheet) extend this same reducer.
+ * The UI dispatches events (tap on a match card, tap on a tray match, tap on an
+ * insertion line, unschedule, cancel) and the reducer returns the next selection
+ * state plus the ordered list of backend actions the tap triggers (zero, one, or —
+ * for a swap — two). Later slices (zoom gating, action sheet) extend this same
+ * reducer.
  *
  * Positions are `position_in_schedule` values, which the backend keeps contiguous
  * (0..n-1) per court. An insertion line with index `k` on a court means "insert
@@ -17,28 +18,40 @@ export interface GridMatchRef {
   position: number;
 }
 
-export type SelectionState = { kind: 'idle' } | { kind: 'match-selected'; match: GridMatchRef };
+export type SelectionState =
+  | { kind: 'idle' }
+  | { kind: 'match-selected'; match: GridMatchRef }
+  | { kind: 'tray-match-selected'; matchId: number };
 
 export const IDLE_SELECTION: SelectionState = { kind: 'idle' };
 
 export type SelectionEvent =
   | { type: 'tap-match'; match: GridMatchRef }
+  | { type: 'tap-tray-match'; matchId: number }
   | { type: 'tap-insertion-line'; courtId: number; index: number }
+  | { type: 'unschedule' }
   | { type: 'cancel' };
 
-export interface RescheduleRequest {
-  matchId: number;
-  body: {
-    old_court_id: number;
-    old_position: number;
-    new_court_id: number;
-    new_position: number;
-  };
-}
+export type PlanningAction =
+  | {
+      type: 'reschedule';
+      matchId: number;
+      body: {
+        old_court_id: number | null;
+        old_position: number | null;
+        new_court_id: number;
+        new_position: number;
+      };
+    }
+  | { type: 'unschedule'; matchId: number };
 
 export interface SelectionTransition {
   state: SelectionState;
-  reschedule: RescheduleRequest | null;
+  actions: PlanningAction[];
+}
+
+function stay(state: SelectionState): SelectionTransition {
+  return { state, actions: [] };
 }
 
 function place(selected: GridMatchRef, courtId: number, index: number): SelectionTransition {
@@ -47,7 +60,7 @@ function place(selected: GridMatchRef, courtId: number, index: number): Selectio
   // The lines directly before and after the selected match put it back where it
   // already is; placing there is a no-op that just clears the selection.
   if (sameCourt && (index === selected.position || index === selected.position + 1)) {
-    return { state: IDLE_SELECTION, reschedule: null };
+    return stay(IDLE_SELECTION);
   }
 
   // When moving later on the same court, the match vacates its old slot first, so
@@ -57,15 +70,77 @@ function place(selected: GridMatchRef, courtId: number, index: number): Selectio
 
   return {
     state: IDLE_SELECTION,
-    reschedule: {
-      matchId: selected.matchId,
-      body: {
-        old_court_id: selected.courtId,
-        old_position: selected.position,
-        new_court_id: courtId,
-        new_position: newPosition,
+    actions: [
+      {
+        type: 'reschedule',
+        matchId: selected.matchId,
+        body: {
+          old_court_id: selected.courtId,
+          old_position: selected.position,
+          new_court_id: courtId,
+          new_position: newPosition,
+        },
       },
-    },
+    ],
+  };
+}
+
+function placeFromTray(matchId: number, courtId: number, index: number): SelectionTransition {
+  return {
+    state: IDLE_SELECTION,
+    actions: [
+      {
+        type: 'reschedule',
+        matchId,
+        body: {
+          old_court_id: null,
+          old_position: null,
+          new_court_id: courtId,
+          new_position: index,
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Swap two scheduled matches via two reschedule operations. The first move puts
+ * the selected match exactly in the target's slot (the backend inserts before the
+ * target across courts and when moving earlier on the same court, and after it
+ * when moving later on the same court — landing on the target's position either
+ * way). That repack shifts the target by one, so the second move's old position
+ * is adjusted accordingly. For adjacent same-court matches the first move already
+ * completes the swap and the second degenerates into a backend no-op.
+ */
+function swap(selected: GridMatchRef, target: GridMatchRef): SelectionTransition {
+  const sameCourt = selected.courtId === target.courtId;
+  const targetPositionAfterFirstMove =
+    sameCourt && selected.position < target.position ? target.position - 1 : target.position + 1;
+
+  return {
+    state: IDLE_SELECTION,
+    actions: [
+      {
+        type: 'reschedule',
+        matchId: selected.matchId,
+        body: {
+          old_court_id: selected.courtId,
+          old_position: selected.position,
+          new_court_id: target.courtId,
+          new_position: target.position,
+        },
+      },
+      {
+        type: 'reschedule',
+        matchId: target.matchId,
+        body: {
+          old_court_id: target.courtId,
+          old_position: targetPositionAfterFirstMove,
+          new_court_id: selected.courtId,
+          new_position: selected.position,
+        },
+      },
+    ],
   };
 }
 
@@ -75,27 +150,55 @@ export function selectionReducer(
 ): SelectionTransition {
   switch (state.kind) {
     case 'idle':
-      if (event.type === 'tap-match') {
-        return { state: { kind: 'match-selected', match: event.match }, reschedule: null };
+      switch (event.type) {
+        case 'tap-match':
+          return stay({ kind: 'match-selected', match: event.match });
+        case 'tap-tray-match':
+          return stay({ kind: 'tray-match-selected', matchId: event.matchId });
+        default:
+          return stay(state);
       }
-      return { state, reschedule: null };
     case 'match-selected':
       switch (event.type) {
         case 'cancel':
-          return { state: IDLE_SELECTION, reschedule: null };
+          return stay(IDLE_SELECTION);
         case 'tap-match':
-          // Tapping the selected match again deselects; tapping another match
-          // moves the selection there (swap arrives in a later slice).
+          // Tapping the selected match again deselects; tapping another
+          // scheduled match swaps the two.
           if (event.match.matchId === state.match.matchId) {
-            return { state: IDLE_SELECTION, reschedule: null };
+            return stay(IDLE_SELECTION);
           }
-          return { state: { kind: 'match-selected', match: event.match }, reschedule: null };
+          return swap(state.match, event.match);
+        case 'tap-tray-match':
+          return stay({ kind: 'tray-match-selected', matchId: event.matchId });
         case 'tap-insertion-line':
           return place(state.match, event.courtId, event.index);
+        case 'unschedule':
+          return {
+            state: IDLE_SELECTION,
+            actions: [{ type: 'unschedule', matchId: state.match.matchId }],
+          };
         default:
-          return { state, reschedule: null };
+          return stay(state);
+      }
+    case 'tray-match-selected':
+      switch (event.type) {
+        case 'cancel':
+          // The match was never scheduled; cancelling simply leaves it in the tray.
+          return stay(IDLE_SELECTION);
+        case 'tap-match':
+          return stay({ kind: 'match-selected', match: event.match });
+        case 'tap-tray-match':
+          if (event.matchId === state.matchId) {
+            return stay(IDLE_SELECTION);
+          }
+          return stay({ kind: 'tray-match-selected', matchId: event.matchId });
+        case 'tap-insertion-line':
+          return placeFromTray(state.matchId, event.courtId, event.index);
+        default:
+          return stay(state);
       }
     default:
-      return { state, reschedule: null };
+      return stay(state);
   }
 }

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import CourtModal from '@components/modals/create_court_modal';
-import MatchModal from '@components/modals/match_modal';
 import { NoContent } from '@components/no_content/empty_table_info';
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
 import { getTournamentIdFromRouter, responseIsValid } from '@components/utils/util';
@@ -26,15 +25,14 @@ import {
   getStageOrderViolations,
   getUnscheduledMatches,
 } from '@services/lookups';
-import { rescheduleMatch, scheduleMatches } from '@services/match';
+import { rescheduleMatch, scheduleMatches, unscheduleMatch } from '@services/match';
 
 import ScheduleGrid from '@components/scheduling/schedule_grid';
 import UnscheduledSheet from '@components/scheduling/unscheduled_sheet';
 
 export default function SchedulePage() {
-  const [modalOpened, modalSetOpened] = useState(false);
-  const [match, setMatch] = useState<MatchWithDetails | null>(null);
   const [selection, setSelection] = useState<SelectionState>(IDLE_SELECTION);
+  const [trayOpened, setTrayOpened] = useState(false);
 
   const { t } = useTranslation();
   const { tournamentData } = getTournamentIdFromRouter();
@@ -81,36 +79,44 @@ export default function SchedulePage() {
     }
   }
 
-  function openMatchModal(matchToOpen: MatchWithDetails) {
-    setMatch(matchToOpen);
-    modalSetOpened(true);
-  }
-
   async function handleSelectionEvent(event: SelectionEvent) {
-    const { state, reschedule } = selectionReducer(selection, event);
+    const wasTraySelection = selection.kind === 'tray-match-selected';
+    const { state, actions } = selectionReducer(selection, event);
     setSelection(state);
-    if (reschedule != null) {
-      await rescheduleMatch(tournamentData.id, reschedule.matchId, reschedule.body);
+
+    // Picking a match from the tray collapses it so the grid is free for placing.
+    if (state.kind === 'tray-match-selected') {
+      setTrayOpened(false);
+    }
+
+    if (actions.length > 0) {
+      for (const action of actions) {
+        if (action.type === 'reschedule') {
+          await rescheduleMatch(tournamentData.id, action.matchId, action.body);
+        } else {
+          await unscheduleMatch(tournamentData.id, action.matchId);
+        }
+      }
       await swrStagesResponse.mutate();
+
+      // After placing a tray match, reopen the tray so scheduling many matches
+      // in a row flows without extra taps.
+      if (wasTraySelection && event.type === 'tap-insertion-line') {
+        setTrayOpened(true);
+      }
     }
   }
 
-  const selectedEntry =
-    selection.kind === 'match-selected' ? matchesLookup[selection.match.matchId] : null;
+  const selectedMatchId =
+    selection.kind === 'match-selected'
+      ? selection.match.matchId
+      : selection.kind === 'tray-match-selected'
+        ? selection.matchId
+        : null;
+  const selectedEntry = selectedMatchId != null ? matchesLookup[selectedMatchId] : null;
 
   return (
     <TournamentLayout tournament_id={tournamentData.id}>
-      {match != null ? (
-        <MatchModal
-          swrStagesResponse={swrStagesResponse}
-          swrUpcomingMatchesResponse={null}
-          tournamentData={tournamentData}
-          match={match}
-          opened={modalOpened}
-          setOpened={modalSetOpened}
-          round={null}
-        />
-      ) : null}
       <Grid grow>
         <Grid.Col span={6}>
           <Title>{t('planning_title')}</Title>
@@ -145,7 +151,7 @@ export default function SchedulePage() {
           />
         </Stack>
       ) : (
-        <Box mt="1rem" pb={selection.kind === 'match-selected' ? '14rem' : '4rem'}>
+        <Box mt="1rem" pb={selection.kind !== 'idle' ? '14rem' : '4rem'}>
           <ScheduleGrid
             layout={layout}
             violations={violations}
@@ -158,7 +164,9 @@ export default function SchedulePage() {
             unscheduledMatches={unscheduledMatches}
             stageItemsLookup={stageItemsLookup}
             matchesLookup={matchesLookup}
-            openMatchModal={openMatchModal}
+            opened={trayOpened}
+            onToggle={() => setTrayOpened(!trayOpened)}
+            onSelectMatch={(m) => handleSelectionEvent({ type: 'tap-tray-match', matchId: m.id })}
           />
           {selectedEntry != null ? (
             <Affix position={{ bottom: 70, left: '50%' }} zIndex={300}>
@@ -185,6 +193,16 @@ export default function SchedulePage() {
                     {t('tap_to_place_hint')}
                   </Text>
                 </Box>
+                {selection.kind === 'match-selected' && (
+                  <Button
+                    size="compact-sm"
+                    variant="light"
+                    color="orange"
+                    onClick={() => handleSelectionEvent({ type: 'unschedule' })}
+                  >
+                    {t('unschedule_button')}
+                  </Button>
+                )}
                 <Button
                   size="compact-sm"
                   variant="light"


### PR DESCRIPTION
Extend the selection reducer with the remaining move vocabulary:

- Swap: tapping another scheduled match while one is selected swaps the
  two via two reschedule operations, with the second operation's old
  position adjusted for the repack caused by the first.
- Unschedule: a selected scheduled match can be sent back to the tray
  through a button on the floating selection bar (moves into the action
  sheet in a later slice).
- Tray placement: tapping a match in the unscheduled bottom sheet
  selects it for placement; the sheet collapses, insertion lines appear,
  and placing schedules it via the reschedule endpoint with null old
  court/position. The sheet reopens after placing, and cancelling leaves
  the match in the tray. Tray taps no longer open the match modal; match
  details return via the action sheet slice.

The reducer transition now returns an ordered list of backend actions
instead of a single optional reschedule, so a swap's two operations stay
a pure, testable output.

Closes #43

https://claude.ai/code/session_01UP16mvNkWyvbkYvXEr9Dct