### PR TITLE
Preview schedule placement conflicts

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -193,6 +193,7 @@
     "only_recommended_radio_label": "Nur empfohlen",
     "password_input_label": "Passwort",
     "password_input_placeholder": "Ihr Passwort",
+    "placement_conflict_preview_label": "Würde ein Team doppelt belegen",
     "plan_next_round_button": "Nächste Runde planen",
     "plan_next_stage_button": "Nächste Phase starten",
     "plan_previous_stage_button": "Zur vorherigen Phase zurückgehen",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -201,6 +201,7 @@
     "only_recommended_radio_label": "Only recommended",
     "password_input_label": "Password",
     "password_input_placeholder": "Your password",
+    "placement_conflict_preview_label": "Would double-book a team",
     "plan_next_round_button": "Plan next round",
     "plan_next_stage_button": "Start the next stage",
     "plan_previous_stage_button": "Go back to the previous stage",

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
+import { ConflictPreview, insertionLineKey } from '@logic/planning/conflict_preview';
 import {
   InsertionLine,
   MatchBlock,
@@ -80,6 +81,7 @@ function MatchCard({
   zoom,
   pxPerMinute,
   isViolation,
+  hasPlacementWarning,
   isSelected,
   stageItemsLookup,
   matchesLookup,
@@ -90,6 +92,7 @@ function MatchCard({
   zoom: 'agenda' | 'compact';
   pxPerMinute: number;
   isViolation: boolean;
+  hasPlacementWarning: boolean;
   isSelected: boolean;
   stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
   matchesLookup: Record<number, MatchLookupEntry>;
@@ -164,10 +167,21 @@ function MatchCard({
       </Box>
     </Tooltip>
   ) : null;
+  const placementWarningIcon = hasPlacementWarning ? (
+    <Tooltip label={t('placement_conflict_preview_label', 'Would double-book a team')}>
+      <Box
+        component="span"
+        style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}
+      >
+        <AiFillWarning color="var(--mantine-color-orange-filled)" />
+      </Box>
+    </Tooltip>
+  ) : null;
 
   return (
     <Box
       data-match-id={match.id}
+      data-conflict-preview={hasPlacementWarning ? 'true' : undefined}
       onClick={(event) => {
         event.stopPropagation();
         onTap();
@@ -183,10 +197,16 @@ function MatchCard({
         borderRadius: 6,
         border: isSelected
           ? '1px solid var(--mantine-color-indigo-filled)'
-          : '1px solid var(--mantine-color-default-border)',
+          : hasPlacementWarning
+            ? '1px dashed var(--mantine-color-orange-filled)'
+            : '1px solid var(--mantine-color-default-border)',
         borderLeft: `4px solid var(--mantine-color-${color}-filled)`,
         backgroundColor: `var(--mantine-color-${color}-light)`,
-        boxShadow: isSelected ? '0 0 0 2px var(--mantine-color-indigo-filled)' : undefined,
+        boxShadow: isSelected
+          ? '0 0 0 2px var(--mantine-color-indigo-filled)'
+          : hasPlacementWarning
+            ? '0 0 0 2px var(--mantine-color-orange-light)'
+            : undefined,
         zIndex: isSelected ? 1 : undefined,
       }}
     >
@@ -207,6 +227,7 @@ function MatchCard({
             {contextRows.length === 0 && contextParts.length > 0
               ? contextBadge(contextParts.join(' · '))
               : null}
+            {placementWarningIcon}
             {violationIcon}
           </Flex>
         )}
@@ -218,6 +239,7 @@ function MatchCard({
         <Flex gap={6} align="center" wrap="nowrap">
           {rows < 3 && showTime && timeLabel}
           {match.stage_item_input1_conflict && <AiFillWarning color="red" />}
+          {rows < 3 && placementWarningIcon}
           {rows === 1 &&
             match.stage_item_input2_conflict &&
             !(mergeConflictIcons && match.stage_item_input1_conflict) && (
@@ -294,12 +316,14 @@ function InsertionLineTarget({
   gridHeight,
   pxPerMinute,
   isNoop,
+  hasConflictWarning,
   onTap,
 }: {
   line: InsertionLine;
   gridHeight: number;
   pxPerMinute: number;
   isNoop: boolean;
+  hasConflictWarning: boolean;
   onTap: () => void;
 }) {
   const lineY = line.offsetMinutes * pxPerMinute;
@@ -316,6 +340,7 @@ function InsertionLineTarget({
   return (
     <Box
       data-insertion-index={line.index}
+      data-conflict-preview={hasConflictWarning ? 'true' : undefined}
       onClick={(event) => {
         event.stopPropagation();
         onTap();
@@ -339,8 +364,12 @@ function InsertionLineTarget({
           right: 4,
           height: 4,
           borderRadius: 2,
-          backgroundColor: 'var(--mantine-color-indigo-filled)',
-          boxShadow: '0 0 0 1px var(--mantine-color-body)',
+          backgroundColor: hasConflictWarning
+            ? 'var(--mantine-color-orange-filled)'
+            : 'var(--mantine-color-indigo-filled)',
+          boxShadow: hasConflictWarning
+            ? '0 0 0 1px var(--mantine-color-body), 0 0 0 4px var(--mantine-color-orange-light)'
+            : '0 0 0 1px var(--mantine-color-body)',
         }}
       />
     </Box>
@@ -362,6 +391,7 @@ function InsertionLineTarget({
 export default function ScheduleGrid({
   layout,
   violations,
+  conflictPreview,
   stageItemsLookup,
   matchesLookup,
   levels,
@@ -372,6 +402,7 @@ export default function ScheduleGrid({
 }: {
   layout: ScheduleGridLayout<Court, MatchWithDetails>;
   violations: Set<number>;
+  conflictPreview: ConflictPreview;
   stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
   matchesLookup: Record<number, MatchLookupEntry>;
   levels: LevelResponse[];
@@ -572,6 +603,7 @@ export default function ScheduleGrid({
                     zoom={zoom}
                     pxPerMinute={pxPerMinute}
                     isViolation={violations.has(block.match.id)}
+                    hasPlacementWarning={conflictPreview.swapTargets.has(block.match.id)}
                     isSelected={selectedMatch?.matchId === block.match.id}
                     stageItemsLookup={stageItemsLookup}
                     matchesLookup={matchesLookup}
@@ -594,6 +626,9 @@ export default function ScheduleGrid({
                       (line.index === selectedMatch.position ||
                         line.index === selectedMatch.position + 1)
                     }
+                    hasConflictWarning={conflictPreview.insertionLines.has(
+                      insertionLineKey(court.id, line.index)
+                    )}
                     onTap={() =>
                       onSelectionEvent({
                         type: 'tap-insertion-line',

--- a/frontend/src/logic/planning/conflict_preview.test.ts
+++ b/frontend/src/logic/planning/conflict_preview.test.ts
@@ -77,7 +77,7 @@ describe('actionCreatesSelectedConflict', () => {
     ).toBe(true);
   });
 
-  it('does not count the selected match post-match margin as team overlap', () => {
+  it('counts post-match margin as team overlap, matching backend conflict flags', () => {
     const stages = stagesWith([
       match({ id: 1, courtId: 1, position: 0, startMinutes: 0, input1: 10, input2: 20 }),
       match({ id: 2, courtId: 2, position: 0, startMinutes: 0, input1: 40, input2: 50 }),
@@ -109,7 +109,7 @@ describe('actionCreatesSelectedConflict', () => {
           },
         },
       })
-    ).toBe(false);
+    ).toBe(true);
   });
 });
 

--- a/frontend/src/logic/planning/conflict_preview.test.ts
+++ b/frontend/src/logic/planning/conflict_preview.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ConflictPreviewMatch,
+  actionCreatesSelectedConflict,
+  computeConflictPreview,
+  insertionLineKey,
+} from './conflict_preview';
+import { computeScheduleLayout } from './layout';
+
+const START = '2026-06-10T09:00:00.000Z';
+const PACKED_SLOT_MINUTES = 105;
+
+function minutesAfterStart(minutes: number): string {
+  return new Date(new Date(START).getTime() + minutes * 60_000).toISOString();
+}
+
+function match({
+  id,
+  courtId,
+  position,
+  startMinutes,
+  input1,
+  input2,
+  durationMinutes = 90,
+  marginMinutes = 15,
+}: {
+  id: number;
+  courtId: number | null;
+  position: number | null;
+  startMinutes: number | null;
+  input1: number;
+  input2: number;
+  durationMinutes?: number;
+  marginMinutes?: number;
+}): ConflictPreviewMatch {
+  return {
+    id,
+    court_id: courtId,
+    position_in_schedule: position,
+    start_time: startMinutes == null ? null : minutesAfterStart(startMinutes),
+    duration_minutes: durationMinutes,
+    margin_minutes: marginMinutes,
+    stage_item_input1_id: input1,
+    stage_item_input2_id: input2,
+  };
+}
+
+function stagesWith(matches: ConflictPreviewMatch[]) {
+  return [{ stage_items: [{ rounds: [{ matches }] }] }];
+}
+
+describe('actionCreatesSelectedConflict', () => {
+  it('detects a selected-match team overlap after a simulated insertion repacks courts', () => {
+    const stages = stagesWith([
+      match({ id: 1, courtId: 1, position: 0, startMinutes: 0, input1: 10, input2: 20 }),
+      match({ id: 2, courtId: 2, position: 0, startMinutes: 0, input1: 40, input2: 50 }),
+      match({ id: 3, courtId: 3, position: 0, startMinutes: 0, input1: 10, input2: 30 }),
+    ]);
+
+    expect(
+      actionCreatesSelectedConflict({
+        stages,
+        selectedMatchId: 1,
+        tournamentStartTime: START,
+        action: {
+          type: 'reschedule',
+          matchId: 1,
+          body: {
+            old_court_id: 1,
+            old_position: 0,
+            new_court_id: 2,
+            new_position: 0,
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('does not count the selected match post-match margin as team overlap', () => {
+    const stages = stagesWith([
+      match({ id: 1, courtId: 1, position: 0, startMinutes: 0, input1: 10, input2: 20 }),
+      match({ id: 2, courtId: 2, position: 0, startMinutes: 0, input1: 40, input2: 50 }),
+      match({
+        id: 3,
+        courtId: 3,
+        position: 0,
+        startMinutes: 0,
+        input1: 40,
+        input2: 50,
+        marginMinutes: 0,
+      }),
+      match({ id: 4, courtId: 3, position: 1, startMinutes: 90, input1: 10, input2: 30 }),
+    ]);
+
+    expect(
+      actionCreatesSelectedConflict({
+        stages,
+        selectedMatchId: 1,
+        tournamentStartTime: START,
+        action: {
+          type: 'reschedule',
+          matchId: 1,
+          body: {
+            old_court_id: 1,
+            old_position: 0,
+            new_court_id: 2,
+            new_position: 0,
+          },
+        },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('computeConflictPreview', () => {
+  it('flags insertion lines that would create a selected-match team overlap', () => {
+    const matches = [
+      match({ id: 1, courtId: 1, position: 0, startMinutes: 0, input1: 10, input2: 20 }),
+      match({ id: 2, courtId: 2, position: 0, startMinutes: 0, input1: 40, input2: 50 }),
+      match({
+        id: 3,
+        courtId: 2,
+        position: 1,
+        startMinutes: PACKED_SLOT_MINUTES,
+        input1: 40,
+        input2: 50,
+      }),
+      match({ id: 4, courtId: 3, position: 0, startMinutes: 0, input1: 10, input2: 30 }),
+    ];
+    const layout = computeScheduleLayout({
+      courts: [
+        { id: 1, name: 'Court 1' },
+        { id: 2, name: 'Court 2' },
+        { id: 3, name: 'Court 3' },
+      ],
+      matchesByCourtId: { 1: [matches[0]], 2: [matches[1], matches[2]], 3: [matches[3]] },
+      tournamentStartTime: START,
+    });
+
+    const preview = computeConflictPreview({
+      stages: stagesWith(matches),
+      layout,
+      selection: {
+        kind: 'match-selected',
+        match: { matchId: 1, courtId: 1, position: 0 },
+      },
+    });
+
+    expect([...preview.insertionLines]).toContain(insertionLineKey(2, 0));
+    expect([...preview.insertionLines]).not.toContain(insertionLineKey(2, 2));
+  });
+
+  it('flags tray-initiated insertion lines using the unscheduled match teams', () => {
+    const matches = [
+      match({ id: 1, courtId: null, position: null, startMinutes: null, input1: 10, input2: 20 }),
+      match({ id: 2, courtId: 1, position: 0, startMinutes: 0, input1: 40, input2: 50 }),
+      match({ id: 3, courtId: 2, position: 0, startMinutes: 0, input1: 10, input2: 30 }),
+    ];
+    const layout = computeScheduleLayout({
+      courts: [
+        { id: 1, name: 'Court 1' },
+        { id: 2, name: 'Court 2' },
+      ],
+      matchesByCourtId: { 1: [matches[1]], 2: [matches[2]] },
+      tournamentStartTime: START,
+    });
+
+    const preview = computeConflictPreview({
+      stages: stagesWith(matches),
+      layout,
+      selection: { kind: 'tray-match-selected', matchId: 1 },
+    });
+
+    expect([...preview.insertionLines]).toContain(insertionLineKey(1, 0));
+    expect([...preview.insertionLines]).not.toContain(insertionLineKey(1, 1));
+  });
+
+  it('flags swap targets that would put the selected match into a conflicting slot', () => {
+    const matches = [
+      match({ id: 1, courtId: null, position: null, startMinutes: null, input1: 10, input2: 20 }),
+      match({ id: 2, courtId: 1, position: 0, startMinutes: 0, input1: 40, input2: 50 }),
+      match({ id: 3, courtId: 2, position: 0, startMinutes: 0, input1: 10, input2: 30 }),
+    ];
+    const layout = computeScheduleLayout({
+      courts: [
+        { id: 1, name: 'Court 1' },
+        { id: 2, name: 'Court 2' },
+      ],
+      matchesByCourtId: { 1: [matches[1]], 2: [matches[2]] },
+      tournamentStartTime: START,
+    });
+
+    const preview = computeConflictPreview({
+      stages: stagesWith(matches),
+      layout,
+      selection: { kind: 'tray-match-selected', matchId: 1 },
+    });
+
+    expect([...preview.swapTargets]).toContain(2);
+    expect([...preview.swapTargets]).not.toContain(3);
+  });
+
+  it('flags scheduled-match swap targets after simulating the traded slots', () => {
+    const matches = [
+      match({ id: 1, courtId: 1, position: 0, startMinutes: 0, input1: 10, input2: 20 }),
+      match({ id: 2, courtId: 2, position: 0, startMinutes: 0, input1: 40, input2: 50 }),
+      match({ id: 3, courtId: 3, position: 0, startMinutes: 0, input1: 10, input2: 30 }),
+      match({
+        id: 4,
+        courtId: 2,
+        position: 1,
+        startMinutes: PACKED_SLOT_MINUTES,
+        input1: 60,
+        input2: 70,
+      }),
+    ];
+    const layout = computeScheduleLayout({
+      courts: [
+        { id: 1, name: 'Court 1' },
+        { id: 2, name: 'Court 2' },
+        { id: 3, name: 'Court 3' },
+      ],
+      matchesByCourtId: { 1: [matches[0]], 2: [matches[1], matches[3]], 3: [matches[2]] },
+      tournamentStartTime: START,
+    });
+
+    const preview = computeConflictPreview({
+      stages: stagesWith(matches),
+      layout,
+      selection: {
+        kind: 'match-selected',
+        match: { matchId: 1, courtId: 1, position: 0 },
+      },
+    });
+
+    expect([...preview.swapTargets]).toContain(2);
+    expect([...preview.swapTargets]).not.toContain(4);
+  });
+});

--- a/frontend/src/logic/planning/conflict_preview.test.ts
+++ b/frontend/src/logic/planning/conflict_preview.test.ts
@@ -176,6 +176,88 @@ describe('computeConflictPreview', () => {
     expect([...preview.insertionLines]).not.toContain(insertionLineKey(1, 1));
   });
 
+  it('flags insertion lines that push a later match into a team overlap', () => {
+    const matches = [
+      match({
+        id: 1,
+        courtId: null,
+        position: null,
+        startMinutes: null,
+        input1: 100,
+        input2: 101,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+      match({
+        id: 2,
+        courtId: 1,
+        position: 0,
+        startMinutes: 0,
+        input1: 200,
+        input2: 201,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+      match({
+        id: 3,
+        courtId: 1,
+        position: 1,
+        startMinutes: 30,
+        input1: 10,
+        input2: 11,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+      match({
+        id: 4,
+        courtId: 2,
+        position: 0,
+        startMinutes: 0,
+        input1: 300,
+        input2: 301,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+      match({
+        id: 5,
+        courtId: 2,
+        position: 1,
+        startMinutes: 30,
+        input1: 302,
+        input2: 303,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+      match({
+        id: 6,
+        courtId: 2,
+        position: 2,
+        startMinutes: 60,
+        input1: 10,
+        input2: 12,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+    ];
+    const layout = computeScheduleLayout({
+      courts: [
+        { id: 1, name: 'Court 1' },
+        { id: 2, name: 'Court 2' },
+      ],
+      matchesByCourtId: { 1: [matches[1], matches[2]], 2: [matches[3], matches[4], matches[5]] },
+      tournamentStartTime: START,
+    });
+
+    const preview = computeConflictPreview({
+      stages: stagesWith(matches),
+      layout,
+      selection: { kind: 'tray-match-selected', matchId: 1 },
+    });
+
+    expect([...preview.insertionLines]).toContain(insertionLineKey(1, 0));
+    expect([...preview.insertionLines]).not.toContain(insertionLineKey(1, 2));
+  });
+
   it('flags swap targets that would put the selected match into a conflicting slot', () => {
     const matches = [
       match({ id: 1, courtId: null, position: null, startMinutes: null, input1: 10, input2: 20 }),
@@ -236,5 +318,85 @@ describe('computeConflictPreview', () => {
 
     expect([...preview.swapTargets]).toContain(2);
     expect([...preview.swapTargets]).not.toContain(4);
+  });
+
+  it('flags swap targets when the other swapped match conflicts in the selected slot', () => {
+    const matches = [
+      match({
+        id: 1,
+        courtId: 1,
+        position: 0,
+        startMinutes: 0,
+        input1: 100,
+        input2: 101,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+      match({
+        id: 2,
+        courtId: 2,
+        position: 0,
+        startMinutes: 0,
+        input1: 200,
+        input2: 201,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+      match({
+        id: 3,
+        courtId: 2,
+        position: 1,
+        startMinutes: 30,
+        input1: 202,
+        input2: 203,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+      match({
+        id: 4,
+        courtId: 2,
+        position: 2,
+        startMinutes: 60,
+        input1: 10,
+        input2: 11,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+      match({
+        id: 5,
+        courtId: 3,
+        position: 0,
+        startMinutes: 0,
+        input1: 10,
+        input2: 12,
+        durationMinutes: 20,
+        marginMinutes: 10,
+      }),
+    ];
+    const layout = computeScheduleLayout({
+      courts: [
+        { id: 1, name: 'Court 1' },
+        { id: 2, name: 'Court 2' },
+        { id: 3, name: 'Court 3' },
+      ],
+      matchesByCourtId: {
+        1: [matches[0]],
+        2: [matches[1], matches[2], matches[3]],
+        3: [matches[4]],
+      },
+      tournamentStartTime: START,
+    });
+
+    const preview = computeConflictPreview({
+      stages: stagesWith(matches),
+      layout,
+      selection: {
+        kind: 'match-selected',
+        match: { matchId: 1, courtId: 1, position: 0 },
+      },
+    });
+
+    expect([...preview.swapTargets]).toContain(4);
+    expect([...preview.swapTargets]).not.toContain(2);
   });
 });

--- a/frontend/src/logic/planning/conflict_preview.ts
+++ b/frontend/src/logic/planning/conflict_preview.ts
@@ -74,7 +74,7 @@ function playingIntervalMillis(match: ConflictPreviewMatch): [number, number] | 
   if (match.start_time == null) return null;
 
   const start = new Date(match.start_time).getTime();
-  return [start, start + match.duration_minutes * 60_000];
+  return [start, start + slotLengthMinutes(match) * 60_000];
 }
 
 function playingTimesOverlap(match1: ConflictPreviewMatch, match2: ConflictPreviewMatch): boolean {
@@ -188,9 +188,9 @@ function blockConflictsWithSelected(
     sharesInput(prepared.selected, block.match) &&
     playingMinutesOverlap(
       selectedStartMinutes,
-      prepared.selected.duration_minutes,
+      slotLengthMinutes(prepared.selected),
       block.startMinutes,
-      block.match.duration_minutes
+      slotLengthMinutes(block.match)
     )
   );
 }

--- a/frontend/src/logic/planning/conflict_preview.ts
+++ b/frontend/src/logic/planning/conflict_preview.ts
@@ -1,0 +1,350 @@
+import { InsertionLine, LayoutCourt, ScheduleGridLayout, computeInsertionLines } from './layout';
+import { OptimisticMatch, OptimisticStage, applyPlanningActions } from './optimistic';
+import { PlanningAction, SelectionState, selectionReducer } from './selection';
+
+export interface ConflictPreviewMatch extends OptimisticMatch {
+  stage_item_input1_id: number | null;
+  stage_item_input2_id: number | null;
+}
+
+export interface ConflictPreviewStage extends OptimisticStage {
+  stage_items: { rounds: { matches: ConflictPreviewMatch[] }[] }[];
+}
+
+export interface ConflictPreview {
+  insertionLines: Set<string>;
+  swapTargets: Set<number>;
+}
+
+interface PreviewBlock {
+  courtId: number;
+  match: ConflictPreviewMatch;
+  startMinutes: number;
+}
+
+interface PreparedPreview {
+  selected: ConflictPreviewMatch;
+  blocksByCourtId: Map<number, PreviewBlock[]>;
+  blockByMatchId: Map<number, PreviewBlock>;
+  sharedBlocks: PreviewBlock[];
+}
+
+export function insertionLineKey(courtId: number, index: number): string {
+  return `${courtId}:${index}`;
+}
+
+function emptyPreview(): ConflictPreview {
+  return { insertionLines: new Set(), swapTargets: new Set() };
+}
+
+function getSelectedMatchId(selection: SelectionState): number | null {
+  switch (selection.kind) {
+    case 'match-selected':
+      return selection.match.matchId;
+    case 'tray-match-selected':
+      return selection.matchId;
+    default:
+      return null;
+  }
+}
+
+function getMatches(stages: ConflictPreviewStage[]): ConflictPreviewMatch[] {
+  return stages.flatMap((stage) =>
+    stage.stage_items.flatMap((stageItem) => stageItem.rounds.flatMap((round) => round.matches))
+  );
+}
+
+function matchInputIds(match: ConflictPreviewMatch): Set<number> {
+  return new Set(
+    [match.stage_item_input1_id, match.stage_item_input2_id].filter(
+      (id): id is number => id != null
+    )
+  );
+}
+
+function sharesInput(match1: ConflictPreviewMatch, match2: ConflictPreviewMatch): boolean {
+  const inputIds = matchInputIds(match1);
+  return (
+    (match2.stage_item_input1_id != null && inputIds.has(match2.stage_item_input1_id)) ||
+    (match2.stage_item_input2_id != null && inputIds.has(match2.stage_item_input2_id))
+  );
+}
+
+function playingIntervalMillis(match: ConflictPreviewMatch): [number, number] | null {
+  if (match.start_time == null) return null;
+
+  const start = new Date(match.start_time).getTime();
+  return [start, start + match.duration_minutes * 60_000];
+}
+
+function playingTimesOverlap(match1: ConflictPreviewMatch, match2: ConflictPreviewMatch): boolean {
+  const interval1 = playingIntervalMillis(match1);
+  const interval2 = playingIntervalMillis(match2);
+  if (interval1 == null || interval2 == null) return false;
+
+  // Half-open intervals [start, end): adjacent playing windows do not conflict.
+  return interval1[0] < interval2[1] && interval2[0] < interval1[1];
+}
+
+function slotLengthMinutes(match: ConflictPreviewMatch): number {
+  return match.duration_minutes + match.margin_minutes;
+}
+
+function playingMinutesOverlap(
+  startMinutes1: number,
+  durationMinutes1: number,
+  startMinutes2: number,
+  durationMinutes2: number
+): boolean {
+  return (
+    startMinutes1 < startMinutes2 + durationMinutes2 &&
+    startMinutes2 < startMinutes1 + durationMinutes1
+  );
+}
+
+export function actionCreatesSelectedConflict({
+  stages,
+  selectedMatchId,
+  tournamentStartTime,
+  action,
+}: {
+  stages: ConflictPreviewStage[];
+  selectedMatchId: number;
+  tournamentStartTime: string | Date;
+  action: PlanningAction;
+}): boolean {
+  const simulated = applyPlanningActions(stages, [action], tournamentStartTime);
+  const matches = getMatches(simulated);
+  const selected = matches.find((match) => match.id === selectedMatchId);
+  if (selected == null || matchInputIds(selected).size === 0) return false;
+
+  return matches.some(
+    (match) =>
+      match.id !== selected.id &&
+      sharesInput(selected, match) &&
+      playingTimesOverlap(selected, match)
+  );
+}
+
+function preparePreview(
+  stages: ConflictPreviewStage[],
+  layout: ScheduleGridLayout<LayoutCourt, ConflictPreviewMatch>,
+  selection: SelectionState
+): PreparedPreview | null {
+  const selectedMatchId = getSelectedMatchId(selection);
+  if (selectedMatchId == null) return null;
+
+  const selected = getMatches(stages).find((match) => match.id === selectedMatchId);
+  if (selected == null) return null;
+
+  const selectedInputIds = matchInputIds(selected);
+  if (selectedInputIds.size === 0) return null;
+
+  const blocksByCourtId = new Map<number, PreviewBlock[]>();
+  const blockByMatchId = new Map<number, PreviewBlock>();
+  const sharedBlocks: PreviewBlock[] = [];
+
+  for (const { court, blocks } of layout.courts) {
+    const previewBlocks = blocks.map((block) => ({
+      courtId: court.id,
+      match: block.match,
+      startMinutes: block.startMinutes,
+    }));
+    blocksByCourtId.set(court.id, previewBlocks);
+    for (const block of previewBlocks) {
+      blockByMatchId.set(block.match.id, block);
+      if (block.match.id !== selected.id && sharesInput(selected, block.match)) {
+        sharedBlocks.push(block);
+      }
+    }
+  }
+
+  return { selected, blocksByCourtId, blockByMatchId, sharedBlocks };
+}
+
+function repackCourt(courtId: number, matches: ConflictPreviewMatch[]): PreviewBlock[] {
+  let startMinutes = 0;
+  return matches.map((match) => {
+    const block = { courtId, match, startMinutes };
+    startMinutes += slotLengthMinutes(match);
+    return block;
+  });
+}
+
+function startAtPosition(blocks: PreviewBlock[], position: number): number {
+  let startMinutes = 0;
+  for (const block of blocks.slice(0, position)) {
+    startMinutes += slotLengthMinutes(block.match);
+  }
+  return startMinutes;
+}
+
+function blockConflictsWithSelected(
+  prepared: PreparedPreview,
+  selectedStartMinutes: number,
+  block: PreviewBlock
+): boolean {
+  return (
+    sharesInput(prepared.selected, block.match) &&
+    playingMinutesOverlap(
+      selectedStartMinutes,
+      prepared.selected.duration_minutes,
+      block.startMinutes,
+      block.match.duration_minutes
+    )
+  );
+}
+
+function selectedIntervalConflicts({
+  prepared,
+  selectedCourtId,
+  selectedStartMinutes,
+  affectedCourts,
+}: {
+  prepared: PreparedPreview;
+  selectedCourtId: number;
+  selectedStartMinutes: number;
+  affectedCourts: Map<number, PreviewBlock[]>;
+}): boolean {
+  for (const [courtId, blocks] of affectedCourts) {
+    if (courtId === selectedCourtId) continue;
+    if (blocks.some((block) => blockConflictsWithSelected(prepared, selectedStartMinutes, block))) {
+      return true;
+    }
+  }
+
+  return prepared.sharedBlocks.some(
+    (block) =>
+      block.courtId !== selectedCourtId &&
+      !affectedCourts.has(block.courtId) &&
+      blockConflictsWithSelected(prepared, selectedStartMinutes, block)
+  );
+}
+
+function rescheduleCreatesSelectedConflict(
+  prepared: PreparedPreview,
+  action: Extract<PlanningAction, { type: 'reschedule' }>
+): boolean {
+  if (action.matchId !== prepared.selected.id) return false;
+
+  const { old_court_id, new_court_id, new_position } = action.body;
+  const targetBlocks = (prepared.blocksByCourtId.get(new_court_id) ?? []).filter(
+    (block) => block.match.id !== prepared.selected.id
+  );
+  const selectedStartMinutes = startAtPosition(targetBlocks, new_position);
+  const affectedCourts = new Map<number, PreviewBlock[]>();
+
+  if (old_court_id != null && old_court_id !== new_court_id) {
+    const oldCourtMatches = (prepared.blocksByCourtId.get(old_court_id) ?? [])
+      .filter((block) => block.match.id !== prepared.selected.id)
+      .map((block) => block.match);
+    affectedCourts.set(old_court_id, repackCourt(old_court_id, oldCourtMatches));
+  }
+
+  return selectedIntervalConflicts({
+    prepared,
+    selectedCourtId: new_court_id,
+    selectedStartMinutes,
+    affectedCourts,
+  });
+}
+
+function swapCreatesSelectedConflict(
+  prepared: PreparedPreview,
+  action: Extract<PlanningAction, { type: 'swap' }>
+): boolean {
+  const selectedMatchId = prepared.selected.id;
+  const targetMatchId =
+    action.matchId1 === selectedMatchId
+      ? action.matchId2
+      : action.matchId2 === selectedMatchId
+        ? action.matchId1
+        : null;
+  if (targetMatchId == null) return false;
+
+  const targetBlock = prepared.blockByMatchId.get(targetMatchId);
+  // Swapping a scheduled selected match with a tray match sends the selected
+  // match to the tray, so there is no selected match interval to preview.
+  if (targetBlock == null) return false;
+
+  const selectedBlock = prepared.blockByMatchId.get(selectedMatchId);
+  const affectedCourts = new Map<number, PreviewBlock[]>();
+  if (selectedBlock != null && selectedBlock.courtId !== targetBlock.courtId) {
+    const oldCourtMatches = (prepared.blocksByCourtId.get(selectedBlock.courtId) ?? []).map(
+      (block) => (block.match.id === selectedMatchId ? targetBlock.match : block.match)
+    );
+    affectedCourts.set(selectedBlock.courtId, repackCourt(selectedBlock.courtId, oldCourtMatches));
+  }
+
+  return selectedIntervalConflicts({
+    prepared,
+    selectedCourtId: targetBlock.courtId,
+    selectedStartMinutes: targetBlock.startMinutes,
+    affectedCourts,
+  });
+}
+
+function planningActionCreatesSelectedConflict(
+  prepared: PreparedPreview,
+  action: PlanningAction
+): boolean {
+  switch (action.type) {
+    case 'reschedule':
+      return rescheduleCreatesSelectedConflict(prepared, action);
+    case 'swap':
+      return swapCreatesSelectedConflict(prepared, action);
+    default:
+      return false;
+  }
+}
+
+export function computeConflictPreview({
+  stages,
+  layout,
+  selection,
+}: {
+  stages: ConflictPreviewStage[];
+  layout: ScheduleGridLayout<LayoutCourt, ConflictPreviewMatch>;
+  selection: SelectionState;
+}): ConflictPreview {
+  if (selection.kind === 'idle') return emptyPreview();
+  const prepared = preparePreview(stages, layout, selection);
+  if (prepared == null) return emptyPreview();
+  const preparedPreview = prepared;
+
+  const preview = emptyPreview();
+
+  function hasConflict(actions: PlanningAction[]): boolean {
+    return actions.some((action) => planningActionCreatesSelectedConflict(preparedPreview, action));
+  }
+
+  for (const { court, blocks } of layout.courts) {
+    const lines: InsertionLine[] = computeInsertionLines(blocks);
+    for (const line of lines) {
+      const transition = selectionReducer(selection, {
+        type: 'tap-insertion-line',
+        courtId: court.id,
+        index: line.index,
+      });
+      if (hasConflict(transition.actions)) {
+        preview.insertionLines.add(insertionLineKey(court.id, line.index));
+      }
+    }
+
+    blocks.forEach((block, blockIndex) => {
+      const transition = selectionReducer(selection, {
+        type: 'tap-match',
+        match: {
+          matchId: block.match.id,
+          courtId: court.id,
+          position: block.match.position_in_schedule ?? blockIndex,
+        },
+      });
+      if (hasConflict(transition.actions)) {
+        preview.swapTargets.add(block.match.id);
+      }
+    });
+  }
+
+  return preview;
+}

--- a/frontend/src/logic/planning/conflict_preview.ts
+++ b/frontend/src/logic/planning/conflict_preview.ts
@@ -23,10 +23,9 @@ interface PreviewBlock {
 }
 
 interface PreparedPreview {
-  selected: ConflictPreviewMatch;
+  matchesById: Map<number, ConflictPreviewMatch>;
   blocksByCourtId: Map<number, PreviewBlock[]>;
   blockByMatchId: Map<number, PreviewBlock>;
-  sharedBlocks: PreviewBlock[];
 }
 
 export function insertionLineKey(courtId: number, index: number): string {
@@ -134,15 +133,11 @@ function preparePreview(
   const selectedMatchId = getSelectedMatchId(selection);
   if (selectedMatchId == null) return null;
 
-  const selected = getMatches(stages).find((match) => match.id === selectedMatchId);
-  if (selected == null) return null;
-
-  const selectedInputIds = matchInputIds(selected);
-  if (selectedInputIds.size === 0) return null;
+  const matchesById = new Map(getMatches(stages).map((match) => [match.id, match]));
+  if (!matchesById.has(selectedMatchId)) return null;
 
   const blocksByCourtId = new Map<number, PreviewBlock[]>();
   const blockByMatchId = new Map<number, PreviewBlock>();
-  const sharedBlocks: PreviewBlock[] = [];
 
   for (const { court, blocks } of layout.courts) {
     const previewBlocks = blocks.map((block) => ({
@@ -153,13 +148,10 @@ function preparePreview(
     blocksByCourtId.set(court.id, previewBlocks);
     for (const block of previewBlocks) {
       blockByMatchId.set(block.match.id, block);
-      if (block.match.id !== selected.id && sharesInput(selected, block.match)) {
-        sharedBlocks.push(block);
-      }
     }
   }
 
-  return { selected, blocksByCourtId, blockByMatchId, sharedBlocks };
+  return { matchesById, blocksByCourtId, blockByMatchId };
 }
 
 function repackCourt(courtId: number, matches: ConflictPreviewMatch[]): PreviewBlock[] {
@@ -171,131 +163,157 @@ function repackCourt(courtId: number, matches: ConflictPreviewMatch[]): PreviewB
   });
 }
 
-function startAtPosition(blocks: PreviewBlock[], position: number): number {
-  let startMinutes = 0;
-  for (const block of blocks.slice(0, position)) {
-    startMinutes += slotLengthMinutes(block.match);
-  }
-  return startMinutes;
-}
-
-function blockConflictsWithSelected(
-  prepared: PreparedPreview,
-  selectedStartMinutes: number,
-  block: PreviewBlock
-): boolean {
+function blocksConflict(block1: PreviewBlock, block2: PreviewBlock): boolean {
   return (
-    sharesInput(prepared.selected, block.match) &&
+    sharesInput(block1.match, block2.match) &&
     playingMinutesOverlap(
-      selectedStartMinutes,
-      slotLengthMinutes(prepared.selected),
-      block.startMinutes,
-      slotLengthMinutes(block.match)
+      block1.startMinutes,
+      slotLengthMinutes(block1.match),
+      block2.startMinutes,
+      slotLengthMinutes(block2.match)
     )
   );
 }
 
-function selectedIntervalConflicts({
-  prepared,
-  selectedCourtId,
-  selectedStartMinutes,
-  affectedCourts,
-}: {
-  prepared: PreparedPreview;
-  selectedCourtId: number;
-  selectedStartMinutes: number;
-  affectedCourts: Map<number, PreviewBlock[]>;
-}): boolean {
-  for (const [courtId, blocks] of affectedCourts) {
-    if (courtId === selectedCourtId) continue;
-    if (blocks.some((block) => blockConflictsWithSelected(prepared, selectedStartMinutes, block))) {
-      return true;
-    }
-  }
-
-  return prepared.sharedBlocks.some(
-    (block) =>
-      block.courtId !== selectedCourtId &&
-      !affectedCourts.has(block.courtId) &&
-      blockConflictsWithSelected(prepared, selectedStartMinutes, block)
+function postScheduleBlocks(
+  prepared: PreparedPreview,
+  affectedCourts: Map<number, PreviewBlock[]>
+): PreviewBlock[] {
+  const courtIds = new Set([...prepared.blocksByCourtId.keys(), ...affectedCourts.keys()]);
+  return [...courtIds].flatMap(
+    (courtId) => affectedCourts.get(courtId) ?? prepared.blocksByCourtId.get(courtId) ?? []
   );
 }
 
-function rescheduleCreatesSelectedConflict(
+function changedPostBlocks(prepared: PreparedPreview, postBlocks: PreviewBlock[]): PreviewBlock[] {
+  return postBlocks.filter((block) => {
+    const previous = prepared.blockByMatchId.get(block.match.id);
+    return (
+      previous == null ||
+      previous.courtId !== block.courtId ||
+      previous.startMinutes !== block.startMinutes
+    );
+  });
+}
+
+function affectedScheduleCreatesConflict(
+  prepared: PreparedPreview,
+  affectedCourts: Map<number, PreviewBlock[]>
+): boolean {
+  const postBlocks = postScheduleBlocks(prepared, affectedCourts);
+  const changedBlocks = changedPostBlocks(prepared, postBlocks);
+
+  for (const changedBlock of changedBlocks) {
+    for (const block of postBlocks) {
+      if (changedBlock.match.id !== block.match.id && blocksConflict(changedBlock, block)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function insertMatchAt(
+  blocks: PreviewBlock[],
+  match: ConflictPreviewMatch,
+  position: number
+): ConflictPreviewMatch[] {
+  const matches = blocks.map((block) => block.match);
+  const index = Math.min(Math.max(position, 0), matches.length);
+  return [...matches.slice(0, index), match, ...matches.slice(index)];
+}
+
+function rescheduleAffectedCourts(
   prepared: PreparedPreview,
   action: Extract<PlanningAction, { type: 'reschedule' }>
-): boolean {
-  if (action.matchId !== prepared.selected.id) return false;
+): Map<number, PreviewBlock[]> | null {
+  const match = prepared.matchesById.get(action.matchId);
+  if (match == null) return null;
 
   const { old_court_id, new_court_id, new_position } = action.body;
   const targetBlocks = (prepared.blocksByCourtId.get(new_court_id) ?? []).filter(
-    (block) => block.match.id !== prepared.selected.id
+    (block) => block.match.id !== match.id
   );
-  const selectedStartMinutes = startAtPosition(targetBlocks, new_position);
   const affectedCourts = new Map<number, PreviewBlock[]>();
+  affectedCourts.set(
+    new_court_id,
+    repackCourt(new_court_id, insertMatchAt(targetBlocks, match, new_position))
+  );
 
   if (old_court_id != null && old_court_id !== new_court_id) {
     const oldCourtMatches = (prepared.blocksByCourtId.get(old_court_id) ?? [])
-      .filter((block) => block.match.id !== prepared.selected.id)
+      .filter((block) => block.match.id !== match.id)
       .map((block) => block.match);
     affectedCourts.set(old_court_id, repackCourt(old_court_id, oldCourtMatches));
   }
 
-  return selectedIntervalConflicts({
-    prepared,
-    selectedCourtId: new_court_id,
-    selectedStartMinutes,
-    affectedCourts,
-  });
+  return affectedCourts;
 }
 
-function swapCreatesSelectedConflict(
+function swapAffectedCourts(
   prepared: PreparedPreview,
   action: Extract<PlanningAction, { type: 'swap' }>
-): boolean {
-  const selectedMatchId = prepared.selected.id;
-  const targetMatchId =
-    action.matchId1 === selectedMatchId
-      ? action.matchId2
-      : action.matchId2 === selectedMatchId
-        ? action.matchId1
-        : null;
-  if (targetMatchId == null) return false;
+): Map<number, PreviewBlock[]> | null {
+  const match1 = prepared.matchesById.get(action.matchId1);
+  const match2 = prepared.matchesById.get(action.matchId2);
+  if (match1 == null || match2 == null) return null;
 
-  const targetBlock = prepared.blockByMatchId.get(targetMatchId);
-  // Swapping a scheduled selected match with a tray match sends the selected
-  // match to the tray, so there is no selected match interval to preview.
-  if (targetBlock == null) return false;
+  const block1 = prepared.blockByMatchId.get(match1.id);
+  const block2 = prepared.blockByMatchId.get(match2.id);
+  if (block1 == null && block2 == null) return null;
 
-  const selectedBlock = prepared.blockByMatchId.get(selectedMatchId);
   const affectedCourts = new Map<number, PreviewBlock[]>();
-  if (selectedBlock != null && selectedBlock.courtId !== targetBlock.courtId) {
-    const oldCourtMatches = (prepared.blocksByCourtId.get(selectedBlock.courtId) ?? []).map(
-      (block) => (block.match.id === selectedMatchId ? targetBlock.match : block.match)
+
+  if (block1 != null && block2 != null) {
+    if (block1.courtId === block2.courtId) {
+      const swappedMatches = (prepared.blocksByCourtId.get(block1.courtId) ?? []).map((block) => {
+        if (block.match.id === match1.id) return match2;
+        if (block.match.id === match2.id) return match1;
+        return block.match;
+      });
+      affectedCourts.set(block1.courtId, repackCourt(block1.courtId, swappedMatches));
+      return affectedCourts;
+    }
+
+    const court1Matches = (prepared.blocksByCourtId.get(block1.courtId) ?? []).map((block) =>
+      block.match.id === match1.id ? match2 : block.match
     );
-    affectedCourts.set(selectedBlock.courtId, repackCourt(selectedBlock.courtId, oldCourtMatches));
+    const court2Matches = (prepared.blocksByCourtId.get(block2.courtId) ?? []).map((block) =>
+      block.match.id === match2.id ? match1 : block.match
+    );
+    affectedCourts.set(block1.courtId, repackCourt(block1.courtId, court1Matches));
+    affectedCourts.set(block2.courtId, repackCourt(block2.courtId, court2Matches));
+    return affectedCourts;
   }
 
-  return selectedIntervalConflicts({
-    prepared,
-    selectedCourtId: targetBlock.courtId,
-    selectedStartMinutes: targetBlock.startMinutes,
-    affectedCourts,
-  });
+  const scheduledBlock = block1 ?? block2!;
+  const incomingMatch = block1 == null ? match1 : match2;
+  const scheduledCourtMatches = (prepared.blocksByCourtId.get(scheduledBlock.courtId) ?? []).map(
+    (block) => (block.match.id === scheduledBlock.match.id ? incomingMatch : block.match)
+  );
+  affectedCourts.set(
+    scheduledBlock.courtId,
+    repackCourt(scheduledBlock.courtId, scheduledCourtMatches)
+  );
+  return affectedCourts;
 }
 
-function planningActionCreatesSelectedConflict(
-  prepared: PreparedPreview,
-  action: PlanningAction
-): boolean {
+function planningActionCreatesConflict(prepared: PreparedPreview, action: PlanningAction): boolean {
+  let affectedCourts: Map<number, PreviewBlock[]> | null = null;
+
   switch (action.type) {
     case 'reschedule':
-      return rescheduleCreatesSelectedConflict(prepared, action);
+      affectedCourts = rescheduleAffectedCourts(prepared, action);
+      break;
     case 'swap':
-      return swapCreatesSelectedConflict(prepared, action);
+      affectedCourts = swapAffectedCourts(prepared, action);
+      break;
     default:
       return false;
   }
+
+  return affectedCourts != null && affectedScheduleCreatesConflict(prepared, affectedCourts);
 }
 
 export function computeConflictPreview({
@@ -315,7 +333,7 @@ export function computeConflictPreview({
   const preview = emptyPreview();
 
   function hasConflict(actions: PlanningAction[]): boolean {
-    return actions.some((action) => planningActionCreatesSelectedConflict(preparedPreview, action));
+    return actions.some((action) => planningActionCreatesConflict(preparedPreview, action));
   }
 
   for (const { court, blocks } of layout.courts) {

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -7,6 +7,7 @@ import CourtModal from '@components/modals/create_court_modal';
 import { NoContent } from '@components/no_content/empty_table_info';
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
 import { getTournamentIdFromRouter, responseIsValid } from '@components/utils/util';
+import { computeConflictPreview } from '@logic/planning/conflict_preview';
 import { computeScheduleLayout } from '@logic/planning/layout';
 import { applyPlanningActions } from '@logic/planning/optimistic';
 import {
@@ -165,6 +166,13 @@ export default function SchedulePage() {
         : null;
   const selectedEntry = selectedMatchId != null ? matchesLookup[selectedMatchId] : null;
   const isOverview = planner.zoom === 'overview';
+  const conflictPreview = isOverview
+    ? { insertionLines: new Set<string>(), swapTargets: new Set<number>() }
+    : computeConflictPreview({
+        stages: rawStages,
+        layout,
+        selection: planner.selection,
+      });
 
   return (
     <TournamentLayout tournament_id={tournamentData.id}>
@@ -230,6 +238,7 @@ export default function SchedulePage() {
             <ScheduleGrid
               layout={layout}
               violations={violations}
+              conflictPreview={conflictPreview}
               stageItemsLookup={stageItemsLookup}
               matchesLookup={matchesLookup}
               levels={levels}


### PR DESCRIPTION
## Summary
- add a pure client-side conflict preview module for insertion lines and swap targets
- render soft warning states for risky placement targets without blocking placement
- include English and German tooltip labels
- match backend conflict intervals by including duration + margin

Closes #46

## Tests
- `cd frontend && pnpm exec vitest run src/logic/planning/conflict_preview.test.ts`
- `cd frontend && pnpm exec vitest run`
- `cd frontend && pnpm run typecheck`
- `cd frontend && pnpm exec prettier --check src/logic/planning/conflict_preview.ts src/logic/planning/conflict_preview.test.ts`