### PR TITLE
✨ feat(planning): poll schedule for multi-device sync and recover from stale writes

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -305,7 +305,13 @@ async def handle_match_reschedule(
             if match.id == match_id
         )
         if target_match.court_id is not None or target_match.start_time is not None:
-            raise ValueError("match_id doesn't match unscheduled match state")
+            # The client thought the match was unscheduled but someone scheduled it
+            # in the meantime: reject so the client can refetch and retry.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="The schedule changed since this device last refreshed: "
+                "the match is no longer unscheduled",
+            )
 
         # Only the destination court changes; other courts keep their packing.
         court_matches = [
@@ -333,7 +339,15 @@ async def handle_match_reschedule(
         or target.position != body.old_position
         or target.match.court_id != body.old_court_id
     ):
-        raise ValueError("match_id doesn't match court id or position in schedule")
+        # Optimistic-concurrency check: the match moved since the client last
+        # refreshed (e.g. a co-organizer rescheduled it from another device).
+        # 409 lets the client distinguish this from a real error and recover by
+        # refetching the schedule.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="The schedule changed since this device last refreshed: "
+            "the match is no longer at the given court and position",
+        )
 
     offset = (
         -0.5

--- a/backend/tests/integration_tests/api/rescheduling_matches_test.py
+++ b/backend/tests/integration_tests/api/rescheduling_matches_test.py
@@ -114,6 +114,94 @@ async def test_reschedule_match(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_reschedule_match_stale_position_returns_conflict(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """
+    A reschedule whose old court/position no longer matches (someone else moved the
+    match in between) is rejected with 409 and leaves the schedule untouched.
+    """
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as stage_inserted,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage_inserted.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item_inserted,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item_inserted.id})
+        ) as round_inserted,
+        inserted_team(
+            DUMMY_TEAM1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as team1_inserted,
+        inserted_team(
+            DUMMY_TEAM2.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as team2_inserted,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=0,
+                team_id=team1_inserted.id,
+                tournament_id=auth_context.tournament.id,
+                stage_item_id=stage_item_inserted.id,
+            )
+        ) as stage_item_input1_inserted,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=0,
+                team_id=team2_inserted.id,
+                tournament_id=auth_context.tournament.id,
+                stage_item_id=stage_item_inserted.id,
+            )
+        ) as stage_item_input2_inserted,
+        inserted_court(
+            DUMMY_COURT1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as court1_inserted,
+        inserted_court(
+            DUMMY_COURT2.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as court2_inserted,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_inserted.id,
+                    "stage_item_input1_id": stage_item_input1_inserted.id,
+                    "stage_item_input2_id": stage_item_input2_inserted.id,
+                    "court_id": court1_inserted.id,
+                    "state": MatchState.NOT_STARTED,
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "completed_at": None,
+                }
+            )
+        ) as match_inserted,
+    ):
+        # The match sits at position 1 on court 1; claim it was at position 0.
+        body = MatchRescheduleBody(
+            old_court_id=court1_inserted.id,
+            old_position=0,
+            new_court_id=court2_inserted.id,
+            new_position=0,
+        )
+        response = await send_tournament_request(
+            HTTPMethod.POST,
+            f"matches/{match_inserted.id}/reschedule",
+            auth_context,
+            json=body.model_dump(),
+        )
+        match = await sql_get_match(match_inserted.id)
+        await assert_row_count_and_clear(matches, 0)
+
+    assert response["detail"] == (
+        "The schedule changed since this device last refreshed: "
+        "the match is no longer at the given court and position"
+    )
+    assert match.court_id == court1_inserted.id
+    assert match.position_in_schedule == DUMMY_MATCH1.position_in_schedule
+    assert match.start_time == DUMMY_MATCH1.start_time
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_unschedule_match(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -226,6 +226,8 @@
     "save_button": "Speichern",
     "save_players_button": "Spieler speichern",
     "save_ranking_button": "Rangliste speichern",
+    "schedule_changed_message": "Jemand anderes hat den Zeitplan in der Zwischenzeit geändert. Er wurde aktualisiert – bitte wählen Sie erneut.",
+    "schedule_changed_title": "Zeitplan geändert",
     "schedule_description": "Alle ungeplanten Spiele planen",
     "schedule_title": "Zeitplan",
     "score_of_label": "Punktzahl von",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -234,6 +234,8 @@
     "save_button": "Save",
     "save_players_button": "Save players",
     "save_ranking_button": "Save Ranking",
+    "schedule_changed_message": "Someone else changed the schedule in the meantime. It has been refreshed — please pick again.",
+    "schedule_changed_title": "Schedule changed",
     "schedule_description": "Schedule All Unscheduled Matches",
     "schedule_title": "Schedule",
     "score_tracking_copy_button": "Copy score tracking URL",

--- a/frontend/src/logic/planning/polling.test.ts
+++ b/frontend/src/logic/planning/polling.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SCHEDULE_POLL_INTERVAL_MS,
+  isStaleScheduleError,
+  pollingPaused,
+  scheduleRefreshInterval,
+  shouldRefreshOnSelectionChange,
+} from './polling';
+import { GridMatchRef, IDLE_SELECTION, SelectionState } from './selection';
+
+const MATCH: GridMatchRef = { matchId: 10, courtId: 1, position: 2 };
+
+const MATCH_SELECTED: SelectionState = { kind: 'match-selected', match: MATCH };
+const TRAY_SELECTED: SelectionState = { kind: 'tray-match-selected', matchId: 10 };
+const SHEET_OPEN: SelectionState = { kind: 'action-sheet-open', match: MATCH };
+
+describe('pollingPaused', () => {
+  it('polls while idle', () => {
+    expect(pollingPaused(IDLE_SELECTION)).toBe(false);
+  });
+
+  it('pauses while a grid match is selected', () => {
+    expect(pollingPaused(MATCH_SELECTED)).toBe(true);
+  });
+
+  it('pauses while a tray match is selected', () => {
+    expect(pollingPaused(TRAY_SELECTED)).toBe(true);
+  });
+
+  it('pauses while the action sheet is open', () => {
+    expect(pollingPaused(SHEET_OPEN)).toBe(true);
+  });
+});
+
+describe('scheduleRefreshInterval', () => {
+  it('returns the polling interval while idle', () => {
+    expect(scheduleRefreshInterval(IDLE_SELECTION)).toBe(SCHEDULE_POLL_INTERVAL_MS);
+  });
+
+  it('disables polling while a selection is active', () => {
+    expect(scheduleRefreshInterval(MATCH_SELECTED)).toBe(0);
+    expect(scheduleRefreshInterval(TRAY_SELECTED)).toBe(0);
+    expect(scheduleRefreshInterval(SHEET_OPEN)).toBe(0);
+  });
+});
+
+describe('shouldRefreshOnSelectionChange', () => {
+  it('refreshes when a selection clears', () => {
+    expect(shouldRefreshOnSelectionChange(MATCH_SELECTED, IDLE_SELECTION)).toBe(true);
+    expect(shouldRefreshOnSelectionChange(TRAY_SELECTED, IDLE_SELECTION)).toBe(true);
+    expect(shouldRefreshOnSelectionChange(SHEET_OPEN, IDLE_SELECTION)).toBe(true);
+  });
+
+  it('does not refresh while idle stays idle', () => {
+    expect(shouldRefreshOnSelectionChange(IDLE_SELECTION, IDLE_SELECTION)).toBe(false);
+  });
+
+  it('does not refresh when a selection starts', () => {
+    expect(shouldRefreshOnSelectionChange(IDLE_SELECTION, MATCH_SELECTED)).toBe(false);
+  });
+
+  it('does not refresh while the pause continues across selection changes', () => {
+    // E.g. selected match -> action sheet, or switching tray selections.
+    expect(shouldRefreshOnSelectionChange(MATCH_SELECTED, SHEET_OPEN)).toBe(false);
+    expect(shouldRefreshOnSelectionChange(SHEET_OPEN, MATCH_SELECTED)).toBe(false);
+    expect(shouldRefreshOnSelectionChange(TRAY_SELECTED, TRAY_SELECTED)).toBe(false);
+  });
+});
+
+describe('isStaleScheduleError', () => {
+  it('recognizes the 409 stale-write rejection', () => {
+    expect(isStaleScheduleError({ response: { status: 409 } })).toBe(true);
+  });
+
+  it('rejects other HTTP errors', () => {
+    expect(isStaleScheduleError({ response: { status: 400 } })).toBe(false);
+    expect(isStaleScheduleError({ response: { status: 500 } })).toBe(false);
+  });
+
+  it('rejects network errors without a response', () => {
+    expect(isStaleScheduleError({ code: 'ERR_NETWORK' })).toBe(false);
+    expect(isStaleScheduleError(new Error('boom'))).toBe(false);
+  });
+
+  it('rejects non-object errors', () => {
+    expect(isStaleScheduleError(null)).toBe(false);
+    expect(isStaleScheduleError(undefined)).toBe(false);
+    expect(isStaleScheduleError('409')).toBe(false);
+  });
+});

