### PR TITLE
Planning: team highlight and jump to now

### DIFF
--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -6,12 +6,14 @@ import { useTranslation } from 'react-i18next';
 
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
 import { ConflictPreview, insertionLineKey } from '@logic/planning/conflict_preview';
+import { HighlightTarget, matchInvolvesHighlight } from '@logic/planning/highlight';
 import {
   InsertionLine,
   MatchBlock,
   ScheduleGridLayout,
   computeInsertionLines,
 } from '@logic/planning/layout';
+import { nowLineScrollTop } from '@logic/planning/now_line';
 import { FocusTarget, GridMatchRef, PlannerEvent, SelectionState } from '@logic/planning/selection';
 import {
   ZOOM_PX_PER_MINUTE,
@@ -83,6 +85,8 @@ function MatchCard({
   isViolation,
   hasPlacementWarning,
   isSelected,
+  highlightActive,
+  isHighlighted,
   stageItemsLookup,
   matchesLookup,
   levels,
@@ -94,6 +98,8 @@ function MatchCard({
   isViolation: boolean;
   hasPlacementWarning: boolean;
   isSelected: boolean;
+  highlightActive: boolean;
+  isHighlighted: boolean;
   stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
   matchesLookup: Record<number, MatchLookupEntry>;
   levels: LevelResponse[];
@@ -207,6 +213,8 @@ function MatchCard({
   return (
     <Box
       data-match-id={match.id}
+      data-highlighted={isHighlighted ? 'true' : undefined}
+      data-dimmed={highlightActive && !isHighlighted ? 'true' : undefined}
       data-conflict-preview={hasPlacementWarning ? 'true' : undefined}
       onClick={(event) => {
         event.stopPropagation();
@@ -222,7 +230,8 @@ function MatchCard({
         // Every card is tappable: unlocked ones select for placement, locked
         // (played) ones open the action sheet with the move-anyway override.
         cursor: 'pointer',
-        opacity: match.state === 'COMPLETED' ? 0.55 : undefined,
+        opacity:
+          highlightActive && !isHighlighted ? 0.22 : match.state === 'COMPLETED' ? 0.55 : undefined,
         borderRadius: 6,
         border: isSelected
           ? '1px solid var(--mantine-color-indigo-filled)'
@@ -233,9 +242,11 @@ function MatchCard({
         backgroundColor: `var(--mantine-color-${color}-light)`,
         boxShadow: isSelected
           ? '0 0 0 2px var(--mantine-color-indigo-filled)'
-          : hasPlacementWarning
-            ? '0 0 0 2px var(--mantine-color-orange-light)'
-            : undefined,
+          : isHighlighted
+            ? '0 0 0 2px var(--mantine-color-teal-filled)'
+            : hasPlacementWarning
+              ? '0 0 0 2px var(--mantine-color-orange-light)'
+              : undefined,
         zIndex: isSelected ? 1 : undefined,
       }}
     >
@@ -313,19 +324,27 @@ function OverviewBlock({
   pxPerMinute,
   colour,
   isSelected,
+  highlightActive,
+  isHighlighted,
 }: {
   block: MatchBlock<MatchWithDetails>;
   pxPerMinute: number;
   colour: string;
   isSelected: boolean;
+  highlightActive: boolean;
+  isHighlighted: boolean;
 }) {
   const blockHeightPx = block.durationMinutes * pxPerMinute;
   const isCompleted = block.match.state === 'COMPLETED';
   const isInProgress = block.match.state === 'IN_PROGRESS';
-  const opacity = isCompleted ? 0.35 : isInProgress ? 1 : 0.85;
+  const opacity =
+    highlightActive && !isHighlighted ? 0.18 : isCompleted ? 0.35 : isInProgress ? 1 : 0.85;
 
   return (
     <Box
+      data-match-id={block.match.id}
+      data-highlighted={isHighlighted ? 'true' : undefined}
+      data-dimmed={highlightActive && !isHighlighted ? 'true' : undefined}
       style={{
         position: 'absolute',
         top: block.startMinutes * pxPerMinute,
@@ -335,7 +354,11 @@ function OverviewBlock({
         borderRadius: 2,
         backgroundColor: `var(--mantine-color-${colour}-filled)`,
         opacity,
-        boxShadow: isSelected ? '0 0 0 2px var(--mantine-color-indigo-filled)' : undefined,
+        boxShadow: isSelected
+          ? '0 0 0 2px var(--mantine-color-indigo-filled)'
+          : isHighlighted
+            ? '0 0 0 2px var(--mantine-color-teal-filled)'
+            : undefined,
         zIndex: isSelected ? 1 : undefined,
         pointerEvents: 'none',
         display: 'flex',
@@ -444,8 +467,11 @@ export default function ScheduleGrid({
   matchesLookup,
   levels,
   selection,
+  highlightTarget,
   zoom,
   focus,
+  nowOffsetMinutes,
+  nowScrollNonce,
   onSelectionEvent,
 }: {
   layout: ScheduleGridLayout<Court, MatchWithDetails>;
@@ -455,8 +481,11 @@ export default function ScheduleGrid({
   matchesLookup: Record<number, MatchLookupEntry>;
   levels: LevelResponse[];
   selection: SelectionState;
+  highlightTarget: HighlightTarget | null;
   zoom: ZoomLevel;
   focus: (FocusTarget & { nonce: number }) | null;
+  nowOffsetMinutes: number | null;
+  nowScrollNonce: number;
   onSelectionEvent: (event: PlannerEvent) => void;
 }) {
   const pxPerMinute = ZOOM_PX_PER_MINUTE[zoom];
@@ -469,6 +498,8 @@ export default function ScheduleGrid({
   // action sheet open the grid is inert behind the sheet's overlay.
   const placing = selection.kind === 'match-selected' || selection.kind === 'tray-match-selected';
   const isOverview = zoom === 'overview';
+  const highlightActive = highlightTarget != null;
+  const { t } = useTranslation();
 
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -508,6 +539,23 @@ export default function ScheduleGrid({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focus?.nonce]);
 
+  useEffect(() => {
+    if (nowScrollNonce === 0 || nowOffsetMinutes == null) return;
+    const container = containerRef.current;
+    if (container == null) return;
+
+    container.scrollTo({
+      top: nowLineScrollTop({
+        offsetMinutes: nowOffsetMinutes,
+        pxPerMinute,
+        viewportHeightPx: container.clientHeight,
+        headerHeightPx: HEADER_HEIGHT_PX,
+        gridTopInsetPx: GRID_TOP_INSET_PX,
+      }),
+      behavior: 'smooth',
+    });
+  }, [nowOffsetMinutes, nowScrollNonce, pxPerMinute]);
+
   return (
     <Box
       ref={containerRef}
@@ -546,6 +594,35 @@ export default function ScheduleGrid({
             }}
           />
           <Box style={{ position: 'relative', height: gridHeight, marginTop: GRID_TOP_INSET_PX }}>
+            {nowOffsetMinutes != null && (
+              <Box
+                data-now-line="ruler"
+                style={{
+                  position: 'absolute',
+                  top: nowOffsetMinutes * pxPerMinute,
+                  left: 0,
+                  right: 0,
+                  zIndex: 1,
+                  borderTop: '2px solid var(--mantine-color-red-filled)',
+                }}
+              >
+                <Text
+                  component="span"
+                  c="red"
+                  fz={10}
+                  fw={700}
+                  style={{
+                    position: 'absolute',
+                    top: -8,
+                    right: 6,
+                    backgroundColor: 'var(--mantine-color-body)',
+                    lineHeight: 1,
+                  }}
+                >
+                  {t('now_marker_label', 'Now')}
+                </Text>
+              </Box>
+            )}
             {layout.ticks.map((tick) => (
               <Text
                 key={tick.offsetMinutes}
@@ -632,7 +709,26 @@ export default function ScheduleGrid({
                   />
                 )
               )}
+              {nowOffsetMinutes != null && (
+                <Box
+                  data-now-line="court"
+                  style={{
+                    position: 'absolute',
+                    top: nowOffsetMinutes * pxPerMinute,
+                    left: 0,
+                    right: 0,
+                    zIndex: 2,
+                    borderTop: '2px solid var(--mantine-color-red-filled)',
+                    pointerEvents: 'none',
+                  }}
+                />
+              )}
               {blocks.map((block, blockIndex) => {
+                const isHighlighted = matchInvolvesHighlight(
+                  block.match,
+                  highlightTarget,
+                  matchesLookup
+                );
                 if (isOverview) {
                   return (
                     <OverviewBlock
@@ -641,6 +737,8 @@ export default function ScheduleGrid({
                       pxPerMinute={pxPerMinute}
                       colour={matchColour(block.match, matchesLookup[block.match.id], levels)}
                       isSelected={selectedMatch?.matchId === block.match.id}
+                      highlightActive={highlightActive}
+                      isHighlighted={isHighlighted}
                     />
                   );
                 }
@@ -659,6 +757,8 @@ export default function ScheduleGrid({
                     isViolation={violations.has(block.match.id)}
                     hasPlacementWarning={conflictPreview.swapTargets.has(block.match.id)}
                     isSelected={selectedMatch?.matchId === block.match.id}
+                    highlightActive={highlightActive}
+                    isHighlighted={isHighlighted}
                     stageItemsLookup={stageItemsLookup}
                     matchesLookup={matchesLookup}
                     levels={levels}

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -31,6 +31,7 @@ import classes from './schedule_grid.module.css';
 const RULER_WIDTH = '3.25rem';
 const HEADER_HEIGHT = '2.5rem';
 const HEADER_HEIGHT_PX = 40;
+const NOW_LINE_OPACITY = 0.4;
 /** Height of an insertion line's tap target; the visible line is centered inside it. */
 const INSERTION_HIT_AREA_PX = 32;
 /**
@@ -604,6 +605,7 @@ export default function ScheduleGrid({
                   right: 0,
                   zIndex: 1,
                   borderTop: '2px solid var(--mantine-color-red-filled)',
+                  opacity: NOW_LINE_OPACITY,
                 }}
               >
                 <Text
@@ -719,6 +721,7 @@ export default function ScheduleGrid({
                     right: 0,
                     zIndex: 2,
                     borderTop: '2px solid var(--mantine-color-red-filled)',
+                    opacity: NOW_LINE_OPACITY,
                     pointerEvents: 'none',
                   }}
                 />

--- a/frontend/src/logic/planning/highlight.test.ts
+++ b/frontend/src/logic/planning/highlight.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { HighlightTarget, matchInvolvesHighlight, stageHighlightOptions } from './highlight';
+
+interface TestInput {
+  id: number;
+  team_id: number | null;
+  team?: { id: number; name: string };
+  winner_from_stage_item_id: number | null;
+  winner_position: number | null;
+}
+
+function input(id: number, teamId: number | null, name?: string): TestInput {
+  return {
+    id,
+    team_id: teamId,
+    team: teamId == null ? undefined : { id: teamId, name: name ?? `Team ${teamId}` },
+    winner_from_stage_item_id: null,
+    winner_position: null,
+  };
+}
+
+function match(
+  id: number,
+  input1: ReturnType<typeof input> | null,
+  input2: ReturnType<typeof input> | null,
+  winnerFromMatch1: number | null = null,
+  winnerFromMatch2: number | null = null
+) {
+  return {
+    id,
+    stage_item_input1: input1,
+    stage_item_input2: input2,
+    stage_item_input1_winner_from_match_id: winnerFromMatch1,
+    stage_item_input2_winner_from_match_id: winnerFromMatch2,
+  };
+}
+
+describe('matchInvolvesHighlight', () => {
+  const target: HighlightTarget = { kind: 'team', teamId: 11, label: 'Alpha' };
+
+  it('matches direct stage item inputs for the selected team', () => {
+    const directMatch = match(1, input(101, 11, 'Alpha'), input(102, 12, 'Beta'));
+    const otherMatch = match(2, input(201, 13, 'Gamma'), input(202, 12, 'Beta'));
+
+    expect(matchInvolvesHighlight(directMatch, target, {})).toBe(true);
+    expect(matchInvolvesHighlight(otherMatch, target, {})).toBe(false);
+  });
+
+  it('matches winner placeholders once the source match resolves to the selected team', () => {
+    const source = match(1, input(101, 11, 'Alpha'), input(102, 12, 'Beta'));
+    const unresolvedFinal = match(2, null, input(203, 13, 'Gamma'), 1);
+
+    expect(
+      matchInvolvesHighlight(unresolvedFinal, target, {
+        1: { match: source },
+      })
+    ).toBe(true);
+  });
+
+  it('matches selected stage item inputs and inherited winner placeholders', () => {
+    const inputTarget: HighlightTarget = {
+      kind: 'stage-item-input',
+      inputId: 301,
+      label: '1st of Group A',
+    };
+    const source = match(1, { ...input(301, null), winner_from_stage_item_id: 10 }, input(302, 12));
+    const final = match(2, null, input(203, 13, 'Gamma'), 1);
+
+    expect(matchInvolvesHighlight(source, inputTarget, {})).toBe(true);
+    expect(matchInvolvesHighlight(final, inputTarget, { 1: { match: source } })).toBe(true);
+  });
+});
+
+describe('stageHighlightOptions', () => {
+  it('lists searchable teams from stage item inputs without duplicates', () => {
+    expect(
+      stageHighlightOptions([
+        {
+          stage_items: [
+            {
+              inputs: [
+                input(101, 11, 'Alpha'),
+                input(102, 12, 'Beta'),
+                input(103, 11, 'Alpha'),
+                input(104, null),
+              ],
+            },
+          ],
+        },
+      ])
+    ).toEqual([
+      { value: 'team:11', label: 'Alpha', target: { kind: 'team', teamId: 11, label: 'Alpha' } },
+      { value: 'team:12', label: 'Beta', target: { kind: 'team', teamId: 12, label: 'Beta' } },
+    ]);
+  });
+
+  it('lists tentative stage item inputs as searchable options', () => {
+    expect(
+      stageHighlightOptions([
+        {
+          stage_items: [
+            { id: 10, name: 'Group A', inputs: [] },
+            {
+              id: 20,
+              name: 'Final',
+              inputs: [{ ...input(301, null), winner_from_stage_item_id: 10, winner_position: 1 }],
+            },
+          ],
+        },
+      ])
+    ).toEqual([
+      {
+        value: 'input:301',
+        label: '1st of Group A',
+        target: { kind: 'stage-item-input', inputId: 301, label: '1st of Group A' },
+      },
+    ]);
+  });
+});

--- a/frontend/src/logic/planning/highlight.ts
+++ b/frontend/src/logic/planning/highlight.ts
@@ -1,0 +1,127 @@
+export type HighlightTarget =
+  | { kind: 'team'; teamId: number; label: string }
+  | { kind: 'stage-item-input'; inputId: number; label: string };
+
+type MatchInputLike = {
+  id?: number | null;
+  team_id?: number | null;
+  team?: { name?: string | null } | null;
+  winner_from_stage_item_id?: number | null;
+  winner_position?: number | null;
+};
+
+type MatchLike = {
+  id: number;
+  stage_item_input1?: MatchInputLike | null;
+  stage_item_input2?: MatchInputLike | null;
+  stage_item_input1_winner_from_match_id?: number | null;
+  stage_item_input2_winner_from_match_id?: number | null;
+};
+
+type MatchLookupLike = Record<number, { match: MatchLike }>;
+
+type StageLike = {
+  stage_items?: Array<{
+    id?: number | null;
+    name?: string | null;
+    inputs?: MatchInputLike[];
+  }>;
+};
+
+export interface HighlightOption {
+  value: string;
+  label: string;
+  target: HighlightTarget;
+}
+
+function inputInvolvesHighlight(input: MatchInputLike | null | undefined, target: HighlightTarget) {
+  if (target.kind === 'team') return input?.team_id === target.teamId;
+  return input?.id === target.inputId;
+}
+
+export function matchInvolvesHighlight(
+  match: MatchLike,
+  target: HighlightTarget | null,
+  matchesLookup: MatchLookupLike
+): boolean {
+  if (target == null) return false;
+  if (
+    inputInvolvesHighlight(match.stage_item_input1, target) ||
+    inputInvolvesHighlight(match.stage_item_input2, target)
+  ) {
+    return true;
+  }
+
+  const sourceMatchIds = [
+    match.stage_item_input1_winner_from_match_id,
+    match.stage_item_input2_winner_from_match_id,
+  ].filter((id): id is number => id != null);
+
+  return sourceMatchIds.some((sourceMatchId) => {
+    const sourceMatch = matchesLookup[sourceMatchId]?.match;
+    return sourceMatch != null && matchInvolvesHighlight(sourceMatch, target, matchesLookup);
+  });
+}
+
+export function stageHighlightOptions(stages: StageLike[]): HighlightOption[] {
+  const byTeamId = new Map<number, HighlightOption>();
+  const byInputId = new Map<number, HighlightOption>();
+  const stageItemNames = new Map<number, string>();
+
+  for (const stage of stages) {
+    for (const stageItem of stage.stage_items ?? []) {
+      if (stageItem.id != null && stageItem.name != null) {
+        stageItemNames.set(stageItem.id, stageItem.name);
+      }
+    }
+  }
+
+  for (const stage of stages) {
+    for (const stageItem of stage.stage_items ?? []) {
+      for (const input of stageItem.inputs ?? []) {
+        if (input.team_id != null) {
+          if (byTeamId.has(input.team_id)) continue;
+          const label = input.team?.name ?? `Team ${input.team_id}`;
+          byTeamId.set(input.team_id, {
+            value: `team:${input.team_id}`,
+            label,
+            target: { kind: 'team', teamId: input.team_id, label },
+          });
+          continue;
+        }
+
+        if (
+          input.id == null ||
+          input.winner_from_stage_item_id == null ||
+          input.winner_position == null ||
+          byInputId.has(input.id)
+        ) {
+          continue;
+        }
+        const sourceName =
+          stageItemNames.get(input.winner_from_stage_item_id) ??
+          `Stage item ${input.winner_from_stage_item_id}`;
+        const label = `${positionName(input.winner_position)} of ${sourceName}`;
+        byInputId.set(input.id, {
+          value: `input:${input.id}`,
+          label,
+          target: { kind: 'stage-item-input', inputId: input.id, label },
+        });
+      }
+    }
+  }
+
+  return [...byTeamId.values(), ...byInputId.values()].sort((a, b) =>
+    a.label.localeCompare(b.label)
+  );
+}
+
+function positionName(position: number): string {
+  return (
+    {
+      1: '1st',
+      2: '2nd',
+      3: '3rd',
+    }[position] ?? `${position}th`
+  );
+}

--- a/frontend/src/logic/planning/now_line.test.ts
+++ b/frontend/src/logic/planning/now_line.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { currentTimeOffsetMinutes, nowLineScrollTop } from './now_line';
+
+describe('currentTimeOffsetMinutes', () => {
+  const tournamentStartTime = '2026-06-10T09:00:00Z';
+
+  it('returns the minute offset when now falls inside the schedule span', () => {
+    expect(
+      currentTimeOffsetMinutes({
+        tournamentStartTime,
+        totalMinutes: 120,
+        now: new Date('2026-06-10T09:45:00Z'),
+      })
+    ).toBe(45);
+  });
+
+  it('renders at both schedule boundaries', () => {
+    expect(
+      currentTimeOffsetMinutes({
+        tournamentStartTime,
+        totalMinutes: 120,
+        now: new Date('2026-06-10T09:00:00Z'),
+      })
+    ).toBe(0);
+    expect(
+      currentTimeOffsetMinutes({
+        tournamentStartTime,
+        totalMinutes: 120,
+        now: new Date('2026-06-10T11:00:00Z'),
+      })
+    ).toBe(120);
+  });
+
+  it('returns null when now is outside the schedule span', () => {
+    expect(
+      currentTimeOffsetMinutes({
+        tournamentStartTime,
+        totalMinutes: 120,
+        now: new Date('2026-06-10T08:59:00Z'),
+      })
+    ).toBeNull();
+    expect(
+      currentTimeOffsetMinutes({
+        tournamentStartTime,
+        totalMinutes: 120,
+        now: new Date('2026-06-10T11:01:00Z'),
+      })
+    ).toBeNull();
+  });
+});
+
+describe('nowLineScrollTop', () => {
+  it('centers the current-time line in the scroll viewport', () => {
+    expect(
+      nowLineScrollTop({
+        offsetMinutes: 45,
+        pxPerMinute: 3,
+        viewportHeightPx: 300,
+        headerHeightPx: 40,
+        gridTopInsetPx: 32,
+      })
+    ).toBe(57);
+  });
+
+  it('clamps above-the-top scroll targets to zero', () => {
+    expect(
+      nowLineScrollTop({
+        offsetMinutes: 0,
+        pxPerMinute: 3,
+        viewportHeightPx: 300,
+        headerHeightPx: 40,
+        gridTopInsetPx: 32,
+      })
+    ).toBe(0);
+  });
+});

--- a/frontend/src/logic/planning/now_line.ts
+++ b/frontend/src/logic/planning/now_line.ts
@@ -1,0 +1,33 @@
+export function currentTimeOffsetMinutes({
+  tournamentStartTime,
+  totalMinutes,
+  now,
+}: {
+  tournamentStartTime: string | Date;
+  totalMinutes: number;
+  now: Date;
+}): number | null {
+  const startTime =
+    tournamentStartTime instanceof Date ? tournamentStartTime : new Date(tournamentStartTime);
+  const offsetMinutes = (now.getTime() - startTime.getTime()) / 60_000;
+
+  if (offsetMinutes < 0 || offsetMinutes > totalMinutes) return null;
+  return offsetMinutes;
+}
+
+export function nowLineScrollTop({
+  offsetMinutes,
+  pxPerMinute,
+  viewportHeightPx,
+  headerHeightPx,
+  gridTopInsetPx,
+}: {
+  offsetMinutes: number;
+  pxPerMinute: number;
+  viewportHeightPx: number;
+  headerHeightPx: number;
+  gridTopInsetPx: number;
+}): number {
+  const targetY = headerHeightPx + gridTopInsetPx + offsetMinutes * pxPerMinute;
+  return Math.max(0, targetY - viewportHeightPx / 2);
+}

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -1,6 +1,18 @@
-import { Affix, Badge, Box, Button, Grid, Group, Paper, Stack, Text, Title } from '@mantine/core';
+import {
+  Affix,
+  Badge,
+  Box,
+  Button,
+  Grid,
+  Group,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { IconCalendarPlus } from '@tabler/icons-react';
+import { IconCalendarPlus, IconClock } from '@tabler/icons-react';
 import { isAxiosError } from 'axios';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -11,7 +23,9 @@ import { NoContent } from '@components/no_content/empty_table_info';
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
 import { getTournamentIdFromRouter, responseIsValid } from '@components/utils/util';
 import { computeConflictPreview } from '@logic/planning/conflict_preview';
+import { stageHighlightOptions } from '@logic/planning/highlight';
 import { computeScheduleLayout } from '@logic/planning/layout';
+import { currentTimeOffsetMinutes } from '@logic/planning/now_line';
 import { applyPlanningActions } from '@logic/planning/optimistic';
 import {
   isStaleScheduleError,
@@ -58,6 +72,9 @@ export default function SchedulePage() {
   const [planner, setPlanner] = useState<PlannerState>(() =>
     initialPlannerState(defaultZoomLevel(window.innerWidth))
   );
+  const [highlightValue, setHighlightValue] = useState<string | null>(null);
+  const [now, setNow] = useState(() => new Date());
+  const [nowScrollNonce, setNowScrollNonce] = useState(0);
   const [trayOpened, setTrayOpened] = useState(false);
   const [focus, setFocus] = useState<(FocusTarget & { nonce: number }) | null>(null);
   // Details modal opened from the action sheet; holds the match id (not the
@@ -67,6 +84,11 @@ export default function SchedulePage() {
   // Captures pinch and ctrl+wheel over the whole planning content, so a pinch
   // that starts next to the grid zooms the schedule instead of the page.
   const pinchRef = usePinchZoom(handlePlannerEvent);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => setNow(new Date()), 60_000);
+    return () => window.clearInterval(intervalId);
+  }, []);
 
   const { t } = useTranslation();
   const { tournamentData } = getTournamentIdFromRouter();
@@ -112,12 +134,20 @@ export default function SchedulePage() {
   const courts: Court[] = swrCourtsResponse.data?.data ?? [];
   const rawStages: StageWithStageItems[] = swrStagesResponse.data?.data ?? [];
   const levels: LevelResponse[] = tournament.levels ?? [];
+  const highlightOptions = stageHighlightOptions(rawStages);
+  const highlightTarget =
+    highlightOptions.find((option) => option.value === highlightValue)?.target ?? null;
 
   const layout = computeScheduleLayout({
     courts,
     matchesByCourtId,
     tournamentStartTime: tournament.start_time,
     tickIntervalMinutes: ZOOM_TICK_INTERVAL_MINUTES[planner.zoom],
+  });
+  const nowOffsetMinutes = currentTimeOffsetMinutes({
+    tournamentStartTime: tournament.start_time,
+    totalMinutes: layout.totalMinutes,
+    now,
   });
 
   const violations = new Set<number>();
@@ -249,12 +279,36 @@ export default function SchedulePage() {
           </Grid.Col>
           <Grid.Col span={6}>
             <Group justify="right">
+              <Select
+                aria-label={t('team_highlight_label', 'Highlight team or input')}
+                placeholder={t('team_highlight_placeholder', 'Find team or input')}
+                data={highlightOptions}
+                value={highlightValue}
+                onChange={setHighlightValue}
+                searchable
+                clearable
+                limit={24}
+                w={220}
+                size="sm"
+                mb={10}
+              />
               <CourtsToolbar
                 tournamentId={tournamentData.id}
                 swrCourtsResponse={swrCourtsResponse}
                 courts={courts}
                 matchesByCourtId={matchesByCourtId}
               />
+              <Button
+                color="red"
+                size="sm"
+                variant="light"
+                style={{ marginBottom: 10 }}
+                leftSection={<IconClock size={18} />}
+                disabled={nowOffsetMinutes == null}
+                onClick={() => setNowScrollNonce((nonce) => nonce + 1)}
+              >
+                {t('jump_to_now_label', 'Now')}
+              </Button>
               {courts.length < 1 ? null : (
                 <Button
                   color="indigo"
@@ -309,8 +363,11 @@ export default function SchedulePage() {
               matchesLookup={matchesLookup}
               levels={levels}
               selection={planner.selection}
+              highlightTarget={highlightTarget}
               zoom={planner.zoom}
               focus={focus}
+              nowOffsetMinutes={nowOffsetMinutes}
+              nowScrollNonce={nowScrollNonce}
               onSelectionEvent={handlePlannerEvent}
             />
             <UnscheduledSheet


### PR DESCRIPTION
## Summary
- Add a searchable planning toolbar control for highlighting teams or tentative stage item inputs.
- Highlight matching scheduled matches and dim non-matches across agenda, compact, and overview zoom levels.
- Add a current-time schedule line plus a Now button that scrolls the grid to the line when the current time is inside the schedule span.

Closes #50

## Testing
- nix develop --command sh -c 'cd frontend && pnpm test'\n- Manual Rodney verification on local dev stack: selected Team 1, verified 3 highlighted / 12 dimmed in compact and overview, cleared highlight, verified placement selection still shows insertion targets while highlight remains, temporarily moved local dev tournament start time into the current window and verified now-line rendering plus Now scroll behavior.