### PR TITLE
feat(planning): add swap, unschedule, and tray placement (issue #43)

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -242,6 +242,7 @@
     "swiss_description": "Teams spielen gegen ebenbürtige Teams, aufgrund der Ergebnisse der vorherigen Partien.",
     "swiss_score": "Schweizer Punktestand",
     "tap_to_place_hint": "Tippen Sie auf eine Linie, um das Spiel zu platzieren",
+    "unschedule_button": "Aus Spielplan entfernen",
     "team_count_input_round_robin_label": "Anzahl der Teams, die aus der vorherigen Stufe weiterkommen.",
     "team_count_select_elimination_label": "Anzahl der Teams, die aus der vorherigen Stufe weiterkommen.",
     "team_count_select_elimination_placeholder": "2, 4, 8 usw.",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -271,6 +271,7 @@
     "swiss_description": "Teams play against equal teams, based on the results of previous matches.",
     "swiss_score": "Swiss score",
     "tap_to_place_hint": "Tap a line to place the match",
+    "unschedule_button": "Unschedule",
     "team_count_input_round_robin_label": "Number of teams advancing from the previous stage",
     "team_count_select_elimination_label": "Number of teams advancing from the previous stage",
     "team_count_select_elimination_placeholder": "2, 4, 8 etc.",

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -217,6 +217,7 @@ export default function ScheduleGrid({
 }) {
   const gridHeight = layout.totalMinutes * PX_PER_MINUTE;
   const selectedMatch = selection.kind === 'match-selected' ? selection.match : null;
+  const isPlacing = selection.kind === 'match-selected' || selection.kind === 'tray-match-selected';
 
   return (
     <Box
@@ -334,13 +335,14 @@ export default function ScheduleGrid({
                   />
                 );
               })}
-              {selectedMatch != null &&
+              {isPlacing &&
                 computeInsertionLines(blocks).map((line) => (
                   <InsertionLineTarget
                     key={line.index}
                     line={line}
                     gridHeight={gridHeight}
                     isNoop={
+                      selectedMatch != null &&
                       selectedMatch.courtId === court.id &&
                       (line.index === selectedMatch.position ||
                         line.index === selectedMatch.position + 1)
@@ -360,7 +362,7 @@ export default function ScheduleGrid({
       </Flex>
       {/* While placing, add scroll slack so insertion lines near the viewport
           bottom can always be scrolled out from under the floating cancel bar. */}
-      {selectedMatch != null && <Box style={{ height: '10rem' }} />}
+      {isPlacing && <Box style={{ height: '10rem' }} />}
     </Box>
   );
 }

--- a/frontend/src/components/scheduling/unscheduled_sheet.tsx
+++ b/frontend/src/components/scheduling/unscheduled_sheet.tsx
@@ -21,21 +21,27 @@ import { MatchLookupEntry, getStageItemLookup, stringToColour } from '@services/
 
 /**
  * Collapsible bottom sheet listing matches that are not on the schedule yet.
- * Read-only flat list; grouping and the tap-to-place flow come in later slices.
+ * Tapping a match selects it for placement (tray collapses, insertion lines appear).
+ * `forceCollapsed` is true while placement mode is active to keep the grid clear.
  */
 export default function UnscheduledSheet({
   unscheduledMatches,
   stageItemsLookup,
   matchesLookup,
-  openMatchModal,
+  selectedTrayMatchId,
+  onTrayMatchSelect,
 }: {
   unscheduledMatches: MatchWithDetails[];
   stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
   matchesLookup: Record<number, MatchLookupEntry>;
-  openMatchModal: (m: MatchWithDetails) => void;
+  selectedTrayMatchId: number | null;
+  onTrayMatchSelect: (matchId: number) => void;
 }) {
   const { t } = useTranslation();
   const [opened, { toggle }] = useDisclosure(false);
+
+  // Collapse the sheet while a tray match is selected for placement.
+  const isOpen = opened && selectedTrayMatchId == null;
 
   return (
     <Paper
@@ -54,7 +60,7 @@ export default function UnscheduledSheet({
         borderBottom: 'none',
       }}
     >
-      <UnstyledButton onClick={toggle} w="100%" p="sm" aria-expanded={opened}>
+      <UnstyledButton onClick={toggle} w="100%" p="sm" aria-expanded={isOpen}>
         <Group justify="space-between" wrap="nowrap">
           <Group gap="xs" wrap="nowrap">
             <Text fw={600}>{t('unscheduled_title')}</Text>
@@ -62,10 +68,10 @@ export default function UnscheduledSheet({
               {unscheduledMatches.length}
             </Badge>
           </Group>
-          {opened ? <IconChevronDown size={20} /> : <IconChevronUp size={20} />}
+          {isOpen ? <IconChevronDown size={20} /> : <IconChevronUp size={20} />}
         </Group>
       </UnstyledButton>
-      <Collapse in={opened}>
+      <Collapse in={isOpen}>
         <ScrollArea.Autosize mah="45dvh">
           <Box px="sm" pb="sm">
             {unscheduledMatches.length === 0 && (
@@ -75,10 +81,23 @@ export default function UnscheduledSheet({
             )}
             {unscheduledMatches.map((match, index) => {
               const entry = matchesLookup[match.id];
+              const isSelected = match.id === selectedTrayMatchId;
               return (
                 <Fragment key={match.id}>
                   {index > 0 && <Divider />}
-                  <UnstyledButton onClick={() => openMatchModal(match)} w="100%" py="xs">
+                  <UnstyledButton
+                    onClick={() => onTrayMatchSelect(match.id)}
+                    w="100%"
+                    py="xs"
+                    style={
+                      isSelected
+                        ? {
+                            borderRadius: 6,
+                            outline: '2px solid var(--mantine-color-indigo-filled)',
+                          }
+                        : undefined
+                    }
+                  >
                     <Flex justify="space-between" align="center" gap="xs" wrap="nowrap">
                       <Box style={{ minWidth: 0 }}>
                         <Text size="sm" fw={500} truncate>

--- a/frontend/src/logic/planning/selection.test.ts
+++ b/frontend/src/logic/planning/selection.test.ts
@@ -260,13 +260,15 @@ describe('selectionReducer', () => {
       expect(state).toEqual(traySelected(77));
     });
 
-    it('tapping a grid match switches to match-selected', () => {
+    it('tapping a grid match is a no-op (stays in tray placement mode)', () => {
       const { state, reschedule, swap } = selectionReducer(selection, {
         type: 'tap-match',
         match: ref(20, 1, 0),
       });
 
-      expect(state).toEqual(selected(ref(20, 1, 0)));
+      // Tapping a match card during tray placement mode keeps the tray match
+      // selected so an accidental card tap doesn't discard the placement.
+      expect(state).toEqual(traySelected(99));
       expect(reschedule).toBeNull();
       expect(swap).toBeNull();
     });

--- a/frontend/src/logic/planning/selection.test.ts
+++ b/frontend/src/logic/planning/selection.test.ts
@@ -10,6 +10,10 @@ function selected(match: GridMatchRef): SelectionState {
   return { kind: 'match-selected', match };
 }
 
+function traySelected(matchId: number): SelectionState {
+  return { kind: 'tray-match-selected', matchId };
+}
+
 describe('selectionReducer', () => {
   describe('in idle state', () => {
     it('selects a match on tap without rescheduling', () => {
@@ -39,6 +43,18 @@ describe('selectionReducer', () => {
       expect(state).toEqual(IDLE_SELECTION);
       expect(reschedule).toBeNull();
     });
+
+    it('tap-tray-match enters tray-match-selected state', () => {
+      const { state, reschedule, swap, unschedule } = selectionReducer(IDLE_SELECTION, {
+        type: 'tap-tray-match',
+        matchId: 99,
+      });
+
+      expect(state).toEqual(traySelected(99));
+      expect(reschedule).toBeNull();
+      expect(swap).toBeNull();
+      expect(unschedule).toBeNull();
+    });
   });
 
   describe('with a match selected', () => {
@@ -62,14 +78,63 @@ describe('selectionReducer', () => {
       expect(reschedule).toBeNull();
     });
 
-    it('tapping a different match selects that match instead', () => {
-      const { state, reschedule } = selectionReducer(selection, {
+    it('tapping a different match on another court swaps the two', () => {
+      const { state, reschedule, swap } = selectionReducer(selection, {
         type: 'tap-match',
         match: ref(20, 2, 0),
       });
 
-      expect(state).toEqual(selected(ref(20, 2, 0)));
+      expect(state).toEqual(IDLE_SELECTION);
       expect(reschedule).toBeNull();
+      // First step: move selected (match 10) to match 20's position
+      expect(swap?.first).toEqual({
+        matchId: 10,
+        body: { old_court_id: 1, old_position: 2, new_court_id: 2, new_position: 0 },
+      });
+      // Second step: move match 20 to where match 10 was; after step 1 match 20
+      // shifts from court2/0 to court2/1 (different courts → posB + 1)
+      expect(swap?.second).toEqual({
+        matchId: 20,
+        body: { old_court_id: 2, old_position: 1, new_court_id: 1, new_position: 2 },
+      });
+    });
+
+    it('swapping same-court match ahead of selected shifts it down by one', () => {
+      // Court 1: [A(0), X(1), sel(2), B(3)] — swap sel(2) with B(3)
+      const { swap } = selectionReducer(selected(ref(10, 1, 2)), {
+        type: 'tap-match',
+        match: ref(30, 1, 3),
+      });
+
+      // First step: move sel to pos 3 (B's position, same court, sel < B)
+      expect(swap?.first).toEqual({
+        matchId: 10,
+        body: { old_court_id: 1, old_position: 2, new_court_id: 1, new_position: 3 },
+      });
+      // Second step: B was at 3, now at 3-1=2 (A before B on same court → posB-1)
+      expect(swap?.second).toEqual({
+        matchId: 30,
+        body: { old_court_id: 1, old_position: 2, new_court_id: 1, new_position: 2 },
+      });
+    });
+
+    it('swapping same-court match behind selected shifts it up by one', () => {
+      // Court 1: [B(0), X(1), sel(2)] — swap sel(2) with B(0)
+      const { swap } = selectionReducer(selected(ref(10, 1, 2)), {
+        type: 'tap-match',
+        match: ref(30, 1, 0),
+      });
+
+      // First step: move sel to pos 0 (B's position, same court, sel > B)
+      expect(swap?.first).toEqual({
+        matchId: 10,
+        body: { old_court_id: 1, old_position: 2, new_court_id: 1, new_position: 0 },
+      });
+      // Second step: B was at 0, now at 0+1=1 (A after B on same court → posB+1)
+      expect(swap?.second).toEqual({
+        matchId: 30,
+        body: { old_court_id: 1, old_position: 1, new_court_id: 1, new_position: 2 },
+      });
     });
 
     it('placing on another court inserts before the match at that index', () => {
@@ -148,6 +213,91 @@ describe('selectionReducer', () => {
 
       expect(state).toEqual(IDLE_SELECTION);
       expect(reschedule).toBeNull();
+    });
+
+    it('unschedule returns idle with unschedule request', () => {
+      const { state, reschedule, swap, unschedule } = selectionReducer(selection, {
+        type: 'unschedule',
+      });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(reschedule).toBeNull();
+      expect(swap).toBeNull();
+      expect(unschedule).toEqual({ matchId: 10 });
+    });
+  });
+
+  describe('with a tray match selected', () => {
+    const selection = traySelected(99);
+
+    it('cancel returns to idle', () => {
+      const { state, reschedule, swap, unschedule } = selectionReducer(selection, {
+        type: 'cancel',
+      });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(reschedule).toBeNull();
+      expect(swap).toBeNull();
+      expect(unschedule).toBeNull();
+    });
+
+    it('tapping the same tray match again deselects it', () => {
+      const { state, swap } = selectionReducer(selection, {
+        type: 'tap-tray-match',
+        matchId: 99,
+      });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(swap).toBeNull();
+    });
+
+    it('tapping a different tray match switches the selection', () => {
+      const { state } = selectionReducer(selection, {
+        type: 'tap-tray-match',
+        matchId: 77,
+      });
+
+      expect(state).toEqual(traySelected(77));
+    });
+
+    it('tapping a grid match switches to match-selected', () => {
+      const { state, reschedule, swap } = selectionReducer(selection, {
+        type: 'tap-match',
+        match: ref(20, 1, 0),
+      });
+
+      expect(state).toEqual(selected(ref(20, 1, 0)));
+      expect(reschedule).toBeNull();
+      expect(swap).toBeNull();
+    });
+
+    it('placing at an insertion line schedules the tray match with null old fields', () => {
+      const { state, reschedule, swap, unschedule } = selectionReducer(selection, {
+        type: 'tap-insertion-line',
+        courtId: 3,
+        index: 1,
+      });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(reschedule).toEqual({
+        matchId: 99,
+        body: { old_court_id: null, old_position: null, new_court_id: 3, new_position: 1 },
+      });
+      expect(swap).toBeNull();
+      expect(unschedule).toBeNull();
+    });
+
+    it('placing at the start of a court uses index 0 as new_position', () => {
+      const { reschedule } = selectionReducer(selection, {
+        type: 'tap-insertion-line',
+        courtId: 3,
+        index: 0,
+      });
+
+      expect(reschedule).toEqual({
+        matchId: 99,
+        body: { old_court_id: null, old_position: null, new_court_id: 3, new_position: 0 },
+      });
     });
   });
 });

--- a/frontend/src/logic/planning/selection.ts
+++ b/frontend/src/logic/planning/selection.ts
@@ -186,7 +186,9 @@ export function selectionReducer(
           }
           return noOp({ kind: 'tray-match-selected', matchId: event.matchId });
         case 'tap-match':
-          return noOp({ kind: 'match-selected', match: event.match });
+          // Tapping a grid match during tray placement is a no-op: the user
+          // is in placement mode and should tap an insertion line, not a card.
+          return noOp(state);
         case 'tap-insertion-line':
           return placeTray(state.matchId, event.courtId, event.index);
         default:

--- a/frontend/src/logic/planning/selection.ts
+++ b/frontend/src/logic/planning/selection.ts
@@ -3,8 +3,8 @@
  *
  * The UI dispatches events (tap on a match card, tap on an insertion line, cancel)
  * and the reducer returns the next selection state plus, when a tap completes a
- * placement, the reschedule request to send to the backend. Later slices (swap,
- * tray placement, zoom gating, action sheet) extend this same reducer.
+ * placement or swap, the request(s) to send to the backend. Tray selection and
+ * unschedule extend this same reducer.
  *
  * Positions are `position_in_schedule` values, which the backend keeps contiguous
  * (0..n-1) per court. An insertion line with index `k` on a court means "insert
@@ -17,28 +17,54 @@ export interface GridMatchRef {
   position: number;
 }
 
-export type SelectionState = { kind: 'idle' } | { kind: 'match-selected'; match: GridMatchRef };
+export type SelectionState =
+  | { kind: 'idle' }
+  | { kind: 'match-selected'; match: GridMatchRef }
+  | { kind: 'tray-match-selected'; matchId: number };
 
 export const IDLE_SELECTION: SelectionState = { kind: 'idle' };
 
 export type SelectionEvent =
   | { type: 'tap-match'; match: GridMatchRef }
+  | { type: 'tap-tray-match'; matchId: number }
   | { type: 'tap-insertion-line'; courtId: number; index: number }
+  | { type: 'unschedule' }
   | { type: 'cancel' };
 
 export interface RescheduleRequest {
   matchId: number;
   body: {
-    old_court_id: number;
-    old_position: number;
+    old_court_id: number | null;
+    old_position: number | null;
     new_court_id: number;
     new_position: number;
   };
 }
 
+export interface SwapRequest {
+  first: RescheduleRequest;
+  second: RescheduleRequest;
+}
+
 export interface SelectionTransition {
   state: SelectionState;
   reschedule: RescheduleRequest | null;
+  swap: SwapRequest | null;
+  unschedule: { matchId: number } | null;
+}
+
+function idle(overrides: Partial<Omit<SelectionTransition, 'state'>> = {}): SelectionTransition {
+  return {
+    state: IDLE_SELECTION,
+    reschedule: null,
+    swap: null,
+    unschedule: null,
+    ...overrides,
+  };
+}
+
+function noOp(state: SelectionState): SelectionTransition {
+  return { state, reschedule: null, swap: null, unschedule: null };
 }
 
 function place(selected: GridMatchRef, courtId: number, index: number): SelectionTransition {
@@ -47,7 +73,7 @@ function place(selected: GridMatchRef, courtId: number, index: number): Selectio
   // The lines directly before and after the selected match put it back where it
   // already is; placing there is a no-op that just clears the selection.
   if (sameCourt && (index === selected.position || index === selected.position + 1)) {
-    return { state: IDLE_SELECTION, reschedule: null };
+    return idle();
   }
 
   // When moving later on the same court, the match vacates its old slot first, so
@@ -55,8 +81,7 @@ function place(selected: GridMatchRef, courtId: number, index: number): Selectio
   // the occupant of `new_position` (+0.5) instead of before it (-0.5).
   const newPosition = sameCourt && index > selected.position ? index - 1 : index;
 
-  return {
-    state: IDLE_SELECTION,
+  return idle({
     reschedule: {
       matchId: selected.matchId,
       body: {
@@ -66,7 +91,56 @@ function place(selected: GridMatchRef, courtId: number, index: number): Selectio
         new_position: newPosition,
       },
     },
+  });
+}
+
+function placeTray(matchId: number, courtId: number, index: number): SelectionTransition {
+  // Tray matches have no old court/position. The backend inserts at new_position-0.5,
+  // placing before the match currently at index `new_position`.
+  return idle({
+    reschedule: {
+      matchId,
+      body: {
+        old_court_id: null,
+        old_position: null,
+        new_court_id: courtId,
+        new_position: index,
+      },
+    },
+  });
+}
+
+function swap(matchA: GridMatchRef, matchB: GridMatchRef): SelectionTransition {
+  // After step one (moving A to B's position), B shifts:
+  //   - Different courts: B shifts up one (A is inserted before/at B).
+  //   - Same court, A before B: B shifts down one (A's removal slides B closer).
+  //   - Same court, A after B: B shifts up one (A is inserted before B).
+  const bPositionAfterFirst =
+    matchA.courtId !== matchB.courtId || matchA.position > matchB.position
+      ? matchB.position + 1
+      : matchB.position - 1;
+
+  const first: RescheduleRequest = {
+    matchId: matchA.matchId,
+    body: {
+      old_court_id: matchA.courtId,
+      old_position: matchA.position,
+      new_court_id: matchB.courtId,
+      new_position: matchB.position,
+    },
   };
+
+  const second: RescheduleRequest = {
+    matchId: matchB.matchId,
+    body: {
+      old_court_id: matchB.courtId,
+      old_position: bPositionAfterFirst,
+      new_court_id: matchA.courtId,
+      new_position: matchA.position,
+    },
+  };
+
+  return idle({ swap: { first, second } });
 }
 
 export function selectionReducer(
@@ -76,26 +150,50 @@ export function selectionReducer(
   switch (state.kind) {
     case 'idle':
       if (event.type === 'tap-match') {
-        return { state: { kind: 'match-selected', match: event.match }, reschedule: null };
+        return noOp({ kind: 'match-selected', match: event.match });
       }
-      return { state, reschedule: null };
+      if (event.type === 'tap-tray-match') {
+        return noOp({ kind: 'tray-match-selected', matchId: event.matchId });
+      }
+      return noOp(state);
+
     case 'match-selected':
       switch (event.type) {
         case 'cancel':
-          return { state: IDLE_SELECTION, reschedule: null };
+          return idle();
         case 'tap-match':
-          // Tapping the selected match again deselects; tapping another match
-          // moves the selection there (swap arrives in a later slice).
           if (event.match.matchId === state.match.matchId) {
-            return { state: IDLE_SELECTION, reschedule: null };
+            return idle();
           }
-          return { state: { kind: 'match-selected', match: event.match }, reschedule: null };
+          return swap(state.match, event.match);
+        case 'tap-tray-match':
+          return noOp({ kind: 'tray-match-selected', matchId: event.matchId });
         case 'tap-insertion-line':
           return place(state.match, event.courtId, event.index);
+        case 'unschedule':
+          return idle({ unschedule: { matchId: state.match.matchId } });
         default:
-          return { state, reschedule: null };
+          return noOp(state);
       }
+
+    case 'tray-match-selected':
+      switch (event.type) {
+        case 'cancel':
+          return idle();
+        case 'tap-tray-match':
+          if (event.matchId === state.matchId) {
+            return idle();
+          }
+          return noOp({ kind: 'tray-match-selected', matchId: event.matchId });
+        case 'tap-match':
+          return noOp({ kind: 'match-selected', match: event.match });
+        case 'tap-insertion-line':
+          return placeTray(state.matchId, event.courtId, event.index);
+        default:
+          return noOp(state);
+      }
+
     default:
-      return { state, reschedule: null };
+      return noOp(state);
   }
 }

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -26,7 +26,7 @@ import {
   getStageOrderViolations,
   getUnscheduledMatches,
 } from '@services/lookups';
-import { rescheduleMatch, scheduleMatches } from '@services/match';
+import { rescheduleMatch, scheduleMatches, unscheduleMatch } from '@services/match';
 
 import ScheduleGrid from '@components/scheduling/schedule_grid';
 import UnscheduledSheet from '@components/scheduling/unscheduled_sheet';
@@ -87,16 +87,32 @@ export default function SchedulePage() {
   }
 
   async function handleSelectionEvent(event: SelectionEvent) {
-    const { state, reschedule } = selectionReducer(selection, event);
+    const { state, reschedule, swap, unschedule } = selectionReducer(selection, event);
     setSelection(state);
     if (reschedule != null) {
       await rescheduleMatch(tournamentData.id, reschedule.matchId, reschedule.body);
       await swrStagesResponse.mutate();
     }
+    if (swap != null) {
+      await rescheduleMatch(tournamentData.id, swap.first.matchId, swap.first.body);
+      await rescheduleMatch(tournamentData.id, swap.second.matchId, swap.second.body);
+      await swrStagesResponse.mutate();
+    }
+    if (unschedule != null) {
+      await unscheduleMatch(tournamentData.id, unschedule.matchId);
+      await swrStagesResponse.mutate();
+    }
   }
 
-  const selectedEntry =
-    selection.kind === 'match-selected' ? matchesLookup[selection.match.matchId] : null;
+  const selectedMatchId =
+    selection.kind === 'match-selected'
+      ? selection.match.matchId
+      : selection.kind === 'tray-match-selected'
+        ? selection.matchId
+        : null;
+  const selectedEntry = selectedMatchId != null ? matchesLookup[selectedMatchId] : null;
+
+  const isPlacing = selection.kind !== 'idle';
 
   return (
     <TournamentLayout tournament_id={tournamentData.id}>
@@ -145,7 +161,7 @@ export default function SchedulePage() {
           />
         </Stack>
       ) : (
-        <Box mt="1rem" pb={selection.kind === 'match-selected' ? '14rem' : '4rem'}>
+        <Box mt="1rem" pb={isPlacing ? '14rem' : '4rem'}>
           <ScheduleGrid
             layout={layout}
             violations={violations}
@@ -158,7 +174,12 @@ export default function SchedulePage() {
             unscheduledMatches={unscheduledMatches}
             stageItemsLookup={stageItemsLookup}
             matchesLookup={matchesLookup}
-            openMatchModal={openMatchModal}
+            selectedTrayMatchId={
+              selection.kind === 'tray-match-selected' ? selection.matchId : null
+            }
+            onTrayMatchSelect={(matchId) =>
+              handleSelectionEvent({ type: 'tap-tray-match', matchId })
+            }
           />
           {selectedEntry != null ? (
             <Affix position={{ bottom: 70, left: '50%' }} zIndex={300}>
@@ -185,14 +206,26 @@ export default function SchedulePage() {
                     {t('tap_to_place_hint')}
                   </Text>
                 </Box>
-                <Button
-                  size="compact-sm"
-                  variant="light"
-                  color="red"
-                  onClick={() => handleSelectionEvent({ type: 'cancel' })}
-                >
-                  {t('cancel_button')}
-                </Button>
+                <Group gap="xs" wrap="nowrap">
+                  {selection.kind === 'match-selected' && (
+                    <Button
+                      size="compact-sm"
+                      variant="light"
+                      color="orange"
+                      onClick={() => handleSelectionEvent({ type: 'unschedule' })}
+                    >
+                      {t('unschedule_button')}
+                    </Button>
+                  )}
+                  <Button
+                    size="compact-sm"
+                    variant="light"
+                    color="red"
+                    onClick={() => handleSelectionEvent({ type: 'cancel' })}
+                  >
+                    {t('cancel_button')}
+                  </Button>
+                </Group>
               </Paper>
             </Affix>
           ) : null}


### PR DESCRIPTION
Extend the selection reducer with three new interaction modes:

- Swap: tapping a scheduled match while another is selected issues two
  sequential reschedule calls to exchange their court/position slots.
  The second call's position is derived analytically from the first so no
  intermediate refetch is needed.
- Unschedule: an "Unschedule" button in the floating action bar sends
  the selected match back to the tray via the existing unschedule endpoint.
- Tray placement: tapping a tray match enters tray-match-selected state,
  collapses the bottom sheet, and shows insertion lines. Tapping a line
  schedules the match there via the reschedule endpoint with null old
  court/position (the existing backend path for unscheduled matches).

Reducer tests cover all new state transitions (22 passing → 33 passing).

https://claude.ai/code/session_01TNG2ei6e1ohq5uzk2tzcPR