--- a/frontend/src/logic/planning/polling.ts
+++ b/frontend/src/logic/planning/polling.ts
@@ -1,0 +1,55 @@
+/**
+ * Multi-device sync policy for the planning grid.
+ *
+ * The schedule revalidates periodically so a co-organizer's moves and score
+ * entries appear without a manual refresh. Polling is suspended whenever a
+ * selection is active (match selected, tray match selected, or the action
+ * sheet open) so the grid never shifts under the user's finger mid-placement,
+ * and resumes — with an immediate refresh — once the selection clears.
+ *
+ * A placement can still race a move made on another device while polling is
+ * paused; the backend rejects such stale writes with 409 Conflict, which
+ * `isStaleScheduleError` recognizes so the UI can refetch and ask the user to
+ * pick again.
+ */
+
+import { SelectionState } from './selection';
+
+export const SCHEDULE_POLL_INTERVAL_MS = 10_000;
+
+export function pollingPaused(selection: SelectionState): boolean {
+  return selection.kind !== 'idle';
+}
+
+/**
+ * The SWR `refreshInterval` for the schedule data: the polling interval, or 0
+ * (disabled) while a selection holds the grid still.
+ */
+export function scheduleRefreshInterval(selection: SelectionState): number {
+  return pollingPaused(selection) ? 0 : SCHEDULE_POLL_INTERVAL_MS;
+}
+
+/**
+ * Whether clearing/changing the selection should trigger an immediate
+ * revalidation: exactly when a pause ends, so changes that piled up while the
+ * grid was held still appear right away instead of after a full interval.
+ */
+export function shouldRefreshOnSelectionChange(
+  previous: SelectionState,
+  next: SelectionState
+): boolean {
+  return pollingPaused(previous) && !pollingPaused(next);
+}
+
+/**
+ * The backend's optimistic-concurrency rejection: a reschedule whose old
+ * court/position no longer matches because someone else moved the match in
+ * between is refused with 409 Conflict.
+ */
+export function isStaleScheduleError(error: unknown): boolean {
+  if (typeof error !== 'object' || error == null) {
+    return false;
+  }
+  const response = (error as { response?: { status?: number } }).response;
+  return response?.status === 409;
+}

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -1,6 +1,8 @@
 import { Affix, Badge, Box, Button, Grid, Group, Paper, Stack, Text, Title } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
 import { IconCalendarPlus } from '@tabler/icons-react';
