### PR TITLE
Polish unscheduled tray grouping and placement flow

### DIFF
--- a/frontend/src/components/scheduling/unscheduled_sheet.tsx
+++ b/frontend/src/components/scheduling/unscheduled_sheet.tsx
@@ -49,6 +49,11 @@ export default function UnscheduledSheet({
 }) {
   const { t } = useTranslation();
   const groups = groupUnscheduledMatchesForTray(unscheduledMatches, matchesLookup, levels);
+  const visibleLevelCount = groups.kind === 'grouped' ? groups.levels.length : 1;
+  const preferredTrayWidthRem =
+    groups.kind === 'grouped'
+      ? Math.max(30, visibleLevelCount * 18 + Math.max(visibleLevelCount - 1, 0) * 0.75 + 2)
+      : 30;
 
   function renderMatchRow(match: MatchWithDetails, badgeLabel?: string) {
     const entry = matchesLookup[match.id];
@@ -98,11 +103,18 @@ export default function UnscheduledSheet({
     }
 
     return (
-      <Stack gap="sm">
+      <Box
+        style={{
+          display: 'grid',
+          gap: 'var(--mantine-spacing-sm)',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 18rem), 1fr))',
+          alignItems: 'start',
+        }}
+      >
         {groupedMatches.levels.map((level) => (
           <Box key={level.id ?? 'none'}>
             <Group justify="space-between" gap="xs" mb={4}>
-              <Text size="xs" fw={700} c="dimmed" tt="uppercase">
+              <Text size="md" fw={700} tt="uppercase">
                 {level.name || t('all_levels_label')}
               </Text>
               <Badge size="sm" color={levelColour(level.id, levels)} variant="light">
@@ -112,7 +124,7 @@ export default function UnscheduledSheet({
             <Stack gap="xs">
               {level.stages.map((stage) => (
                 <Box key={stage.id}>
-                  <Text size="sm" fw={600} mb={2}>
+                  <Text size="sm" fw={600} c="dimmed" mb={2}>
                     {stage.name}
                   </Text>
                   <Box>
@@ -126,7 +138,7 @@ export default function UnscheduledSheet({
             </Stack>
           </Box>
         ))}
-      </Stack>
+      </Box>
     );
   }
 
@@ -140,7 +152,7 @@ export default function UnscheduledSheet({
         bottom: 0,
         left: '50%',
         transform: 'translateX(-50%)',
-        width: 'min(100%, 30rem)',
+        width: `min(100%, ${preferredTrayWidthRem}rem)`,
         zIndex: 150,
         borderTopLeftRadius: 12,
         borderTopRightRadius: 12,

--- a/frontend/src/components/scheduling/unscheduled_sheet.tsx
+++ b/frontend/src/components/scheduling/unscheduled_sheet.tsx
@@ -7,27 +7,34 @@ import {
   Group,
   Paper,
   ScrollArea,
+  Stack,
   Text,
+  ThemeIcon,
   UnstyledButton,
 } from '@mantine/core';
-import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import { IconCheck, IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
-import { MatchWithDetails } from '@openapi';
-import { MatchLookupEntry, getStageItemLookup, stringToColour } from '@services/lookups';
+import {
+  groupUnscheduledMatchesForTray,
+  type TrayMatchGroups,
+} from '@logic/planning/unscheduled_tray';
+import { levelColour } from '@logic/planning/zoom';
+import type { LevelResponse, MatchWithDetails } from '@openapi';
+import { getStageItemLookup, type MatchLookupEntry, stringToColour } from '@services/lookups';
 
 /**
  * Collapsible bottom sheet listing matches that are not on the schedule yet.
  * Tapping a match selects it for tap-to-place placement on the grid; the parent
- * collapses the sheet while placing, so `opened` is controlled. Grouping by
- * level/stage comes in a later slice.
+ * collapses the sheet while placing, so `opened` is controlled.
  */
 export default function UnscheduledSheet({
   unscheduledMatches,
   stageItemsLookup,
   matchesLookup,
+  levels,
   opened,
   onToggle,
   onSelectMatch,
@@ -35,11 +42,93 @@ export default function UnscheduledSheet({
   unscheduledMatches: MatchWithDetails[];
   stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
   matchesLookup: Record<number, MatchLookupEntry>;
+  levels: LevelResponse[];
   opened: boolean;
   onToggle: () => void;
   onSelectMatch: (m: MatchWithDetails) => void;
 }) {
   const { t } = useTranslation();
+  const groups = groupUnscheduledMatchesForTray(unscheduledMatches, matchesLookup, levels);
+
+  function renderMatchRow(match: MatchWithDetails, badgeLabel?: string) {
+    const entry = matchesLookup[match.id];
+    const label =
+      badgeLabel ?? (entry != null ? `${entry.stage.name} · ${entry.stageItem.name}` : null);
+
+    return (
+      <UnstyledButton key={match.id} onClick={() => onSelectMatch(match)} w="100%" py="xs">
+        <Flex justify="space-between" align="center" gap="xs" wrap="nowrap">
+          <Box style={{ minWidth: 0 }}>
+            <Text size="sm" fw={500} truncate>
+              {formatMatchInput1(t, stageItemsLookup, matchesLookup, match)}
+            </Text>
+            <Text size="sm" fw={500} truncate>
+              {formatMatchInput2(t, stageItemsLookup, matchesLookup, match)}
+            </Text>
+          </Box>
+          {entry != null && label != null && (
+            <Badge
+              color={stringToColour(`${entry.stageItem.id}`)}
+              variant="outline"
+              style={{ flexShrink: 0 }}
+            >
+              {label}
+            </Badge>
+          )}
+        </Flex>
+      </UnstyledButton>
+    );
+  }
+
+  function renderMatchList(
+    matches: MatchWithDetails[],
+    badgeLabel?: (match: MatchWithDetails) => string
+  ) {
+    return matches.map((match, index) => (
+      <Fragment key={match.id}>
+        {index > 0 && <Divider />}
+        {renderMatchRow(match, badgeLabel?.(match))}
+      </Fragment>
+    ));
+  }
+
+  function renderGroups(groupedMatches: TrayMatchGroups) {
+    if (groupedMatches.kind === 'flat') {
+      return renderMatchList(groupedMatches.matches);
+    }
+
+    return (
+      <Stack gap="sm">
+        {groupedMatches.levels.map((level) => (
+          <Box key={level.id ?? 'none'}>
+            <Group justify="space-between" gap="xs" mb={4}>
+              <Text size="xs" fw={700} c="dimmed" tt="uppercase">
+                {level.name || t('all_levels_label')}
+              </Text>
+              <Badge size="sm" color={levelColour(level.id, levels)} variant="light">
+                {level.stages.reduce((count, stage) => count + stage.matches.length, 0)}
+              </Badge>
+            </Group>
+            <Stack gap="xs">
+              {level.stages.map((stage) => (
+                <Box key={stage.id}>
+                  <Text size="sm" fw={600} mb={2}>
+                    {stage.name}
+                  </Text>
+                  <Box>
+                    {renderMatchList(
+                      stage.matches,
+                      (match) => matchesLookup[match.id]?.stageItem.name
+                    )}
+                  </Box>
+                </Box>
+              ))}
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    );
+  }
 
   return (
     <Paper
@@ -72,40 +161,23 @@ export default function UnscheduledSheet({
       <Collapse in={opened}>
         <ScrollArea.Autosize mah="45dvh">
           <Box px="sm" pb="sm">
-            {unscheduledMatches.length === 0 && (
-              <Text c="dimmed" size="sm" pb="xs">
-                {t('unscheduled_column_empty_description')}
-              </Text>
+            {unscheduledMatches.length === 0 ? (
+              <Group gap="sm" py="xs" wrap="nowrap">
+                <ThemeIcon color="green" variant="light" radius="xl">
+                  <IconCheck size={18} />
+                </ThemeIcon>
+                <Box>
+                  <Text size="sm" fw={600}>
+                    {t('all_matches_scheduled_title')}
+                  </Text>
+                  <Text c="dimmed" size="sm">
+                    {t('unscheduled_column_empty_description')}
+                  </Text>
+                </Box>
+              </Group>
+            ) : (
+              renderGroups(groups)
             )}
-            {unscheduledMatches.map((match, index) => {
-              const entry = matchesLookup[match.id];
-              return (
-                <Fragment key={match.id}>
-                  {index > 0 && <Divider />}
-                  <UnstyledButton onClick={() => onSelectMatch(match)} w="100%" py="xs">
-                    <Flex justify="space-between" align="center" gap="xs" wrap="nowrap">
-                      <Box style={{ minWidth: 0 }}>
-                        <Text size="sm" fw={500} truncate>
-                          {formatMatchInput1(t, stageItemsLookup, matchesLookup, match)}
-                        </Text>
-                        <Text size="sm" fw={500} truncate>
-                          {formatMatchInput2(t, stageItemsLookup, matchesLookup, match)}
-                        </Text>
-                      </Box>
-                      {entry != null && (
-                        <Badge
-                          color={stringToColour(`${entry.stageItem.id}`)}
-                          variant="outline"
-                          style={{ flexShrink: 0 }}
-                        >
-                          {entry.stage.name} · {entry.stageItem.name}
-                        </Badge>
-                      )}
-                    </Flex>
-                  </UnstyledButton>
-                </Fragment>
-              );
-            })}
           </Box>
         </ScrollArea.Autosize>
       </Collapse>

--- a/frontend/src/logic/planning/unscheduled_tray.test.ts
+++ b/frontend/src/logic/planning/unscheduled_tray.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  LevelResponse,
+  MatchWithDetails,
+  StageItemWithRounds,
+  StageWithStageItems,
+} from '@openapi';
+import type { MatchLookupEntry } from '@services/lookups';
+import {
+  groupUnscheduledMatchesForTray,
+  nextTrayOpenedAfterPlannerEvent,
+} from './unscheduled_tray';
+
+function level(id: number, name: string, position: number): LevelResponse {
+  return { id, name, position };
+}
+
+function match(id: number): MatchWithDetails {
+  return { id } as MatchWithDetails;
+}
+
+function stage(
+  id: number,
+  name: string,
+  levelId: number | null,
+  stageItems: StageItemWithRounds[] = []
+): StageWithStageItems {
+  return { id, name, level_id: levelId, stage_items: stageItems } as StageWithStageItems;
+}
+
+function stageItem(id: number, name: string): StageItemWithRounds {
+  return { id, name } as StageItemWithRounds;
+}
+
+function entry(
+  matchDetails: MatchWithDetails,
+  parentStage: StageWithStageItems,
+  parentStageItem: StageItemWithRounds
+): MatchLookupEntry {
+  return {
+    match: matchDetails,
+    stage: parentStage,
+    stageItem: parentStageItem,
+  };
+}
+
+describe('groupUnscheduledMatchesForTray', () => {
+  it('groups matches by level position and then by stage, skipping empty groups', () => {
+    const beginner = level(10, 'Beginner', 1);
+    const advanced = level(20, 'Advanced', 0);
+    const groupA = stageItem(100, 'Group A');
+    const groupB = stageItem(101, 'Group B');
+    const advancedGroups = stage(200, 'Groups', advanced.id, [groupA]);
+    const beginnerGroups = stage(201, 'Groups', beginner.id, [groupB]);
+    const advancedFinals = stage(202, 'Finals', advanced.id, []);
+    const matches = [match(1), match(2), match(3)];
+    const lookup: Record<number, MatchLookupEntry> = {
+      1: entry(matches[0], beginnerGroups, groupB),
+      2: entry(matches[1], advancedGroups, groupA),
+      3: entry(matches[2], advancedGroups, groupA),
+      99: entry(match(99), advancedFinals, groupA),
+    };
+
+    expect(groupUnscheduledMatchesForTray(matches, lookup, [beginner, advanced])).toEqual({
+      kind: 'grouped',
+      levels: [
+        {
+          id: advanced.id,
+          name: advanced.name,
+          stages: [
+            {
+              id: advancedGroups.id,
+              name: advancedGroups.name,
+              matches: [matches[1], matches[2]],
+            },
+          ],
+        },
+        {
+          id: beginner.id,
+          name: beginner.name,
+          stages: [
+            {
+              id: beginnerGroups.id,
+              name: beginnerGroups.name,
+              matches: [matches[0]],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('keeps no-level tournaments as one flat match list', () => {
+    const matches = [match(1), match(2)];
+
+    expect(groupUnscheduledMatchesForTray(matches, {}, [])).toEqual({
+      kind: 'flat',
+      matches,
+    });
+  });
+});
+
+describe('nextTrayOpenedAfterPlannerEvent', () => {
+  it('collapses while placing a tray match and restores after placement or cancel', () => {
+    expect(
+      nextTrayOpenedAfterPlannerEvent({
+        opened: true,
+        previousSelection: { kind: 'idle' },
+        nextSelection: { kind: 'tray-match-selected', matchId: 30 },
+        event: { type: 'tap-tray-match', matchId: 30 },
+        actions: [],
+      })
+    ).toBe(false);
+
+    expect(
+      nextTrayOpenedAfterPlannerEvent({
+        opened: false,
+        previousSelection: { kind: 'tray-match-selected', matchId: 30 },
+        nextSelection: { kind: 'idle' },
+        event: { type: 'tap-insertion-line', courtId: 1, index: 0 },
+        actions: [
+          {
+            type: 'reschedule',
+            matchId: 30,
+            body: {
+              old_court_id: null,
+              old_position: null,
+              new_court_id: 1,
+              new_position: 0,
+            },
+          },
+        ],
+      })
+    ).toBe(true);
+
+    expect(
+      nextTrayOpenedAfterPlannerEvent({
+        opened: false,
+        previousSelection: { kind: 'tray-match-selected', matchId: 31 },
+        nextSelection: { kind: 'idle' },
+        event: { type: 'cancel' },
+        actions: [],
+      })
+    ).toBe(true);
+  });
+});

--- a/frontend/src/logic/planning/unscheduled_tray.ts
+++ b/frontend/src/logic/planning/unscheduled_tray.ts
@@ -1,0 +1,107 @@
+import type { LevelResponse, MatchWithDetails } from '@openapi';
+import type { MatchLookupEntry } from '@services/lookups';
+import type { PlannerEvent, PlanningAction, SelectionState } from './selection';
+
+export type TrayStageGroup = {
+  id: number;
+  name: string;
+  matches: MatchWithDetails[];
+};
+
+export type TrayLevelGroup = {
+  id: number | null;
+  name: string;
+  stages: TrayStageGroup[];
+};
+
+export type TrayMatchGroups =
+  | { kind: 'flat'; matches: MatchWithDetails[] }
+  | { kind: 'grouped'; levels: TrayLevelGroup[] };
+
+export function groupUnscheduledMatchesForTray(
+  matches: MatchWithDetails[],
+  matchesLookup: Record<number, MatchLookupEntry>,
+  levels: LevelResponse[]
+): TrayMatchGroups {
+  if (levels.length === 0) {
+    return { kind: 'flat', matches };
+  }
+
+  const levelOrder = new Map(levels.map((level) => [level.id, level]));
+  const levelsById = new Map<number | null, TrayLevelGroup>();
+  const stagesByLevelAndId = new Map<string, TrayStageGroup>();
+
+  for (const match of matches) {
+    const entry = matchesLookup[match.id];
+    if (entry == null) continue;
+
+    const levelId = entry.stage.level_id;
+    const level = levelId == null ? null : levelOrder.get(levelId);
+    const levelGroup = getOrInsert(levelsById, levelId, () => ({
+      id: levelId,
+      name: level?.name ?? '',
+      stages: [],
+    }));
+    const stageKey = `${levelId ?? 'none'}:${entry.stage.id}`;
+    const stageGroup = getOrInsert(stagesByLevelAndId, stageKey, () => {
+      const group = {
+        id: entry.stage.id,
+        name: entry.stage.name,
+        matches: [],
+      };
+      levelGroup.stages.push(group);
+      return group;
+    });
+
+    stageGroup.matches.push(match);
+  }
+
+  return {
+    kind: 'grouped',
+    levels: [...levelsById.values()].sort((a, b) => {
+      const levelA = a.id == null ? null : levelOrder.get(a.id);
+      const levelB = b.id == null ? null : levelOrder.get(b.id);
+      return (
+        (levelA?.position ?? Number.MAX_SAFE_INTEGER) -
+        (levelB?.position ?? Number.MAX_SAFE_INTEGER)
+      );
+    }),
+  };
+}
+
+export function nextTrayOpenedAfterPlannerEvent({
+  opened,
+  previousSelection,
+  nextSelection,
+  event,
+  actions,
+}: {
+  opened: boolean;
+  previousSelection: SelectionState;
+  nextSelection: SelectionState;
+  event: PlannerEvent;
+  actions: PlanningAction[];
+}): boolean {
+  if (nextSelection.kind === 'tray-match-selected') {
+    return false;
+  }
+
+  if (previousSelection.kind !== 'tray-match-selected') {
+    return opened;
+  }
+
+  if (event.type === 'cancel' || actions.length > 0) {
+    return true;
+  }
+
+  return opened;
+}
+
+function getOrInsert<K, V>(map: Map<K, V>, key: K, create: () => V): V {
+  const existing = map.get(key);
+  if (existing != null) return existing;
+
+  const value = create();
+  map.set(key, value);
+  return value;
+}

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -18,6 +18,7 @@ import {
   initialPlannerState,
   plannerReducer,
 } from '@logic/planning/selection';
+import { nextTrayOpenedAfterPlannerEvent } from '@logic/planning/unscheduled_tray';
 import { ZOOM_TICK_INTERVAL_MINUTES, defaultZoomLevel, levelColour } from '@logic/planning/zoom';
 import { Court, LevelResponse, MatchWithDetails, StageWithStageItems } from '@openapi';
 import TournamentLayout from '@pages/tournaments/_tournament_layout';
@@ -122,18 +123,18 @@ export default function SchedulePage() {
       setFocus((previous) => ({ ...focusTarget, nonce: (previous?.nonce ?? 0) + 1 }));
     }
 
-    // Picking a match from the tray collapses it so the grid is free for placing.
-    if (state.selection.kind === 'tray-match-selected') {
-      setTrayOpened(false);
-    }
+    const updateTrayOpened = () =>
+      setTrayOpened((opened) =>
+        nextTrayOpenedAfterPlannerEvent({
+          opened,
+          previousSelection: planner.selection,
+          nextSelection: state.selection,
+          event,
+          actions,
+        })
+      );
 
     if (actions.length > 0) {
-      // After placing a tray match, reopen the tray so scheduling many matches
-      // in a row flows without extra taps.
-      if (wasTraySelection && event.type === 'tap-insertion-line') {
-        setTrayOpened(true);
-      }
-
       // Show the predicted outcome immediately; the revalidation that follows the
       // request replaces it with the backend's authoritative schedule.
       await swrStagesResponse.mutate(
@@ -155,6 +156,11 @@ export default function SchedulePage() {
           revalidate: true,
         }
       );
+      if (wasTraySelection) {
+        updateTrayOpened();
+      }
+    } else {
+      updateTrayOpened();
     }
   }
 
@@ -251,8 +257,9 @@ export default function SchedulePage() {
               unscheduledMatches={unscheduledMatches}
               stageItemsLookup={stageItemsLookup}
               matchesLookup={matchesLookup}
+              levels={levels}
               opened={trayOpened}
-              onToggle={() => setTrayOpened(!trayOpened)}
+              onToggle={() => setTrayOpened((opened) => !opened)}
               onSelectMatch={(m) => handlePlannerEvent({ type: 'tap-tray-match', matchId: m.id })}
             />
             <Affix position={{ right: 8, top: '45%' }} zIndex={200}>


### PR DESCRIPTION
## Summary

- Group unscheduled tray matches by level, then stage, while keeping no-level tournaments as a flat list.
- Add a headless tray helper for grouping and tray open/close transitions with Vitest coverage.
- Reopen the tray after tray-originated placement or cancel, and show a success state when all matches are scheduled.

Closes #49

## Verification

- `cd frontend && pnpm run typecheck`
- `cd frontend && pnpm exec vitest run`
- `cd frontend && pnpm run build`
- Rodney manual pass on the dev app: empty success state, grouped tray after unscheduling, tray selection collapse, cancel restore, and placement reopening the tray with count update.

Note: `cd frontend && pnpm run prettier:check` still reports the pre-existing unrelated `src/components/builder/builder.tsx` formatting issue. The files touched in this PR pass Prettier.
