### PR TITLE
fix: resolve all ruff and mypy linter/type-checker issues

### DIFF
--- a/backend/alembic/versions/4e5516c97f50_add_levels_table_and_level_id_fks.py
+++ b/backend/alembic/versions/4e5516c97f50_add_levels_table_and_level_id_fks.py
@@ -11,8 +11,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str | None = '4e5516c97f50'
-down_revision: str | None = 'a9f4c8d2b1e7'
+revision: str | None = "4e5516c97f50"
+down_revision: str | None = "a9f4c8d2b1e7"
 branch_labels: str | None = None
 depends_on: str | None = None
 

--- a/backend/bracket/logic/planning/template.py
+++ b/backend/bracket/logic/planning/template.py
@@ -46,7 +46,10 @@ def _group_names(groups: int) -> list[str]:
 
 
 def _empty_inputs(team_count: int) -> list[BlueprintInput]:
-    return [BlueprintInput(slot=i + 1, winner_from=None, winner_position=None) for i in range(team_count)]
+    return [
+        BlueprintInput(slot=i + 1, winner_from=None, winner_position=None)
+        for i in range(team_count)
+    ]
 
 
 def _t(slot: int, winner_from: str, winner_position: int) -> BlueprintInput:
@@ -78,7 +81,8 @@ def _validate(config: TemplateConfig) -> None:
             raise ValueError("until_rank must be even")
         if config.until_rank > _max_rank(config):
             raise ValueError(
-                f"until_rank {config.until_rank} exceeds maximum {_max_rank(config)} for this config"
+                f"until_rank {config.until_rank} exceeds maximum "
+                f"{_max_rank(config)} for this config"
             )
 
 
@@ -92,12 +96,14 @@ def _build_group_stage(config: TemplateConfig) -> BlueprintStage:
     items = []
     for i, name in enumerate(_group_names(config.groups)):
         team_count = base + (1 if i < remainder else 0)
-        items.append(BlueprintStageItem(
-            name=name,
-            type=config.group_stage_type,
-            team_count=team_count,
-            inputs=_empty_inputs(team_count),
-        ))
+        items.append(
+            BlueprintStageItem(
+                name=name,
+                type=config.group_stage_type,
+                team_count=team_count,
+                inputs=_empty_inputs(team_count),
+            )
+        )
     return BlueprintStage(name="Group Phase", items=items)
 
 
@@ -138,10 +144,14 @@ def _build_4group_stages(until_rank: int) -> tuple[BlueprintStage, BlueprintStag
             _item("7th Place", [_t(1, "5th-8th Semi A", 2), _t(2, "5th-8th Semi B", 2)])
         )
 
