### PR TITLE
Lock completed/in-progress matches from rescheduling

### DIFF
--- a/frontend/src/components/scheduling/schedule_grid.module.css
+++ b/frontend/src/components/scheduling/schedule_grid.module.css
@@ -20,3 +20,28 @@
     animation: zoom-snap 120ms ease-out;
   }
 }
+
+/* Live indicator on in-progress match cards. */
+@keyframes live-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.liveDot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--mantine-color-green-filled);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .liveDot {
+    animation: live-pulse 1.5s ease-in-out infinite;
+  }
+}

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -125,6 +125,16 @@ function MatchCard({
       {format(block.startTime, 'HH:mm')}
     </Text>
   );
+  // Status marker: a check for completed matches (paired with the dimmed card),
+  // a pulsing dot for in-progress ones. Upcoming matches carry no marker.
+  const statusIndicator =
+    match.state === 'COMPLETED' ? (
+      <Text component="span" c="teal" fz={fontSize ?? 12} fw={700} lh={1} style={{ flexShrink: 0 }}>
+        ✓
+      </Text>
+    ) : match.state === 'IN_PROGRESS' ? (
+      <Box component="span" className={classes.liveDot} />
+    ) : null;
   // Agenda is the full-detail level: cards also carry the match's level, stage
   // and stage item. The tallest cards spread that over two rows of their own
   // (level · stage, then stage item), shorter ones get a single combined row,
@@ -179,7 +189,10 @@ function MatchCard({
         left: 3,
         right: 3,
         overflow: 'hidden',
-        cursor: 'pointer',
+        // Soft-locked cards are not placement targets; tapping them is ignored
+        // by the reducer, so don't advertise them as tappable.
+        cursor: block.locked ? 'default' : 'pointer',
+        opacity: match.state === 'COMPLETED' ? 0.55 : undefined,
         borderRadius: 6,
         border: isSelected
           ? '1px solid var(--mantine-color-indigo-filled)'
@@ -203,7 +216,10 @@ function MatchCard({
       >
         {rows === 3 && (
           <Flex gap={4} justify="space-between" align="center" wrap="nowrap">
-            {timeLabel}
+            <Flex gap={4} align="center" wrap="nowrap">
+              {timeLabel}
+              {statusIndicator}
+            </Flex>
             {contextRows.length === 0 && contextParts.length > 0
               ? contextBadge(contextParts.join(' · '))
               : null}
@@ -217,6 +233,7 @@ function MatchCard({
         ))}
         <Flex gap={6} align="center" wrap="nowrap">
           {rows < 3 && showTime && timeLabel}
+          {rows < 3 && statusIndicator}
           {match.stage_item_input1_conflict && <AiFillWarning color="red" />}
           {rows === 1 &&
             match.stage_item_input2_conflict &&
@@ -259,7 +276,8 @@ function OverviewBlock({
 }) {
   const blockHeightPx = block.durationMinutes * pxPerMinute;
   const isCompleted = block.match.state === 'COMPLETED';
-  const opacity = isCompleted ? 0.35 : block.match.state === 'IN_PROGRESS' ? 1 : 0.85;
+  const isInProgress = block.match.state === 'IN_PROGRESS';
+  const opacity = isCompleted ? 0.35 : isInProgress ? 1 : 0.85;
 
   return (
     <Box
@@ -284,6 +302,13 @@ function OverviewBlock({
         <Text c="white" fz={Math.min(blockHeightPx - 2, 12)} lh={1}>
           ✓
         </Text>
+      )}
+      {isInProgress && blockHeightPx >= 12 && (
+        <Box
+          component="span"
+          className={classes.liveDot}
+          style={{ backgroundColor: 'var(--mantine-color-white)' }}
+        />
       )}
     </Box>
   );
@@ -564,6 +589,7 @@ export default function ScheduleGrid({
                   matchId: block.match.id,
                   courtId: court.id,
                   position: block.match.position_in_schedule ?? blockIndex,
+                  locked: block.locked,
                 };
                 return (
                   <MatchCard

--- a/frontend/src/logic/planning/layout.test.ts
+++ b/frontend/src/logic/planning/layout.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { LayoutCourt, LayoutMatch, computeInsertionLines, computeScheduleLayout } from './layout';
+import {
+  LayoutCourt,
+  LayoutMatch,
+  LayoutMatchState,
+  computeInsertionLines,
+  computeScheduleLayout,
+} from './layout';
 
 const TOURNAMENT_START = '2026-06-10T09:00:00Z';
 
@@ -22,6 +28,16 @@ function match(
     margin_minutes: marginMinutes,
     start_time: startTime,
   };
+}
+
+function playedMatch(
+  id: number,
+  position: number,
+  state: LayoutMatchState = 'COMPLETED',
+  durationMinutes = 15,
+  marginMinutes = 5
+): LayoutMatch {
+  return { ...match(id, position, durationMinutes, marginMinutes), state };
 }
 
 describe('computeScheduleLayout', () => {
@@ -189,5 +205,112 @@ describe('computeInsertionLines', () => {
       { index: 1, offsetMinutes: 20 },
       { index: 2, offsetMinutes: 40 },
     ]);
+  });
+});
+
+describe('locked blocks for played matches', () => {
+  function blocksFor(matches: LayoutMatch[]) {
+    return computeScheduleLayout({
+      courts: [court(1)],
+      matchesByCourtId: { 1: matches },
+      tournamentStartTime: TOURNAMENT_START,
+    }).courts[0].blocks;
+  }
+
+  it('locks nothing on a court with only upcoming matches', () => {
+    const blocks = blocksFor([match(10, 0), match(11, 1)]);
+
+    expect(blocks.map((b) => b.locked)).toEqual([false, false]);
+  });
+
+  it('locks completed and in-progress matches', () => {
+    const blocks = blocksFor([
+      playedMatch(10, 0, 'COMPLETED'),
+      playedMatch(11, 1, 'IN_PROGRESS'),
+      match(12, 2),
+    ]);
+
+    expect(blocks.map((b) => b.locked)).toEqual([true, true, false]);
+  });
+
+  it('treats matches without a state as upcoming', () => {
+    const blocks = blocksFor([match(10, 0), { ...match(11, 1), state: 'NOT_STARTED' }]);
+
+    expect(blocks.map((b) => b.locked)).toEqual([false, false]);
+  });
+
+  it('locks an upcoming match sitting above a played one, freezing the whole past', () => {
+    // Moving the sandwiched upcoming match would shift the recorded start time
+    // of the completed match below it, so it is part of the frozen past.
+    const blocks = blocksFor([match(10, 0), playedMatch(11, 1, 'COMPLETED'), match(12, 2)]);
+
+    expect(blocks.map((b) => b.locked)).toEqual([true, true, false]);
+  });
+});
+
+describe('computeInsertionLines with played matches', () => {
+  function blocksFor(matches: LayoutMatch[]) {
+    return computeScheduleLayout({
+      courts: [court(1)],
+      matchesByCourtId: { 1: matches },
+      tournamentStartTime: TOURNAMENT_START,
+    }).courts[0].blocks;
+  }
+
+  it('offers all positions on a court with no played matches', () => {
+    const lines = computeInsertionLines(blocksFor([match(10, 0), match(11, 1)]));
+
+    expect(lines.map((line) => line.index)).toEqual([0, 1, 2]);
+  });
+
+  it('hides lines above the last completed match', () => {
+    const lines = computeInsertionLines(
+      blocksFor([
+        playedMatch(10, 0, 'COMPLETED'),
+        playedMatch(11, 1, 'COMPLETED'),
+        match(12, 2),
+        match(13, 3),
+      ])
+    );
+
+    expect(lines).toEqual([
+      // Centered in the 35..40 gap after the last completed match.
+      { index: 2, offsetMinutes: 37.5 },
+      { index: 3, offsetMinutes: 57.5 },
+      { index: 4, offsetMinutes: 77.5 },
+    ]);
+  });
+
+  it('treats an in-progress match like a completed one', () => {
+    const lines = computeInsertionLines(
+      blocksFor([playedMatch(10, 0, 'IN_PROGRESS'), match(11, 1)])
+    );
+
+    expect(lines.map((line) => line.index)).toEqual([1, 2]);
+  });
+
+  it('offers only the end-of-court line when every match is played', () => {
+    const lines = computeInsertionLines(
+      blocksFor([playedMatch(10, 0, 'COMPLETED'), playedMatch(11, 1, 'IN_PROGRESS')])
+    );
+
+    expect(lines.map((line) => line.index)).toEqual([2]);
+  });
+
+  it('hides lines around an upcoming match sandwiched between played ones', () => {
+    const lines = computeInsertionLines(
+      blocksFor([
+        playedMatch(10, 0, 'COMPLETED'),
+        match(11, 1),
+        playedMatch(12, 2, 'COMPLETED'),
+        match(13, 3),
+      ])
+    );
+
+    expect(lines.map((line) => line.index)).toEqual([3, 4]);
+  });
+
+  it('still offers the single top line on an empty court', () => {
+    expect(computeInsertionLines([])).toEqual([{ index: 0, offsetMinutes: 0 }]);
   });
 });

--- a/frontend/src/logic/planning/layout.ts
+++ b/frontend/src/logic/planning/layout.ts
@@ -13,12 +13,16 @@ export interface LayoutCourt {
   name: string;
 }
 
+/** Structural mirror of the generated `MatchState`; absent means upcoming. */
+export type LayoutMatchState = 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED';
+
 export interface LayoutMatch {
   id: number;
   duration_minutes: number;
   margin_minutes: number;
   position_in_schedule: number | null;
   start_time: string | null;
+  state?: LayoutMatchState | null;
 }
 
 export interface MatchBlock<M extends LayoutMatch = LayoutMatch> {
@@ -33,6 +37,13 @@ export interface MatchBlock<M extends LayoutMatch = LayoutMatch> {
   endMinutes: number;
   /** Absolute computed start time. */
   startTime: Date;
+  /**
+   * Inside the court's frozen past: at or before the court's last completed or
+   * in-progress match. Moving any such match (even an upcoming one scored out
+   * of order around) would repack the court and shift the recorded start times
+   * of played matches, so locked matches are excluded from tap-to-place.
+   */
+  locked: boolean;
 }
 
 export interface CourtTimeline<
@@ -73,16 +84,27 @@ export interface InsertionLine {
   offsetMinutes: number;
 }
 
+function isPlayed(match: LayoutMatch): boolean {
+  return match.state === 'COMPLETED' || match.state === 'IN_PROGRESS';
+}
+
 /**
  * Tap targets for placing a match on a court: one line half a margin above the
  * first match (mirroring the end-of-court line below the last one), one centered
  * in each margin gap between consecutive matches, and one in the gap after the
  * last match. An empty court gets a single line at the top.
+ *
+ * Only the future portion of the court accepts insertions: lines above the last
+ * locked (completed/in-progress) match are omitted, so a repack can never shift
+ * the recorded start times of already-played matches. Courts with no played
+ * matches offer all positions.
  */
 export function computeInsertionLines(blocks: MatchBlock[]): InsertionLine[] {
   if (blocks.length === 0) {
     return [{ index: 0, offsetMinutes: 0 }];
   }
+
+  const lockedCount = blocks.filter((block) => block.locked).length;
 
   const first = blocks[0];
   const lines: InsertionLine[] = [
@@ -93,7 +115,7 @@ export function computeInsertionLines(blocks: MatchBlock[]): InsertionLine[] {
     const gapStart = previous.startMinutes + previous.durationMinutes;
     lines.push({ index: i, offsetMinutes: (gapStart + previous.endMinutes) / 2 });
   }
-  return lines;
+  return lines.filter((line) => line.index >= lockedCount);
 }
 
 const DEFAULT_TICK_INTERVAL_MINUTES = 30;
@@ -118,6 +140,9 @@ export function computeScheduleLayout<C extends LayoutCourt, M extends LayoutMat
       .filter((m) => m.start_time != null)
       .sort((m1, m2) => (m1.position_in_schedule ?? 0) - (m2.position_in_schedule ?? 0));
 
+    // Everything up to the court's last played match is the frozen past.
+    const lockedCount = scheduled.reduce((count, m, index) => (isPlayed(m) ? index + 1 : count), 0);
+
     const blocks: MatchBlock<M>[] = [];
     let currentMinutes = 0;
     for (const m of scheduled) {
@@ -129,6 +154,7 @@ export function computeScheduleLayout<C extends LayoutCourt, M extends LayoutMat
         marginMinutes: m.margin_minutes,
         endMinutes,
         startTime: addMinutes(startTime, currentMinutes),
+        locked: blocks.length < lockedCount,
       });
       currentMinutes = endMinutes;
     }

--- a/frontend/src/logic/planning/selection.test.ts
+++ b/frontend/src/logic/planning/selection.test.ts
@@ -15,6 +15,10 @@ function ref(matchId: number, courtId: number, position: number): GridMatchRef {
   return { matchId, courtId, position };
 }
 
+function lockedRef(matchId: number, courtId: number, position: number): GridMatchRef {
+  return { matchId, courtId, position, locked: true };
+}
+
 function selected(match: GridMatchRef): SelectionState {
   return { kind: 'match-selected', match };
 }
@@ -289,6 +293,40 @@ describe('selectionReducer', () => {
       expect(actions).toEqual([]);
     });
   });
+
+  describe('soft-locked (completed/in-progress) matches', () => {
+    it('tapping a locked match from idle does not select it', () => {
+      const { state, actions } = selectionReducer(IDLE_SELECTION, {
+        type: 'tap-match',
+        match: lockedRef(10, 1, 0),
+      });
+
+      expect(state).toEqual(IDLE_SELECTION);
+      expect(actions).toEqual([]);
+    });
+
+    it('tapping a locked match with a scheduled match selected does not swap', () => {
+      const selection = selected(ref(10, 1, 2));
+      const { state, actions } = selectionReducer(selection, {
+        type: 'tap-match',
+        match: lockedRef(20, 2, 0),
+      });
+
+      expect(state).toEqual(selection);
+      expect(actions).toEqual([]);
+    });
+
+    it('tapping a locked match with a tray match selected does not swap', () => {
+      const selection = traySelected(30);
+      const { state, actions } = selectionReducer(selection, {
+        type: 'tap-match',
+        match: lockedRef(10, 1, 0),
+      });
+
+      expect(state).toEqual(selection);
+      expect(actions).toEqual([]);
+    });
+  });
 });
 
 describe('plannerReducer', () => {
@@ -379,6 +417,16 @@ describe('plannerReducer', () => {
         ]);
       }
     );
+
+    it('never selects a locked (played) match', () => {
+      const { state, actions } = plannerReducer(planner('compact'), {
+        type: 'tap-match',
+        match: lockedRef(10, 1, 0),
+      });
+
+      expect(state).toEqual(planner('compact'));
+      expect(actions).toEqual([]);
+    });
 
     it('swaps two matches on a card tap', () => {
       const { state, actions } = plannerReducer(planner('compact', selected(ref(10, 1, 2))), {

--- a/frontend/src/logic/planning/selection.ts
+++ b/frontend/src/logic/planning/selection.ts
@@ -22,6 +22,13 @@ export interface GridMatchRef {
   matchId: number;
   courtId: number;
   position: number;
+  /**
+   * Soft-locked: part of a court's frozen past (completed/in-progress, or
+   * scheduled above such a match — see `MatchBlock.locked`). Taps on locked
+   * matches never select or swap; an explicit override arrives with the
+   * action sheet.
+   */
+  locked?: boolean;
 }
 
 export type SelectionState =
@@ -132,6 +139,9 @@ export function selectionReducer(
     case 'idle':
       switch (event.type) {
         case 'tap-match':
+          if (event.match.locked) {
+            return stay(state);
+          }
           return stay({ kind: 'match-selected', match: event.match });
         case 'tap-tray-match':
           return stay({ kind: 'tray-match-selected', matchId: event.matchId });
@@ -144,9 +154,14 @@ export function selectionReducer(
           return stay(IDLE_SELECTION);
         case 'tap-match':
           // Tapping the selected match again deselects; tapping another
-          // match — scheduled or in the tray — swaps the two.
+          // match — scheduled or in the tray — swaps the two. Locked
+          // (played) matches are not swap targets: the selection stays so
+          // the user can pick a valid target instead.
           if (event.match.matchId === state.match.matchId) {
             return stay(IDLE_SELECTION);
+          }
+          if (event.match.locked) {
+            return stay(state);
           }
           return swap(state.match.matchId, event.match.matchId);
         case 'tap-tray-match':
@@ -167,6 +182,9 @@ export function selectionReducer(
           // The match was never scheduled; cancelling simply leaves it in the tray.
           return stay(IDLE_SELECTION);
         case 'tap-match':
+          if (event.match.locked) {
+            return stay(state);
+          }
           return swap(state.matchId, event.match.matchId);
         case 'tap-tray-match':
           // Swapping two tray matches is meaningless, so taps inside the tray


### PR DESCRIPTION
## Summary
Prevents users from moving matches that have already been played (completed or in-progress), protecting the recorded start times of past matches from being shifted by repacking the court schedule.

## Key Changes

- **Layout computation**: Added `locked` property to `MatchBlock` to mark matches in a court's "frozen past" (at or before the last completed/in-progress match). Matches are locked even if they're upcoming but scheduled above a played match, since moving them would repack and shift recorded times.

- **Insertion lines filtering**: Updated `computeInsertionLines()` to exclude tap targets above the frozen past, preventing insertions that would trigger a repack of played matches.

- **Selection logic**: Modified `selectionReducer()` to reject tap-to-select and tap-to-swap actions on locked matches, keeping the selection state unchanged when users tap played matches.

- **UI feedback**: 
  - Added visual indicators: checkmark (✓) for completed matches, pulsing green dot for in-progress matches
  - Dimmed completed matches to 55% opacity
  - Changed cursor to `default` on locked cards to signal they're not tappable
  - Added status indicators to both compact and agenda card layouts

- **Type definitions**: Introduced `LayoutMatchState` type and added optional `state` field to `LayoutMatch` interface to track match progress.

## Implementation Details

The "frozen past" concept ensures that any match at or before the last played match on a court is locked, preventing cascading schedule shifts. This applies even to upcoming matches that happen to be scheduled out of order above a completed match. The UI prevents interaction with these locked matches at the selection layer, while the layout layer prevents them from being insertion targets.

Closes #47

https://claude.ai/code/session_01PknFb9fEhPBrEzQiFdRkyN