### PR TITLE
Relax healthcheck interval and cap container log size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY --from=builder /app/dist /app/frontend-dist
 
 EXPOSE 8400
 
-HEALTHCHECK --interval=3s --timeout=5s --retries=10 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=5 \
     CMD ["wget", "-O", "/dev/null", "http://0.0.0.0:8400/ping"]
 
 CMD [ \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
     restart: unless-stopped
     volumes:
       - bracket_static_data:/app/static
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
 
   postgres:
     image: postgres:17
@@ -40,3 +45,8 @@ services:
     restart: always
     volumes:
       - bracket_pg_data:/var/lib/postgresql/data
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"


### PR DESCRIPTION
The 3s healthcheck interval caused dockerd to accumulate significant
memory and CPU over time (~29k tracked execs per day), starving small
hosts during builds. Use a 30s interval with a start period instead,
and bound container log growth with json-file rotation.