-    return BlueprintStage(name="Semi-finals", items=semis_items), BlueprintStage(name="Finals", items=finals_items)
+    return BlueprintStage(name="Semi-finals", items=semis_items), BlueprintStage(
+        name="Finals", items=finals_items
+    )
 
 
-def _build_2group_sf_stages(until_rank: int, teams_per_group: int) -> tuple[BlueprintStage, BlueprintStage]:
+def _build_2group_sf_stages(
+    until_rank: int, teams_per_group: int
+) -> tuple[BlueprintStage, BlueprintStage]:
     # Semi-finals stage: only the two main cross-seeded semis, always
     semis_items = [
         _item("Semi-final A", [_t(1, "Group A", 1), _t(2, "Group B", 2)]),
@@ -166,7 +176,9 @@ def _build_2group_sf_stages(until_rank: int, teams_per_group: int) -> tuple[Blue
         name = place_names[i] if i < len(place_names) else f"{rank - 1}th Place"
         finals_items.append(_item(name, [_t(1, "Group A", position), _t(2, "Group B", position)]))
 
-    return BlueprintStage(name="Semi-finals", items=semis_items), BlueprintStage(name="Finals", items=finals_items)
+    return BlueprintStage(name="Semi-finals", items=semis_items), BlueprintStage(
+        name="Finals", items=finals_items
+    )
 
 
 def _build_2group_nosf_finals(until_rank: int, teams_per_group: int) -> BlueprintStage:
@@ -190,7 +202,9 @@ def build_template_blueprint(config: TemplateConfig) -> Blueprint:
         if config.groups == 4:
             semis_stage, finals_stage = _build_4group_stages(until_rank)
         else:
-            semis_stage, finals_stage = _build_2group_sf_stages(until_rank, config.total_teams // config.groups)
+            semis_stage, finals_stage = _build_2group_sf_stages(
+                until_rank, config.total_teams // config.groups
+            )
         return Blueprint(stages=[group_stage, semis_stage, finals_stage])
 
     teams_per_group = config.total_teams // config.groups

--- a/backend/bracket/logic/planning/template_service.py
+++ b/backend/bracket/logic/planning/template_service.py
@@ -3,6 +3,7 @@ from bracket.logic.planning.template import Blueprint, BlueprintInput
 from bracket.logic.scheduling.builder import build_matches_for_stage_item
 from bracket.models.db.stage_item import StageItemWithInputsCreate
 from bracket.models.db.stage_item_inputs import (
+    StageItemInputCreateBody,
     StageItemInputCreateBodyEmpty,
     StageItemInputCreateBodyTentative,
 )
@@ -16,8 +17,8 @@ from bracket.utils.id_types import LevelId, StageItemId, TournamentId
 def build_stage_item_inputs(
     inputs: list[BlueprintInput],
     stage_item_ids_by_name: dict[str, StageItemId],
-) -> list[StageItemInputCreateBodyEmpty | StageItemInputCreateBodyTentative]:
-    created_inputs: list[StageItemInputCreateBodyEmpty | StageItemInputCreateBodyTentative] = []
+) -> list[StageItemInputCreateBody]:
+    created_inputs: list[StageItemInputCreateBody] = []
 
     for input_ in inputs:
         if input_.winner_from is None:
@@ -45,9 +46,7 @@ async def replace_stages_from_template(
     level_id: LevelId | None = None,
 ) -> list[StageWithStageItems]:
     existing_stages = [
-        s
-        for s in await get_full_tournament_details(tournament_id)
-        if s.level_id == level_id
+        s for s in await get_full_tournament_details(tournament_id) if s.level_id == level_id
     ]
 
     async with database.transaction():
@@ -77,15 +76,15 @@ async def replace_stages_from_template(
 
         stage_item_ids_by_name: dict[str, StageItemId] = {}
         for blueprint_stage in blueprint.stages:
-            stage = await sql_create_stage(
+            new_stage = await sql_create_stage(
                 tournament_id, blueprint_stage.name, level_id=level_id
             )
 
             for blueprint_stage_item in blueprint_stage.items:
-                stage_item = await sql_create_stage_item_with_inputs(
+                new_stage_item = await sql_create_stage_item_with_inputs(
                     tournament_id,
                     StageItemWithInputsCreate(
-                        stage_id=stage.id,
+                        stage_id=new_stage.id,
                         name=blueprint_stage_item.name,
                         type=blueprint_stage_item.type,
                         team_count=blueprint_stage_item.team_count,
@@ -95,7 +94,7 @@ async def replace_stages_from_template(
                         ),
                     ),
                 )
-                stage_item_ids_by_name[blueprint_stage_item.name] = stage_item.id
-                await build_matches_for_stage_item(stage_item, tournament_id)
+                stage_item_ids_by_name[blueprint_stage_item.name] = new_stage_item.id
+                await build_matches_for_stage_item(new_stage_item, tournament_id)
 
     return await get_full_tournament_details(tournament_id)

--- a/backend/bracket/logic/subscriptions.py
+++ b/backend/bracket/logic/subscriptions.py
@@ -90,6 +90,7 @@ async def setup_demo_account(user_id: UserId) -> None:
         max_team_size=4,
         signup_team_choice_enabled=True,
         score_tracking_enabled=False,
+        rules=None,
     )
     tournament_id = await sql_create_tournament(tournament)
 

--- a/backend/bracket/models/db/match.py
+++ b/backend/bracket/models/db/match.py
@@ -1,6 +1,7 @@
 import json
 from decimal import Decimal
 from enum import auto
+from typing import cast
 
 from heliclockter import datetime_utc, timedelta
 from pydantic import BaseModel, field_validator
@@ -76,7 +77,7 @@ class MatchWithDetails(Match):
     @staticmethod
     def parse_nested_json(value: str | dict[str, object] | None) -> str | dict[str, object] | None:
         if isinstance(value, str):
-            return json.loads(value)
+            return cast("str | dict[str, object]", json.loads(value))
         return value
 
 

--- a/backend/bracket/models/db/stage.py
+++ b/backend/bracket/models/db/stage.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 from heliclockter import datetime_utc
 
@@ -42,7 +42,7 @@ class StageTemplateCreateBody(BaseModelORM):
 
     def to_template_config(self) -> TemplateConfig:
         return TemplateConfig(
-            groups=self.groups,
+            groups=cast("Literal[2, 4]", self.groups),
             total_teams=self.total_teams,
             until_rank=self.until_rank,
             include_semi_final=self.include_semi_final,

--- a/backend/bracket/models/db/tournament.py
+++ b/backend/bracket/models/db/tournament.py
@@ -84,5 +84,5 @@ class TournamentBody(TournamentUpdateBody):
 
     @model_validator(mode="before")
     @classmethod
-    def reject_levels(cls, data: dict) -> dict:  # type: ignore[override, type-arg]
+    def reject_levels(cls, data: dict) -> dict:  # type: ignore[type-arg]
         return data

--- a/backend/bracket/routes/stage_items.py
+++ b/backend/bracket/routes/stage_items.py
@@ -72,7 +72,7 @@ from bracket.utils.errors import (
     ForeignKey,
     check_foreign_key_violation,
 )
-from bracket.utils.id_types import StageItemId, TournamentId
+from bracket.utils.id_types import MatchId, StageItemId, StageItemInputId, TournamentId
 
 router = APIRouter(prefix=config.api_prefix)
 
@@ -86,7 +86,7 @@ def format_slots(slots: Iterable[int]) -> str:
 
 
 async def update_stage_item_input_slots(
-    stage_item_id: StageItemId, input_ids_in_slot_order: list[int]
+    stage_item_id: StageItemId, input_ids_in_slot_order: list[StageItemInputId]
 ) -> None:
     for index, stage_item_input_id in enumerate(input_ids_in_slot_order, start=1):
         await database.execute(
@@ -142,9 +142,9 @@ async def update_stage_item_row(
 
 
 def get_removed_match_ids_and_blocking_slots(
-    stage_item: StageItemWithRounds, removable_input_ids: set[int]
-) -> tuple[list[int], set[int]]:
-    removable_match_ids: list[int] = []
+    stage_item: StageItemWithRounds, removable_input_ids: set[StageItemInputId]
+) -> tuple[list[MatchId], set[int]]:
+    removable_match_ids: list[MatchId] = []
     blocking_slots: set[int] = set()
     slot_by_input_id = {
         input_.id: input_.slot for input_ in stage_item.inputs if input_.id is not None

--- a/backend/bracket/routes/teams.py
+++ b/backend/bracket/routes/teams.py
@@ -277,7 +277,7 @@ async def create_multiple_teams(
     check_requirement(existing_players, user, "max_players", additions=len(all_players))
 
     tournament = await sql_get_tournament(tournament_id)
-    for _, player_names in teams_and_players:
+    for _team_name, player_names in teams_and_players:
         if len(player_names) > tournament.max_team_size:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/bracket/routes/tournaments.py
+++ b/backend/bracket/routes/tournaments.py
@@ -14,6 +14,7 @@ from bracket.logic.subscriptions import check_requirement
 from bracket.logic.tournaments import get_tournament_logo_path
 from bracket.models.db.ranking import RankingCreateBody
 from bracket.models.db.tournament import (
+    LevelResponse,
     Tournament,
     TournamentBody,
     TournamentChangeStatusBody,
@@ -64,7 +65,13 @@ router = APIRouter(prefix=config.api_prefix)
 
 async def _tournament_with_levels(tournament: Tournament) -> TournamentWithLevels:
     levels = await sql_get_levels_for_tournament(tournament.id)
-    return TournamentWithLevels(**tournament.model_dump(), levels=levels)
+    return TournamentWithLevels(
+        **tournament.model_dump(),
+        levels=[
+            LevelResponse(id=level.id, name=level.name, position=level.position)
+            for level in levels
+        ],
+    )
 
 
 unauthorized_exception = HTTPException(

--- a/backend/bracket/sql/matches.py
+++ b/backend/bracket/sql/matches.py
@@ -126,7 +126,7 @@ async def sql_update_match(match_id: MatchId, match: MatchBody, tournament: Tour
             "state": match.state.value,
             "completed_at": (
                 datetime.fromisoformat(match.completed_at.isoformat())
-                if getattr(match, "completed_at", None) is not None
+                if match.completed_at is not None
                 else None
             ),
         },

--- a/backend/bracket/utils/dummy_records.py
+++ b/backend/bracket/utils/dummy_records.py
@@ -53,6 +53,7 @@ DUMMY_TOURNAMENT = TournamentInsertable(
     auto_assign_courts=True,
     duration_minutes=10,
     margin_minutes=5,
+    max_team_size=4,
 )
 
 DUMMY_LEVEL1 = LevelInsertable(

--- a/backend/bracket/utils/errors.py
+++ b/backend/bracket/utils/errors.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from enum import auto
 
-import asyncpg  # type: ignore[import-untyped]
+import asyncpg
 from fastapi import HTTPException
 from starlette import status
 
@@ -32,12 +32,8 @@ class ForeignKey(EnumAutoStr):
 
 
 unique_index_violation_error_lookup = {
-    UniqueIndex.ix_stages_one_active_no_level: (
-        "Only one stage can be active per tournament"
-    ),
-    UniqueIndex.ix_stages_one_active_per_level: (
-        "Only one stage can be active per level"
-    ),
+    UniqueIndex.ix_stages_one_active_no_level: ("Only one stage can be active per tournament"),
+    UniqueIndex.ix_stages_one_active_per_level: ("Only one stage can be active per level"),
     UniqueIndex.ix_tournaments_dashboard_endpoint: "This dashboard link is already taken",
     UniqueIndex.ix_users_email: "This email is already taken",
     UniqueIndex.stage_item_inputs_stage_item_id_team_id_key: (

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -112,6 +112,10 @@ disallow_any_generics = false
 module = ['fastapi_sso.*']
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ['asyncpg.*']
+ignore_missing_imports = true
+
 [tool.pylint.'MESSAGES CONTROL']
 disable = [
     'broad-except',

--- a/backend/tests/integration_tests/api/matches_test.py
+++ b/backend/tests/integration_tests/api/matches_test.py
@@ -659,11 +659,11 @@ async def test_update_endpoint_custom_duration_margin_honours_positions_across_c
     ]
     court1_matches = sorted(
         (m for m in all_matches if m.court_id == court1_inserted.id),
-        key=lambda m: m.position_in_schedule,
+        key=lambda m: m.position_in_schedule if m.position_in_schedule is not None else -1,
     )
     court2_matches = sorted(
         (m for m in all_matches if m.court_id == court2_inserted.id),
-        key=lambda m: m.position_in_schedule,
+        key=lambda m: m.position_in_schedule if m.position_in_schedule is not None else -1,
     )
 
     # Court 1 keeps its 3 matches in position order; the updated match now

--- a/backend/tests/integration_tests/api/per_level_rankings_test.py
+++ b/backend/tests/integration_tests/api/per_level_rankings_test.py
@@ -18,9 +18,7 @@ from tests.integration_tests.api.shared import (
 from tests.integration_tests.models import AuthContext
 
 
-def _create_body(
-    endpoint: str, club_id: int, levels: list[str] | None = None
-) -> dict[str, object]:
+def _create_body(endpoint: str, club_id: int, levels: list[str] | None = None) -> dict[str, object]:
     body: dict[str, object] = {
         "name": "Per-Level Rankings Tournament",
         "start_time": DUMMY_MOCK_TIME.isoformat().replace("+00:00", "Z"),

--- a/backend/tests/integration_tests/api/rescheduling_matches_test.py
+++ b/backend/tests/integration_tests/api/rescheduling_matches_test.py
@@ -531,11 +531,11 @@ async def test_reschedule_match_honours_positions_across_courts(
     ]
     court1_matches = sorted(
         (m for m in all_matches if m.court_id == court1_inserted.id),
-        key=lambda m: m.position_in_schedule,
+        key=lambda m: m.position_in_schedule if m.position_in_schedule is not None else -1,
     )
     court2_matches = sorted(
         (m for m in all_matches if m.court_id == court2_inserted.id),
-        key=lambda m: m.position_in_schedule,
+        key=lambda m: m.position_in_schedule if m.position_in_schedule is not None else -1,
     )
 
     # Court 1 now holds all 3 stage-1 matches plus the stage-2 match in position order
@@ -1325,11 +1325,11 @@ async def test_unschedule_match_reorders_remaining_positions(
     ]
     court1_matches = sorted(
         (m for m in all_matches if m.court_id == court1_inserted.id),
-        key=lambda m: m.position_in_schedule,
+        key=lambda m: m.position_in_schedule if m.position_in_schedule is not None else -1,
     )
     court2_matches = sorted(
         (m for m in all_matches if m.court_id == court2_inserted.id),
-        key=lambda m: m.position_in_schedule,
+        key=lambda m: m.position_in_schedule if m.position_in_schedule is not None else -1,
     )
 
     # The unscheduled match is gone from any court

--- a/backend/tests/integration_tests/api/scheduling_matches_test.py
+++ b/backend/tests/integration_tests/api/scheduling_matches_test.py
@@ -6,6 +6,7 @@ from bracket.models.db.stage_item_inputs import (
     StageItemInputCreateBodyFinal,
     StageItemInputCreateBodyTentative,
 )
+from bracket.models.db.util import StageWithStageItems
 from bracket.sql.shared import sql_delete_stage_item_with_foreign_keys
 from bracket.sql.stage_items import sql_create_stage_item_with_inputs
 from bracket.sql.stages import get_full_tournament_details
@@ -126,8 +127,8 @@ async def test_schedule_all_matches(
         assert len(round_.matches) == 2
 
 
-def _count_matches_per_court(stages: list) -> dict:
-    counts: dict = {}
+def _count_matches_per_court(stages: list[StageWithStageItems]) -> dict[object, int]:
+    counts: dict[object, int] = {}
     for stage in stages:
         for stage_item in stage.stage_items:
             for round_ in stage_item.rounds:
@@ -184,7 +185,8 @@ async def test_schedule_distributes_evenly_across_courts_round_robin(
 async def test_schedule_does_not_move_already_scheduled_matches(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:
-    """Calling schedule_matches twice: the second call must leave already-scheduled matches alone."""
+    """Calling schedule_matches twice: the second call must leave already-scheduled matches alone.
+    """
     tid = auth_context.tournament.id
     async with (
         inserted_court(DUMMY_COURT1.model_copy(update={"tournament_id": tid})),

--- a/backend/tests/integration_tests/api/signup_test.py
+++ b/backend/tests/integration_tests/api/signup_test.py
@@ -26,12 +26,12 @@ async def test_signup_none_team_action_without_levels_creates_player_with_no_lev
         players_response: JsonDict = await send_tournament_request(
             HTTPMethod.GET, "players", auth_context
         )
-        await database.execute(query=players.delete().where(players.c.tournament_id == tournament_id))
+        await database.execute(
+            query=players.delete().where(players.c.tournament_id == tournament_id)
+        )
 
     assert response == {"success": True}
-    player = next(
-        p for p in players_response["data"]["players"] if p["name"] == "Teamless Player"
-    )
+    player = next(p for p in players_response["data"]["players"] if p["name"] == "Teamless Player")
     assert player["level_id"] is None
 
 
@@ -74,11 +74,11 @@ async def test_signup_none_team_action_with_level_id_sets_player_level(
         players_response: JsonDict = await send_tournament_request(
             HTTPMethod.GET, "players", auth_context
         )
-        await database.execute(query=players.delete().where(players.c.tournament_id == tournament_id))
+        await database.execute(
+            query=players.delete().where(players.c.tournament_id == tournament_id)
+        )
 
-    player = next(
-        p for p in players_response["data"]["players"] if p["name"] == "Leveled Teamless"
-    )
+    player = next(p for p in players_response["data"]["players"] if p["name"] == "Leveled Teamless")
     assert player["level_id"] == level.id
 
 
@@ -107,7 +107,9 @@ async def test_signup_create_team_copies_level_to_player(
             HTTPMethod.GET, "players", auth_context
         )
         await database.execute(query=teams.delete().where(teams.c.tournament_id == tournament_id))
-        await database.execute(query=players.delete().where(players.c.tournament_id == tournament_id))
+        await database.execute(
+            query=players.delete().where(players.c.tournament_id == tournament_id)
+        )
 
     player = next(p for p in players_response["data"]["players"] if p["name"] == "Team Creator")
     assert player["level_id"] == level.id
@@ -135,7 +137,9 @@ async def test_signup_join_team_copies_level_to_player(
         players_response: JsonDict = await send_tournament_request(
             HTTPMethod.GET, "players", auth_context
         )
-        await database.execute(query=players.delete().where(players.c.tournament_id == tournament_id))
+        await database.execute(
+            query=players.delete().where(players.c.tournament_id == tournament_id)
+        )
 
     player = next(p for p in players_response["data"]["players"] if p["name"] == "Team Joiner")
     assert player["level_id"] == level.id

--- a/backend/tests/integration_tests/api/stage_items_test.py
+++ b/backend/tests/integration_tests/api/stage_items_test.py
@@ -16,6 +16,7 @@ from bracket.utils.dummy_records import (
     DUMMY_TEAM3,
 )
 from bracket.utils.http import HTTPMethod
+from bracket.utils.id_types import StageItemId
 from tests.integration_tests.api.shared import (
     SUCCESS_RESPONSE,
     send_tournament_request,
@@ -31,7 +32,7 @@ from tests.integration_tests.sql import (
 
 async def create_stage_item_via_api(
     auth_context: AuthContext, stage_id: int, stage_type: StageType, team_count: int
-) -> int:
+) -> StageItemId:
     assert (
         await send_tournament_request(
             HTTPMethod.POST,

--- a/backend/tests/integration_tests/api/stages_test.py
+++ b/backend/tests/integration_tests/api/stages_test.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from bracket.database import database
@@ -171,7 +173,7 @@ async def test_create_stages_from_template(
     semi_final_b_id = semis_stage_items["Semi-final B"]["id"]
 
     def relevant_inputs(
-        items: dict[str, dict], stage_item_name: str
+        items: dict[str, dict[str, Any]], stage_item_name: str
     ) -> list[tuple[int, int, int | None]]:
         return sorted(
             (

--- a/backend/tests/integration_tests/api/team_levels_test.py
+++ b/backend/tests/integration_tests/api/team_levels_test.py
@@ -33,9 +33,7 @@ async def test_create_team_requires_level_id_when_tournament_has_levels(
         DUMMY_LEVEL1.model_copy(update={"tournament_id": auth_context.tournament.id})
     ):
         body = {"name": "Team A", "active": True, "player_ids": []}
-        response = await send_tournament_request(
-            HTTPMethod.POST, "teams", auth_context, None, body
-        )
+        response = await send_tournament_request(HTTPMethod.POST, "teams", auth_context, None, body)
     assert response == {"detail": "level_id is required when the tournament has levels"}
     await assert_row_count_and_clear(teams, 0)
 
@@ -45,18 +43,14 @@ async def test_create_team_persists_level_id(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:
     tid = auth_context.tournament.id
-    async with inserted_level(
-        DUMMY_LEVEL1.model_copy(update={"tournament_id": tid})
-    ) as level:
+    async with inserted_level(DUMMY_LEVEL1.model_copy(update={"tournament_id": tid})) as level:
         body = {
             "name": "Team A",
             "active": True,
             "player_ids": [],
             "level_id": level.id,
         }
-        response = await send_tournament_request(
-            HTTPMethod.POST, "teams", auth_context, None, body
-        )
+        response = await send_tournament_request(HTTPMethod.POST, "teams", auth_context, None, body)
         assert response["data"]["level_id"] == level.id
 
         team = await get_team_by_id(response["data"]["id"], tid)
@@ -74,9 +68,7 @@ async def test_create_team_rejects_level_id_when_no_levels(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:
     body = {"name": "Team A", "active": True, "player_ids": [], "level_id": 1}
-    response = await send_tournament_request(
-        HTTPMethod.POST, "teams", auth_context, None, body
-    )
+    response = await send_tournament_request(HTTPMethod.POST, "teams", auth_context, None, body)
     assert response == {"detail": "level_id must be null when the tournament has no levels"}
     await assert_row_count_and_clear(teams, 0)
 
@@ -86,9 +78,7 @@ async def test_create_teams_multi_applies_level_id_to_batch(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:
     tid = auth_context.tournament.id
-    async with inserted_level(
-        DUMMY_LEVEL1.model_copy(update={"tournament_id": tid})
-    ) as level:
+    async with inserted_level(DUMMY_LEVEL1.model_copy(update={"tournament_id": tid})) as level:
         body = {
             "names": "Team -1,\nTeam -2,",
             "active": True,
@@ -171,9 +161,7 @@ async def test_update_team_rejects_level_change_when_assigned_to_stage_item(
         response = await send_tournament_request(
             HTTPMethod.PUT, f"teams/{team.id}", auth_context, None, body
         )
-        assert response == {
-            "detail": "Cannot change level: team is assigned to a stage item"
-        }
+        assert response == {"detail": "Cannot change level: team is assigned to a stage item"}
 
         refreshed = await get_team_by_id(team.id, tid)
         assert refreshed is not None

--- a/backend/tests/unit_tests/template_test.py
+++ b/backend/tests/unit_tests/template_test.py
@@ -99,7 +99,10 @@ def test_4_groups_until_rank_4() -> None:
 def test_4_groups_until_rank_6() -> None:
     bp = build_template_blueprint(make_config(groups=4, until_rank=6))
     assert item_names_in(bp, "Semi-finals") == [
-        "Semi-final A", "Semi-final B", "5th-8th Semi A", "5th-8th Semi B",
+        "Semi-final A",
+        "Semi-final B",
+        "5th-8th Semi A",
+        "5th-8th Semi B",
     ]
     assert item_names_in(bp, "Finals") == ["Final", "3rd Place", "5th Place"]
 
@@ -118,7 +121,10 @@ def test_4_groups_until_rank_6() -> None:
 def test_4_groups_until_rank_8() -> None:
     bp = build_template_blueprint(make_config(groups=4, until_rank=8))
     assert item_names_in(bp, "Semi-finals") == [
-        "Semi-final A", "Semi-final B", "5th-8th Semi A", "5th-8th Semi B",
+        "Semi-final A",
+        "Semi-final B",
+        "5th-8th Semi A",
+        "5th-8th Semi B",
     ]
     assert item_names_in(bp, "Finals") == ["Final", "3rd Place", "5th Place", "7th Place"]
 
@@ -228,13 +234,17 @@ def test_2_groups_sf_all_resolves_to_2x_teams_per_group() -> None:
 
 def test_2_groups_sf_4_teams_raises() -> None:
     with pytest.raises(ValueError, match="teams per group must be at least 3"):
-        build_template_blueprint(make_config(groups=2, total_teams=4, include_semi_final=True, until_rank=2))
+        build_template_blueprint(
+            make_config(groups=2, total_teams=4, include_semi_final=True, until_rank=2)
+        )
 
 
 def test_2_groups_sf_rank_exceeds_team_count_raises() -> None:
     # 6 teams, 2 groups → 3 per group → max rank 6; until_rank=8 should fail
     with pytest.raises(ValueError, match="until_rank.*exceeds maximum"):
-        build_template_blueprint(make_config(groups=2, total_teams=6, include_semi_final=True, until_rank=8))
+        build_template_blueprint(
+            make_config(groups=2, total_teams=6, include_semi_final=True, until_rank=8)
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -297,8 +307,11 @@ def test_2_groups_nosf_all_resolves_to_teams_per_group_times_2() -> None:
 def test_2_groups_nosf_swiss_group_stage() -> None:
     bp = build_template_blueprint(
         make_config(
-            groups=2, total_teams=12, include_semi_final=False,
-            until_rank=2, group_stage_type=StageType.SWISS,
+            groups=2,
+            total_teams=12,
+            include_semi_final=False,
+            until_rank=2,
+            group_stage_type=StageType.SWISS,
         )
     )
     assert all(item.type == StageType.SWISS for item in items_in(bp, "Group Phase"))
@@ -311,7 +324,9 @@ def test_2_groups_nosf_swiss_group_stage() -> None:
 
 def test_uneven_2_groups_group_sizes() -> None:
     # 7 teams, 2 groups → Group A: 4 slots, Group B: 3 slots
-    bp = build_template_blueprint(make_config(groups=2, total_teams=7, include_semi_final=False, until_rank=2))
+    bp = build_template_blueprint(
+        make_config(groups=2, total_teams=7, include_semi_final=False, until_rank=2)
+    )
     group_a, group_b = items_in(bp, "Group Phase")
     assert group_a.team_count == 4
     assert len(group_a.inputs) == 4
@@ -329,7 +344,9 @@ def test_uneven_4_groups_group_sizes() -> None:
 
 def test_uneven_groups_knockout_uses_min_team_count() -> None:
     # 7 teams, 2 groups → floor=3, max_rank=6; knockout references only positions 1–3
-    bp = build_template_blueprint(make_config(groups=2, total_teams=7, include_semi_final=False, until_rank="all"))
+    bp = build_template_blueprint(
+        make_config(groups=2, total_teams=7, include_semi_final=False, until_rank="all")
+    )
     ko_items = items_in(bp, "Finals")
     assert len(ko_items) == 3  # Final, 3rd, 5th — not 4th rank (position 4 doesn't advance)
     assert ko_items[-1].inputs == [
@@ -340,7 +357,9 @@ def test_uneven_groups_knockout_uses_min_team_count() -> None:
 
 def test_uneven_2_groups_sf_valid() -> None:
     # 7 teams, 2 groups with SF → floor=3 ≥ min 3, should not raise
-    bp = build_template_blueprint(make_config(groups=2, total_teams=7, include_semi_final=True, until_rank=2))
+    bp = build_template_blueprint(
+        make_config(groups=2, total_teams=7, include_semi_final=True, until_rank=2)
+    )
     assert stage_names(bp) == ["Group Phase", "Semi-finals", "Finals"]
     group_a, group_b = items_in(bp, "Group Phase")
     assert group_a.team_count == 4
@@ -379,6 +398,8 @@ def test_one_team_per_group_raises() -> None:
 
 def test_4_groups_ignores_include_semi_final_false() -> None:
     bp_true = build_template_blueprint(make_config(groups=4, include_semi_final=True, until_rank=4))
-    bp_false = build_template_blueprint(make_config(groups=4, include_semi_final=False, until_rank=4))
+    bp_false = build_template_blueprint(
+        make_config(groups=4, include_semi_final=False, until_rank=4)
+    )
     assert stage_names(bp_true) == stage_names(bp_false)
     assert item_names_in(bp_true, "Semi-finals") == item_names_in(bp_false, "Semi-finals")

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
     "paths": {
-      "@*": ["*"],
-      "@components/*": ["components/*"],
-      "@pages/*": ["pages/*"],
-      "@openapi/*": ["openapi/*"],
+      "@*": ["./src/*"],
+      "@components/*": ["./src/components/*"],
+      "@pages/*": ["./src/pages/*"],
+      "@openapi/*": ["./src/openapi/*"],
     },
     "target": "es6",
     "allowJs": true,


### PR DESCRIPTION
- ruff: format long lines across template.py, test files, and template_service.py
- mypy: fix unused type-ignore comment in tournament.py
- mypy: cast json.loads() return in match.py parse_nested_json validator
- mypy: guard completed_at access via direct None check in sql/matches.py
- mypy: cast groups field to Literal[2, 4] in stage.py to_template_config
- mypy: add missing rules=None to TournamentBody in subscriptions.py
- mypy: add missing max_team_size=4 to TournamentInsertable in dummy_records.py
- mypy: convert list[Level] to list[LevelResponse] in routes/tournaments.py
- mypy: rename loop variable to avoid shadowing Tournament function param in routes/teams.py
- mypy: update get_removed_match_ids_and_blocking_slots and update_stage_item_input_slots
  to use StageItemInputId/MatchId typed IDs in routes/stage_items.py
- mypy: rename stage/stage_item loop vars in template_service.py to avoid type conflict;
  use StageItemInputCreateBody alias for return type
- mypy: add asyncpg to mypy ignore_missing_imports overrides, remove now-redundant
  type: ignore comment in utils/errors.py
- tests: fix missing generic type args in stages_test.py and scheduling_matches_test.py
- tests: fix create_stage_item_via_api return type to StageItemId
- tests: fix sorted() key lambdas returning int | None in rescheduling and matches tests
- frontend: remove deprecated baseUrl from tsconfig.json, update paths to root-relative

https://claude.ai/code/session_01FxA211Z8Uu4qusqFV9Q2LA