-import { useState } from 'react';
+import { isAxiosError } from 'axios';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import CourtModal from '@components/modals/create_court_modal';
@@ -12,7 +14,13 @@ import { computeConflictPreview } from '@logic/planning/conflict_preview';
 import { computeScheduleLayout } from '@logic/planning/layout';
 import { applyPlanningActions } from '@logic/planning/optimistic';
 import {
+  isStaleScheduleError,
+  scheduleRefreshInterval,
+  shouldRefreshOnSelectionChange,
+} from '@logic/planning/polling';
+import {
   FocusTarget,
+  IDLE_SELECTION,
   PlannerEvent,
   PlannerState,
   PlanningAction,
@@ -23,7 +31,12 @@ import { nextTrayOpenedAfterPlannerEvent } from '@logic/planning/unscheduled_tra
 import { ZOOM_TICK_INTERVAL_MINUTES, defaultZoomLevel, levelColour } from '@logic/planning/zoom';
 import { Court, LevelResponse, MatchWithDetails, StageWithStageItems } from '@openapi';
 import TournamentLayout from '@pages/tournaments/_tournament_layout';
-import { getCourts, getStages, getTournamentById } from '@services/adapter';
+import {
+  getCourts,
+  getStagesWithPolling,
+  getTournamentById,
+  handleRequestError,
+} from '@services/adapter';
 import {
   MatchLookupEntry,
   getMatchLookup,
@@ -57,9 +70,25 @@ export default function SchedulePage() {
 
   const { t } = useTranslation();
   const { tournamentData } = getTournamentIdFromRouter();
-  const swrStagesResponse = getStages(tournamentData.id);
+  // The schedule polls so co-organizers' changes show up, but holds still
+  // (interval 0) while a selection or the action sheet is active.
+  const swrStagesResponse = getStagesWithPolling(
+    tournamentData.id,
+    scheduleRefreshInterval(planner.selection)
+  );
   const swrCourtsResponse = getCourts(tournamentData.id);
   const swrTournamentResponse = getTournamentById(tournamentData.id);
+
+  // When a pause ends (selection cleared), refresh immediately instead of
+  // waiting up to a full polling interval for changes made in the meantime.
+  const refreshSchedule = swrStagesResponse.mutate;
+  const previousSelectionRef = useRef(planner.selection);
+  useEffect(() => {
+    if (shouldRefreshOnSelectionChange(previousSelectionRef.current, planner.selection)) {
+      refreshSchedule();
+    }
+    previousSelectionRef.current = planner.selection;
+  }, [planner.selection, refreshSchedule]);
 
   const stageItemsLookup = responseIsValid(swrStagesResponse)
     ? getStageItemLookup(swrStagesResponse)
@@ -141,27 +170,48 @@ export default function SchedulePage() {
       );
 
     if (actions.length > 0) {
-      // Show the predicted outcome immediately; the revalidation that follows the
-      // request replaces it with the backend's authoritative schedule.
-      await swrStagesResponse.mutate(
-        async (current) => {
-          for (const action of actions) {
-            await performAction(action);
+      try {
+        // Show the predicted outcome immediately; the revalidation that follows the
+        // request replaces it with the backend's authoritative schedule.
+        await swrStagesResponse.mutate(
+          async (current) => {
+            for (const action of actions) {
+              await performAction(action);
+            }
+            return current;
+          },
+          {
+            optimisticData: (current) =>
+              current == null
+                ? current!
+                : {
+                    ...current,
+                    data: applyPlanningActions(current.data, actions, tournament.start_time),
+                  },
+            populateCache: false,
+            revalidate: true,
           }
-          return current;
-        },
-        {
-          optimisticData: (current) =>
-            current == null
-              ? current!
-              : {
-                  ...current,
-                  data: applyPlanningActions(current.data, actions, tournament.start_time),
-                },
-          populateCache: false,
-          revalidate: true,
+        );
+      } catch (error) {
+        // The optimistic update was rolled back; resync with the backend's
+        // authoritative schedule and restart the placement flow from idle.
+        setPlanner((current) => ({ ...current, selection: IDLE_SELECTION }));
+        await swrStagesResponse.mutate();
+        if (isStaleScheduleError(error)) {
+          // Someone else moved a match between this device's last refresh and
+          // the placement: not an error to apologize for, just pick again.
+          showNotification({
+            color: 'orange',
+            title: t('schedule_changed_title'),
+            message: t('schedule_changed_message'),
+            autoClose: 10000,
+          });
+        } else if (isAxiosError(error)) {
+          handleRequestError(error);
+        } else {
+          throw error;
         }
-      );
+      }
       if (wasTraySelection) {
         updateTrayOpened();
       }

--- a/frontend/src/services/adapter.tsx
+++ b/frontend/src/services/adapter.tsx
@@ -196,6 +196,29 @@ export function getStages(
   );
 }
 
+/**
+ * Like `getStages`, but revalidates every `refreshIntervalMs` so changes made by
+ * co-organizers on other devices show up without a manual refresh. Pass 0 to
+ * hold the data still (e.g. while the planner has a match selected); that also
+ * suspends focus/reconnect revalidation, so nothing shifts under the user.
+ */
+export function getStagesWithPolling(
+  tournament_id: number | null,
+  refreshIntervalMs: number
+): SWRResponse<StagesWithStageItemsResponse> {
+  return useSWR(
+    tournament_id == null || tournament_id === -1
+      ? null
+      : `tournaments/${tournament_id}/stages?no_draft_rounds=false`,
+    fetcher,
+    {
+      refreshInterval: refreshIntervalMs,
+      revalidateOnFocus: refreshIntervalMs > 0,
+      revalidateOnReconnect: refreshIntervalMs > 0,
+    }
+  );
+}
+
 export function getStagesLive(
   tournament_id: number | null
 ): SWRResponse<StagesWithStageItemsResponse> {

--- a/frontend/src/services/match.tsx
+++ b/frontend/src/services/match.tsx
@@ -47,10 +47,13 @@ export async function updateTournamentScoreTrackingMatch(
     .catch((response: any) => handleRequestError(response));
 }
 
+// The planner's scheduling mutations let errors propagate instead of handling
+// them here: the planner must see failures (in particular the 409 stale-write
+// rejection when another device moved a match concurrently) to refetch the
+// schedule and clear the selection.
+
 export async function unscheduleMatch(tournament_id: number, match_id: number) {
-  return createAxios()
-    .post(`tournaments/${tournament_id}/matches/${match_id}/unschedule`)
-    .catch((response: any) => handleRequestError(response));
+  return createAxios().post(`tournaments/${tournament_id}/matches/${match_id}/unschedule`);
 }
 
 export async function rescheduleMatch(
@@ -58,15 +61,11 @@ export async function rescheduleMatch(
   match_id: number,
   match: MatchRescheduleBody
 ) {
-  return createAxios()
-    .post(`tournaments/${tournament_id}/matches/${match_id}/reschedule`, match)
-    .catch((response: any) => handleRequestError(response));
+  return createAxios().post(`tournaments/${tournament_id}/matches/${match_id}/reschedule`, match);
 }
 
 export async function swapMatches(tournament_id: number, body: MatchSwapBody) {
-  return createAxios()
-    .post(`tournaments/${tournament_id}/matches/swap`, body)
-    .catch((response: any) => handleRequestError(response));
+  return createAxios().post(`tournaments/${tournament_id}/matches/swap`, body);
 }
 
 export async function scheduleMatches(tournament_id: number) {


### PR DESCRIPTION
The planner now revalidates the schedule every 10s so a co-organizer's
moves and score entries appear without a manual refresh. Polling (and
focus/reconnect revalidation) is suspended while a match is selected or
the action sheet is open, so the grid never shifts mid-placement, and
resumes with an immediate refresh once the selection clears.

The reschedule endpoint's stale-write rejection (old court/position no
longer matching because another device moved the match in between) now
returns 409 Conflict instead of an opaque 500. The client catches any
failed placement/swap/unschedule, rolls back the optimistic update,
refetches the schedule, clears the selection, and shows a
"schedule changed — pick again" notification for the 409 case.

Closes #51

https://claude.ai/code/session_01CPQQRuz1t6c7DcCZ89Cefa