### PR TITLE
Fix conflict detection to use canonical interval intersection

### DIFF
--- a/backend/bracket/logic/planning/conflicts.py
+++ b/backend/bracket/logic/planning/conflicts.py
@@ -7,18 +7,11 @@ from bracket.utils.id_types import MatchId
 
 
 def matches_overlap(match1: Match, match2: Match) -> bool:
-    if (
-        match1.start_time is None
-        or match1.end_time is None
-        or match2.start_time is None
-        or match2.end_time is None
-    ):
+    if match1.start_time is None or match2.start_time is None:
         return False
 
-    return not (
-        (match1.end_time < match2.end_time and match1.start_time < match2.start_time)
-        or (match1.start_time > match2.start_time or match1.end_time > match2.end_time)
-    )
+    # Half-open intervals [start, end): back-to-back matches (end1 == start2) do not conflict.
+    return match1.start_time < match2.end_time and match2.start_time < match1.end_time
 
 
 def get_conflicting_matches(
@@ -42,9 +35,6 @@ def get_conflicting_matches(
 
     for i, match1 in enumerate(matches):
         for match2 in matches[i + 1 :]:
-            if match1.id == match2.id:
-                continue
-
             conflicting_input_ids = []
 
             if match2.stage_item_input1_id in match1.stage_item_input_ids:

--- a/backend/tests/unit_tests/conflicts_test.py
+++ b/backend/tests/unit_tests/conflicts_test.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 
-from bracket.logic.planning.conflicts import get_conflicting_matches
+import pytest
+
+from bracket.logic.planning.conflicts import get_conflicting_matches, matches_overlap
 from bracket.models.db.util import StageWithStageItems
 from bracket.utils.dummy_records import DUMMY_MOCK_TIME
 from bracket.utils.id_types import StageId, TournamentId
@@ -10,18 +12,25 @@ from tests.unit_tests.mocks import (
     get_one_round_with_two_definitive_matches,
     get_stage_item_inputs_mock,
     get_stage_item_mock,
+    make_simple_match,
 )
 
+T = DUMMY_MOCK_TIME
 
-def test_get_conflicting_matches_conflicts_to_set() -> None:
-    """
-    Test `get_conflicting_matches` returns the right conflicts to set
-    """
+
+def _make_stage(
+    match1_start: object, match2_start: object, **kwargs: object
+) -> StageWithStageItems:
     tournament_id = TournamentId(-1)
     stage_item_inputs = get_stage_item_inputs_mock(tournament_id)
-    match1, match2 = get_2_definitive_matches_mock(stage_item_inputs)
+    match1, match2 = get_2_definitive_matches_mock(
+        stage_item_inputs,
+        match1_start_time=match1_start,  # type: ignore[arg-type]
+        match2_start_time=match2_start,  # type: ignore[arg-type]
+        **kwargs,  # type: ignore[arg-type]
+    )
     rounds = get_one_round_with_two_definitive_matches(match1, match2)
-    stage_item = StageWithStageItems(
+    return StageWithStageItems(
         id=StageId(-1),
         tournament_id=tournament_id,
         name="",
@@ -30,26 +39,91 @@ def test_get_conflicting_matches_conflicts_to_set() -> None:
         stage_items=[get_stage_item_mock(stage_item_inputs, [rounds])],
     )
 
-    assert get_conflicting_matches([stage_item]) == ({-1: [True, False], -2: [True, False]}, set())
+
+# ---------------------------------------------------------------------------
+# matches_overlap unit tests
+# ---------------------------------------------------------------------------
+
+_OVERLAP_CASES: list[tuple[object, int, int, object, int, int, bool]] = [
+    # Partial overlap, match1 first
+    (T, 15, 0, T + timedelta(minutes=5), 15, 0, True),
+    # Partial overlap, match2 first (symmetric)
+    (T + timedelta(minutes=5), 15, 0, T, 15, 0, True),
+    # match1 fully contains match2
+    (T, 30, 0, T + timedelta(minutes=5), 10, 0, True),
+    # match2 fully contains match1 (symmetric)
+    (T + timedelta(minutes=5), 10, 0, T, 30, 0, True),
+    # Identical intervals
+    (T, 15, 0, T, 15, 0, True),
+    # Overlap only within margin window (durations disjoint, margins overlap)
+    (T, 10, 5, T + timedelta(minutes=12), 10, 5, True),
+    # Symmetric
+    (T + timedelta(minutes=12), 10, 5, T, 10, 5, True),
+    # Back-to-back: end1 == start2 — not a conflict (half-open intervals)
+    (T, 15, 0, T + timedelta(minutes=15), 10, 0, False),
+    # Back-to-back reversed (symmetric)
+    (T + timedelta(minutes=15), 10, 0, T, 15, 0, False),
+    # Disjoint with a gap
+    (T, 10, 0, T + timedelta(minutes=20), 10, 0, False),
+    # Symmetric
+    (T + timedelta(minutes=20), 10, 0, T, 10, 0, False),
+    # match1 start_time is None
+    (None, 15, 0, T, 15, 0, False),
+    # match2 start_time is None
+    (T, 15, 0, None, 15, 0, False),
+    # Both start_time are None
+    (None, 15, 0, None, 15, 0, False),
+]
+
+
+@pytest.mark.parametrize("start1,dur1,margin1,start2,dur2,margin2,expected", _OVERLAP_CASES)
+def test_matches_overlap(
+    start1: object,
+    dur1: int,
+    margin1: int,
+    start2: object,
+    dur2: int,
+    margin2: int,
+    expected: bool,
+) -> None:
+    m1 = make_simple_match(start1, dur1, margin1)  # type: ignore[arg-type]
+    m2 = make_simple_match(start2, dur2, margin2)  # type: ignore[arg-type]
+    assert matches_overlap(m1, m2) == expected
+
+
+# ---------------------------------------------------------------------------
+# get_conflicting_matches tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_conflicting_matches_conflicts_to_set() -> None:
+    """Identical start times → both matches flagged on their shared input side."""
+    stage = _make_stage(T, T)
+    assert get_conflicting_matches([stage]) == ({-1: [True, False], -2: [True, False]}, set())
+
+
+def test_get_conflicting_matches_partial_overlap_is_detected() -> None:
+    """
+    Staggered starts that partially overlap must be flagged.
+
+    match1: T → T+105 min, match2: T+60 min → T+165 min  (45-min overlap)
+    This is the bug scenario from issue #64.
+    """
+    stage = _make_stage(T, T + timedelta(hours=1))
+    assert get_conflicting_matches([stage]) == ({-1: [True, False], -2: [True, False]}, set())
 
 
 def test_get_conflicting_matches_conflicts_to_clear() -> None:
     """
-    Test `get_conflicting_matches` returns the right conflicts to clear
-    """
-    tournament_id = TournamentId(-1)
-    stage_item_inputs = get_stage_item_inputs_mock(tournament_id)
-    match1, match2 = get_2_definitive_matches_mock(
-        stage_item_inputs, DUMMY_MOCK_TIME + timedelta(hours=1)
-    )
-    rounds = get_one_round_with_two_definitive_matches(match1, match2)
-    stage_item = StageWithStageItems(
-        id=StageId(-1),
-        tournament_id=tournament_id,
-        name="",
-        created=MOCK_NOW,
-        is_active=False,
-        stage_items=[get_stage_item_mock(stage_item_inputs, [rounds])],
-    )
+    Matches separated by more than their combined duration+margin do not conflict.
 
-    assert get_conflicting_matches([stage_item]) == ({}, {-1, -2})
+    Each match is 90+15=105 min; a 2-hour (120 min) gap between starts means no overlap.
+    """
+    stage = _make_stage(T, T + timedelta(hours=2))
+    assert get_conflicting_matches([stage]) == ({}, {-1, -2})
+
+
+def test_get_conflicting_matches_back_to_back_no_conflict() -> None:
+    """Back-to-back matches (end1 == start2) must not be flagged."""
+    stage = _make_stage(T, T + timedelta(minutes=105))  # 90+15=105 min
+    assert get_conflicting_matches([stage]) == ({}, {-1, -2})

--- a/backend/tests/unit_tests/mocks.py
+++ b/backend/tests/unit_tests/mocks.py
@@ -1,6 +1,6 @@
 from heliclockter import datetime_utc
 
-from bracket.models.db.match import MatchState, MatchWithDetails, MatchWithDetailsDefinitive
+from bracket.models.db.match import Match, MatchState, MatchWithDetails, MatchWithDetailsDefinitive
 from bracket.models.db.stage_item import StageType
 from bracket.models.db.stage_item_inputs import StageItemInputFinal
 from bracket.models.db.team import Team
@@ -57,8 +57,32 @@ def get_stage_item_inputs_mock(tournament_id: TournamentId) -> list[StageItemInp
     ]
 
 
+def make_simple_match(
+    start_time: datetime_utc | None,
+    duration_minutes: int,
+    margin_minutes: int,
+    match_id: MatchId = MatchId(-1),
+) -> Match:
+    return Match(
+        id=match_id,
+        created=DUMMY_MOCK_TIME,
+        start_time=start_time,
+        duration_minutes=duration_minutes,
+        margin_minutes=margin_minutes,
+        round_id=RoundId(-1),
+        stage_item_input1_score=0,
+        stage_item_input2_score=0,
+        stage_item_input1_conflict=False,
+        stage_item_input2_conflict=False,
+    )
+
+
 def get_2_definitive_matches_mock(
-    stage_item_inputs: list[StageItemInputFinal], match1_start_time: datetime_utc = DUMMY_MOCK_TIME
+    stage_item_inputs: list[StageItemInputFinal],
+    match1_start_time: datetime_utc = DUMMY_MOCK_TIME,
+    match2_start_time: datetime_utc = DUMMY_MOCK_TIME,
+    duration_minutes: int = 90,
+    margin_minutes: int = 15,
 ) -> tuple[MatchWithDetailsDefinitive, MatchWithDetailsDefinitive]:
     match1 = MatchWithDetailsDefinitive(
         id=MatchId(-1),
@@ -68,8 +92,8 @@ def get_2_definitive_matches_mock(
         stage_item_input2_id=stage_item_inputs[1].id,
         created=DUMMY_MOCK_TIME,
         start_time=match1_start_time,
-        duration_minutes=90,
-        margin_minutes=15,
+        duration_minutes=duration_minutes,
+        margin_minutes=margin_minutes,
         round_id=RoundId(-3),
         court_id=CourtId(-1),
         stage_item_input1_score=2,
@@ -87,9 +111,9 @@ def get_2_definitive_matches_mock(
         stage_item_input1_id=stage_item_inputs[2].id,
         stage_item_input2_id=stage_item_inputs[3].id,
         created=DUMMY_MOCK_TIME,
-        start_time=DUMMY_MOCK_TIME,
-        duration_minutes=90,
-        margin_minutes=15,
+        start_time=match2_start_time,
+        duration_minutes=duration_minutes,
+        margin_minutes=margin_minutes,
         round_id=RoundId(-3),
         court_id=CourtId(-2),
         stage_item_input1_score=2,


### PR DESCRIPTION
The previous matches_overlap() expression only triggered on identical
start or end times, missing all partial overlaps and producing asymmetric
results. Replace with the standard half-open interval test
(start1 < end2 and start2 < end1) so any genuine overlap — including
staggered starts — is correctly detected.

Also removes an unreachable self-pair guard inside the pair loop, and
extends test coverage with parametrized matches_overlap() cases plus
get_conflicting_matches() scenarios for partial overlap, back-to-back,
and separated schedules.

https://claude.ai/code/session_01AQUuwNfFsnqC6aRBxYGEwy