### PR TITLE
Flag advisory schedule conflicts in planner

### DIFF
--- a/backend/alembic/versions/7c1e9f0d2a4b_add_planner_advisory_conflict_flags.py
+++ b/backend/alembic/versions/7c1e9f0d2a4b_add_planner_advisory_conflict_flags.py
@@ -1,0 +1,37 @@
+"""add planner advisory conflict flags
+
+Revision ID: 7c1e9f0d2a4b
+Revises: 0d4f19b8c6a2
+Create Date: 2026-06-13 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str | None = "7c1e9f0d2a4b"
+down_revision: str | None = "0d4f19b8c6a2"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "matches",
+        sa.Column("precedence_conflict", sa.Boolean(), nullable=True, server_default="f"),
+    )
+    op.add_column(
+        "matches",
+        sa.Column("short_break_conflict", sa.Boolean(), nullable=True, server_default="f"),
+    )
+    op.execute(text("UPDATE matches SET precedence_conflict=false, short_break_conflict=false"))
+    op.alter_column("matches", "precedence_conflict", nullable=False)
+    op.alter_column("matches", "short_break_conflict", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("matches", "short_break_conflict")
+    op.drop_column("matches", "precedence_conflict")

--- a/backend/bracket/logic/planning/conflicts.py
+++ b/backend/bracket/logic/planning/conflicts.py
@@ -1,9 +1,12 @@
 from collections import defaultdict
+from dataclasses import dataclass
+
+from heliclockter import datetime_utc
 
 from bracket.database import database
-from bracket.models.db.match import Match, MatchWithDetailsDefinitive
+from bracket.models.db.match import Match, MatchWithDetails, MatchWithDetailsDefinitive
 from bracket.models.db.util import StageWithStageItems
-from bracket.utils.id_types import MatchId
+from bracket.utils.id_types import CourtId, MatchId, StageItemId
 
 
 def matches_overlap(match1: Match, match2: Match) -> bool:
@@ -14,27 +17,36 @@ def matches_overlap(match1: Match, match2: Match) -> bool:
     return match1.start_time < match2.end_time and match2.start_time < match1.end_time
 
 
-def get_conflicting_matches(
+@dataclass
+class MatchConflictFlags:
+    stage_item_input1_conflict: bool = False
+    stage_item_input2_conflict: bool = False
+    precedence_conflict: bool = False
+    short_break_conflict: bool = False
+
+
+def _get_all_matches(
     stages: list[StageWithStageItems],
-) -> tuple[
-    defaultdict[MatchId, list[bool]],
-    set[MatchId],
-]:
-    matches = [
+) -> list[MatchWithDetailsDefinitive | MatchWithDetails]:
+    return [
         match
         for stage in stages
         for stage_item in stage.stage_items
         for round_ in stage_item.rounds
         for match in round_.matches
-        if isinstance(match, MatchWithDetailsDefinitive)
     ]
 
-    conflicts_to_set: defaultdict[MatchId, list[bool]] = defaultdict(lambda: [False, False])
-    matches_with_conflicts = set()
-    conflicts_to_clear = set()
 
-    for i, match1 in enumerate(matches):
-        for match2 in matches[i + 1 :]:
+def _set_team_overlap_conflicts(
+    matches: list[MatchWithDetailsDefinitive | MatchWithDetails],
+    flags: dict[MatchId, MatchConflictFlags],
+) -> None:
+    definitive_matches = [
+        match for match in matches if isinstance(match, MatchWithDetailsDefinitive)
+    ]
+
+    for i, match1 in enumerate(definitive_matches):
+        for match2 in definitive_matches[i + 1 :]:
             conflicting_input_ids = []
 
             if match2.stage_item_input1_id in match1.stage_item_input_ids:
@@ -42,64 +54,173 @@ def get_conflicting_matches(
             if match2.stage_item_input2_id in match1.stage_item_input_ids:
                 conflicting_input_ids.append(match2.stage_item_input2_id)
 
-            if len(conflicting_input_ids) < 1:
+            if len(conflicting_input_ids) < 1 or not matches_overlap(match1, match2):
                 continue
 
-            if matches_overlap(match1, match2):
-                for match in (match1, match2):
-                    if not conflicts_to_set[match.id][0]:
-                        conflicts_to_set[match.id][0] = (
-                            match.stage_item_input1_id in conflicting_input_ids
-                        )
-                    if not conflicts_to_set[match.id][1]:
-                        conflicts_to_set[match.id][1] = (
-                            match.stage_item_input2_id in conflicting_input_ids
-                        )
+            for match in (match1, match2):
+                flags[match.id].stage_item_input1_conflict = (
+                    flags[match.id].stage_item_input1_conflict
+                    or match.stage_item_input1_id in conflicting_input_ids
+                )
+                flags[match.id].stage_item_input2_conflict = (
+                    flags[match.id].stage_item_input2_conflict
+                    or match.stage_item_input2_id in conflicting_input_ids
+                )
 
-                matches_with_conflicts.add(match1.id)
-                matches_with_conflicts.add(match2.id)
+
+def _set_winner_of_precedence_conflicts(
+    matches: list[MatchWithDetailsDefinitive | MatchWithDetails],
+    flags: dict[MatchId, MatchConflictFlags],
+) -> None:
+    matches_by_id = {match.id: match for match in matches}
 
     for match in matches:
-        if match.id not in matches_with_conflicts:
-            conflicts_to_clear.add(match.id)
+        if match.start_time is None:
+            continue
+
+        feeder_ids = [
+            match.stage_item_input1_winner_from_match_id,
+            match.stage_item_input2_winner_from_match_id,
+        ]
+        for feeder_id in feeder_ids:
+            if feeder_id is None:
+                continue
+            feeder = matches_by_id.get(feeder_id)
+            if (
+                feeder is not None
+                and feeder.start_time is not None
+                and match.start_time < feeder.end_time
+            ):
+                flags[match.id].precedence_conflict = True
+
+
+def _get_stage_item_end_times(
+    stages: list[StageWithStageItems],
+) -> dict[StageItemId, datetime_utc]:
+    stage_item_end_times: dict[StageItemId, datetime_utc] = {}
+    for stage in stages:
+        for stage_item in stage.stage_items:
+            latest_end_time: datetime_utc | None = None
+            for round_ in stage_item.rounds:
+                for match in round_.matches:
+                    if match.start_time is None:
+                        continue
+                    if latest_end_time is None or match.end_time > latest_end_time:
+                        latest_end_time = match.end_time
+            if latest_end_time is not None:
+                stage_item_end_times[stage_item.id] = latest_end_time
+    return stage_item_end_times
+
+
+def _set_cross_stage_precedence_conflicts(
+    stages: list[StageWithStageItems],
+    flags: dict[MatchId, MatchConflictFlags],
+) -> None:
+    stage_item_end_times = _get_stage_item_end_times(stages)
+
+    for match in _get_all_matches(stages):
+        if match.start_time is None:
+            continue
+
+        for stage_item_input in (match.stage_item_input1, match.stage_item_input2):
+            if stage_item_input is None or stage_item_input.winner_from_stage_item_id is None:
+                continue
+            source_end_time = stage_item_end_times.get(stage_item_input.winner_from_stage_item_id)
+            if source_end_time is not None and match.start_time < source_end_time:
+                flags[match.id].precedence_conflict = True
+
+
+def _set_short_break_conflicts(
+    matches: list[MatchWithDetailsDefinitive | MatchWithDetails],
+    default_break_minutes: int,
+    flags: dict[MatchId, MatchConflictFlags],
+) -> None:
+    matches_by_court: defaultdict[CourtId, list[MatchWithDetailsDefinitive | MatchWithDetails]] = (
+        defaultdict(list)
+    )
+    for match in matches:
+        if match.court_id is not None and match.start_time is not None:
+            matches_by_court[match.court_id].append(match)
+
+    for court_matches in matches_by_court.values():
+        scheduled = sorted(court_matches, key=lambda match: (match.start_time, match.id))
+        for previous, match in zip(scheduled, scheduled[1:], strict=False):
+            assert previous.start_time is not None
+            assert match.start_time is not None
+            break_minutes = (match.start_time - previous.end_time).total_seconds() / 60
+            if break_minutes < default_break_minutes:
+                flags[match.id].short_break_conflict = True
+
+
+def get_match_conflict_flags(
+    stages: list[StageWithStageItems], default_break_minutes: int
+) -> dict[MatchId, MatchConflictFlags]:
+    matches = _get_all_matches(stages)
+    flags = {match.id: MatchConflictFlags() for match in matches}
+
+    _set_team_overlap_conflicts(matches, flags)
+    _set_winner_of_precedence_conflicts(matches, flags)
+    _set_cross_stage_precedence_conflicts(stages, flags)
+    _set_short_break_conflicts(matches, default_break_minutes, flags)
+
+    return flags
+
+
+def get_conflicting_matches(
+    stages: list[StageWithStageItems],
+) -> tuple[
+    defaultdict[MatchId, list[bool]],
+    set[MatchId],
+]:
+    flags = get_match_conflict_flags(stages, default_break_minutes=0)
+    conflicts_to_set: defaultdict[MatchId, list[bool]] = defaultdict(lambda: [False, False])
+    conflicts_to_clear = set()
+
+    for match_id, conflict_flags in flags.items():
+        if conflict_flags.stage_item_input1_conflict or conflict_flags.stage_item_input2_conflict:
+            conflicts_to_set[match_id] = [
+                conflict_flags.stage_item_input1_conflict,
+                conflict_flags.stage_item_input2_conflict,
+            ]
+        else:
+            conflicts_to_clear.add(match_id)
 
     assert set(conflicts_to_set.keys()).intersection(conflicts_to_clear) == set()
     return conflicts_to_set, conflicts_to_clear
 
 
-async def set_conflicts(
-    conflicts_to_set: dict[MatchId, list[bool]],
-    conflicts_to_clear: set[MatchId],
-) -> None:
-    for match_id, conflict in conflicts_to_set.items():
+async def set_conflicts(match_conflicts: dict[MatchId, MatchConflictFlags]) -> None:
+    for match_id, conflict in match_conflicts.items():
         await database.execute(
             """
             UPDATE matches
             SET
-                stage_item_input1_conflict = :conflict1_id,
-                stage_item_input2_conflict = :conflict2_id
+                stage_item_input1_conflict = :stage_item_input1_conflict,
+                stage_item_input2_conflict = :stage_item_input2_conflict,
+                precedence_conflict = :precedence_conflict,
+                short_break_conflict = :short_break_conflict
             WHERE id = :match_id
             """,
             values={
                 "match_id": match_id,
-                "conflict1_id": conflict[0],
-                "conflict2_id": conflict[1],
+                "stage_item_input1_conflict": conflict.stage_item_input1_conflict,
+                "stage_item_input2_conflict": conflict.stage_item_input2_conflict,
+                "precedence_conflict": conflict.precedence_conflict,
+                "short_break_conflict": conflict.short_break_conflict,
             },
         )
 
-    for match_id in conflicts_to_clear:
-        await database.execute(
-            """
-            UPDATE matches
-            SET
-                stage_item_input1_conflict = false,
-                stage_item_input2_conflict = false
-            WHERE id = :match_id
-            """,
-            values={"match_id": match_id},
-        )
 
+async def handle_conflicts(
+    stages: list[StageWithStageItems], default_break_minutes: int | None = None
+) -> None:
+    if len(stages) < 1:
+        return
 
-async def handle_conflicts(stages: list[StageWithStageItems]) -> None:
-    conflicts_to_set, conflicts_to_clear = get_conflicting_matches(stages)
-    await set_conflicts(conflicts_to_set, conflicts_to_clear)
+    if default_break_minutes is None:
+        from bracket.sql.tournaments import sql_get_tournament
+
+        tournament = await sql_get_tournament(stages[0].tournament_id)
+        default_break_minutes = tournament.margin_minutes
+
+    await set_conflicts(get_match_conflict_flags(stages, default_break_minutes))

--- a/backend/bracket/models/db/match.py
+++ b/backend/bracket/models/db/match.py
@@ -30,6 +30,8 @@ class MatchBaseInsertable(BaseModelORM):
     court_id: CourtId | None = None
     stage_item_input1_conflict: bool
     stage_item_input2_conflict: bool
+    precedence_conflict: bool = False
+    short_break_conflict: bool = False
     state: MatchState = MatchState.NOT_STARTED
     completed_at: datetime_utc | None = None
 

--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -225,10 +225,13 @@ async def create_match(
 async def schedule_matches(
     tournament_id: TournamentId,
     _: UserPublic = Depends(user_authenticated_for_tournament),
-    __: Tournament = Depends(disallow_archived_tournament),
+    tournament: Tournament = Depends(disallow_archived_tournament),
 ) -> SuccessResponse:
     stages = await get_full_tournament_details(tournament_id)
     await schedule_all_unscheduled_matches(tournament_id, stages)
+    await handle_conflicts(
+        await get_full_tournament_details(tournament_id), tournament.margin_minutes
+    )
     return SuccessResponse()
 
 
@@ -237,14 +240,16 @@ async def schedule_matches(
 )
 async def unschedule_match(
     tournament_id: TournamentId,
-    __: Tournament = Depends(disallow_archived_tournament),
+    tournament: Tournament = Depends(disallow_archived_tournament),
     _: UserPublic = Depends(user_authenticated_for_tournament),
     match_row: Match = Depends(match_dependency),
 ) -> SuccessResponse:
     validate_match_can_be_unscheduled(match_row)
     await sql_unschedule_match(match_row.id)
 
-    await handle_conflicts(await get_full_tournament_details(tournament_id))
+    await handle_conflicts(
+        await get_full_tournament_details(tournament_id), tournament.margin_minutes
+    )
     return SuccessResponse()
 
 
@@ -260,7 +265,9 @@ async def reschedule_match(
 ) -> SuccessResponse:
     await check_foreign_keys_belong_to_tournament(body, tournament_id)
     await handle_match_reschedule(tournament, body, match_id)
-    await handle_conflicts(await get_full_tournament_details(tournament_id))
+    await handle_conflicts(
+        await get_full_tournament_details(tournament_id), tournament.margin_minutes
+    )
     return SuccessResponse()
 
 
@@ -274,7 +281,9 @@ async def swap_matches(
     await check_foreign_keys_belong_to_tournament(body, tournament_id)
     async with database.transaction():
         await handle_match_swap(tournament, body)
-        await handle_conflicts(await get_full_tournament_details(tournament_id))
+        await handle_conflicts(
+            await get_full_tournament_details(tournament_id), tournament.margin_minutes
+        )
     return SuccessResponse()
 
 
@@ -315,7 +324,9 @@ async def update_match_by_id(
         # The match's new footprint and the shifted start times behind it can
         # create or resolve overlaps with any court, so refresh the persisted
         # conflict flags like the reschedule/swap/unschedule endpoints do.
-        await handle_conflicts(await get_full_tournament_details(tournament_id))
+        await handle_conflicts(
+            await get_full_tournament_details(tournament_id), tournament.margin_minutes
+        )
 
     if stage_item.type == StageType.SINGLE_ELIMINATION:
         await update_inputs_in_subsequent_elimination_rounds(round_.id, stage_item, {match_id})

--- a/backend/bracket/schema.py
+++ b/backend/bracket/schema.py
@@ -162,6 +162,8 @@ matches = Table(
     Column("stage_item_input2_id", BigInteger, ForeignKey("stage_item_inputs.id"), nullable=True),
     Column("stage_item_input1_conflict", Boolean, nullable=False),
     Column("stage_item_input2_conflict", Boolean, nullable=False),
+    Column("precedence_conflict", Boolean, nullable=False, server_default="f"),
+    Column("short_break_conflict", Boolean, nullable=False, server_default="f"),
     Column(
         "stage_item_input1_winner_from_match_id",
         BigInteger,

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -458,9 +458,19 @@
             "title": "Id",
             "type": "integer"
           },
+          "precedence_conflict": {
+            "default": false,
+            "title": "Precedence Conflict",
+            "type": "boolean"
+          },
           "round_id": {
             "title": "Round Id",
             "type": "integer"
+          },
+          "short_break_conflict": {
+            "default": false,
+            "title": "Short Break Conflict",
+            "type": "boolean"
           },
           "stage_item_input1": {
             "anyOf": [
@@ -584,6 +594,8 @@
           "court_id",
           "stage_item_input1_conflict",
           "stage_item_input2_conflict",
+          "precedence_conflict",
+          "short_break_conflict",
           "state",
           "completed_at",
           "stage_item_input1_id",
@@ -902,9 +914,19 @@
             ],
             "title": "Level Id"
           },
+          "precedence_conflict": {
+            "default": false,
+            "title": "Precedence Conflict",
+            "type": "boolean"
+          },
           "round_id": {
             "title": "Round Id",
             "type": "integer"
+          },
+          "short_break_conflict": {
+            "default": false,
+            "title": "Short Break Conflict",
+            "type": "boolean"
           },
           "stage_item_input1": {
             "anyOf": [
@@ -1028,6 +1050,8 @@
           "court_id",
           "stage_item_input1_conflict",
           "stage_item_input2_conflict",
+          "precedence_conflict",
+          "short_break_conflict",
           "state",
           "completed_at",
           "stage_item_input1_id",
@@ -1113,9 +1137,19 @@
             ],
             "title": "Level Id"
           },
+          "precedence_conflict": {
+            "default": false,
+            "title": "Precedence Conflict",
+            "type": "boolean"
+          },
           "round_id": {
             "title": "Round Id",
             "type": "integer"
+          },
+          "short_break_conflict": {
+            "default": false,
+            "title": "Short Break Conflict",
+            "type": "boolean"
           },
           "stage_item_input1": {
             "anyOf": [
@@ -1233,6 +1267,8 @@
           "court_id",
           "stage_item_input1_conflict",
           "stage_item_input2_conflict",
+          "precedence_conflict",
+          "short_break_conflict",
           "state",
           "completed_at",
           "stage_item_input1_id",

--- a/backend/tests/integration_tests/api/planner_conflict_flags_test.py
+++ b/backend/tests/integration_tests/api/planner_conflict_flags_test.py
@@ -1,0 +1,302 @@
+from typing import cast
+
+import pytest
+from heliclockter import timedelta
+
+from bracket.models.db.match import MatchRescheduleBody, MatchState, MatchSwapBody
+from bracket.models.db.stage_item_inputs import StageItemInputInsertable
+from bracket.schema import matches
+from bracket.utils.dummy_records import (
+    DUMMY_COURT1,
+    DUMMY_COURT2,
+    DUMMY_MATCH1,
+    DUMMY_ROUND1,
+    DUMMY_ROUND3,
+    DUMMY_STAGE1,
+    DUMMY_STAGE_ITEM1,
+    DUMMY_TEAM1,
+    DUMMY_TEAM2,
+    DUMMY_TEAM3,
+    DUMMY_TEAM4,
+)
+from bracket.utils.http import HTTPMethod
+from bracket.utils.types import JsonDict
+from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
+from tests.integration_tests.models import AuthContext
+from tests.integration_tests.sql import (
+    assert_row_count_and_clear,
+    inserted_court,
+    inserted_match,
+    inserted_round,
+    inserted_stage,
+    inserted_stage_item,
+    inserted_stage_item_input,
+    inserted_team,
+)
+
+
+def _match_from_stages_response(response: JsonDict, match_id: int) -> JsonDict:
+    for stage in response["data"]:
+        for stage_item in stage["stage_items"]:
+            for round_ in stage_item["rounds"]:
+                for match in round_["matches"]:
+                    if match["id"] == match_id:
+                        return cast("JsonDict", match)
+    raise AssertionError(f"Could not find match {match_id}")
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_precedence_flag_appears_and_clears_through_api(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    tournament = auth_context.tournament
+    later_start = tournament.start_time + timedelta(minutes=30)
+
+    async with (
+        inserted_stage(DUMMY_STAGE1.model_copy(update={"tournament_id": tournament.id})) as stage,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item.id})
+        ) as semi_round,
+        inserted_round(
+            DUMMY_ROUND3.model_copy(update={"stage_item_id": stage_item.id})
+        ) as final_round,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament.id})) as team1,
+        inserted_team(DUMMY_TEAM2.model_copy(update={"tournament_id": tournament.id})) as team2,
+        inserted_team(DUMMY_TEAM3.model_copy(update={"tournament_id": tournament.id})) as team3,
+        inserted_team(DUMMY_TEAM4.model_copy(update={"tournament_id": tournament.id})) as team4,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=1,
+                team_id=team1.id,
+                tournament_id=tournament.id,
+                stage_item_id=stage_item.id,
+            )
+        ) as input1,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=2,
+                team_id=team2.id,
+                tournament_id=tournament.id,
+                stage_item_id=stage_item.id,
+            )
+        ) as input2,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=3,
+                team_id=team3.id,
+                tournament_id=tournament.id,
+                stage_item_id=stage_item.id,
+            )
+        ) as input3,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=4,
+                team_id=team4.id,
+                tournament_id=tournament.id,
+                stage_item_id=stage_item.id,
+            )
+        ) as input4,
+        inserted_court(DUMMY_COURT1.model_copy(update={"tournament_id": tournament.id})) as court1,
+        inserted_court(DUMMY_COURT2.model_copy(update={"tournament_id": tournament.id})) as court2,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": semi_round.id,
+                    "stage_item_input1_id": input1.id,
+                    "stage_item_input2_id": input2.id,
+                    "court_id": court1.id,
+                    "start_time": tournament.start_time,
+                    "state": MatchState.NOT_STARTED,
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "completed_at": None,
+                }
+            )
+        ) as semi1,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": semi_round.id,
+                    "stage_item_input1_id": input3.id,
+                    "stage_item_input2_id": input4.id,
+                    "court_id": court1.id,
+                    "start_time": tournament.start_time + timedelta(minutes=15),
+                    "state": MatchState.NOT_STARTED,
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "completed_at": None,
+                }
+            )
+        ) as semi2,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": final_round.id,
+                    "stage_item_input1_id": None,
+                    "stage_item_input2_id": None,
+                    "stage_item_input1_winner_from_match_id": semi1.id,
+                    "stage_item_input2_winner_from_match_id": semi2.id,
+                    "court_id": court2.id,
+                    "start_time": tournament.start_time + timedelta(minutes=5),
+                    "state": MatchState.NOT_STARTED,
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "completed_at": None,
+                }
+            )
+        ) as final,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": final_round.id,
+                    "stage_item_input1_id": input1.id,
+                    "stage_item_input2_id": input4.id,
+                    "court_id": court2.id,
+                    "start_time": later_start,
+                    "state": MatchState.NOT_STARTED,
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "completed_at": None,
+                }
+            )
+        ) as later_match,
+    ):
+        body = MatchRescheduleBody(
+            old_court_id=court2.id,
+            old_position=0,
+            new_court_id=court2.id,
+            new_position=0,
+        )
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                f"matches/{final.id}/reschedule",
+                auth_context,
+                json=body.model_dump(mode="json", exclude_none=False),
+            )
+            == SUCCESS_RESPONSE
+        )
+        response = await send_tournament_request(HTTPMethod.GET, "stages", auth_context)
+        assert _match_from_stages_response(response, final.id)["precedence_conflict"] is True
+
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                "matches/swap",
+                auth_context,
+                json=MatchSwapBody(match1_id=final.id, match2_id=later_match.id).model_dump(
+                    mode="json"
+                ),
+            )
+            == SUCCESS_RESPONSE
+        )
+        response = await send_tournament_request(HTTPMethod.GET, "stages", auth_context)
+        assert _match_from_stages_response(response, final.id)["precedence_conflict"] is False
+
+        await assert_row_count_and_clear(matches, 0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_short_break_flag_appears_and_clears_through_api(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    tournament = auth_context.tournament
+
+    async with (
+        inserted_stage(DUMMY_STAGE1.model_copy(update={"tournament_id": tournament.id})) as stage,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item,
+        inserted_round(DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item.id})) as round_,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament.id})) as team1,
+        inserted_team(DUMMY_TEAM2.model_copy(update={"tournament_id": tournament.id})) as team2,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=1,
+                team_id=team1.id,
+                tournament_id=tournament.id,
+                stage_item_id=stage_item.id,
+            )
+        ) as input1,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=2,
+                team_id=team2.id,
+                tournament_id=tournament.id,
+                stage_item_id=stage_item.id,
+            )
+        ) as input2,
+        inserted_court(DUMMY_COURT1.model_copy(update={"tournament_id": tournament.id})) as court,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_.id,
+                    "stage_item_input1_id": input1.id,
+                    "stage_item_input2_id": input2.id,
+                    "court_id": court.id,
+                    "start_time": tournament.start_time,
+                    "state": MatchState.NOT_STARTED,
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "completed_at": None,
+                }
+            )
+        ) as first_match,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_.id,
+                    "stage_item_input1_id": input1.id,
+                    "stage_item_input2_id": input2.id,
+                    "court_id": court.id,
+                    "start_time": tournament.start_time + timedelta(minutes=12),
+                    "state": MatchState.NOT_STARTED,
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "completed_at": None,
+                }
+            )
+        ) as second_match,
+    ):
+        body = MatchRescheduleBody(
+            old_court_id=court.id,
+            old_position=1,
+            new_court_id=court.id,
+            new_position=1,
+        )
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                f"matches/{second_match.id}/reschedule",
+                auth_context,
+                json=body.model_dump(mode="json", exclude_none=False),
+            )
+            == SUCCESS_RESPONSE
+        )
+        response = await send_tournament_request(HTTPMethod.GET, "stages", auth_context)
+        assert (
+            _match_from_stages_response(response, second_match.id)["short_break_conflict"] is True
+        )
+
+        assert (
+            await send_tournament_request(
+                HTTPMethod.PUT,
+                f"matches/{first_match.id}",
+                auth_context,
+                json={"round_id": round_.id, "custom_duration_minutes": 7},
+            )
+            == SUCCESS_RESPONSE
+        )
+        response = await send_tournament_request(HTTPMethod.GET, "stages", auth_context)
+        assert (
+            _match_from_stages_response(response, second_match.id)["short_break_conflict"] is False
+        )
+
+        await assert_row_count_and_clear(matches, 0)

--- a/backend/tests/unit_tests/conflicts_test.py
+++ b/backend/tests/unit_tests/conflicts_test.py
@@ -2,16 +2,32 @@ from datetime import timedelta
 
 import pytest
 
-from bracket.logic.planning.conflicts import get_conflicting_matches, matches_overlap
-from bracket.models.db.util import StageWithStageItems
+from bracket.logic.planning.conflicts import (
+    get_conflicting_matches,
+    get_match_conflict_flags,
+    matches_overlap,
+)
+from bracket.models.db.match import MatchState, MatchWithDetailsDefinitive
+from bracket.models.db.stage_item_inputs import StageItemInputTentative
+from bracket.models.db.util import RoundWithMatches, StageWithStageItems
 from bracket.utils.dummy_records import DUMMY_MOCK_TIME
-from bracket.utils.id_types import StageId, TournamentId
+from bracket.utils.id_types import (
+    CourtId,
+    MatchId,
+    RoundId,
+    StageId,
+    StageItemId,
+    StageItemInputId,
+    TournamentId,
+)
 from tests.integration_tests.mocks import MOCK_NOW
 from tests.unit_tests.mocks import (
+    get_2_definitive_and_2_tentative_matches_mock,
     get_2_definitive_matches_mock,
     get_one_round_with_two_definitive_matches,
     get_stage_item_inputs_mock,
     get_stage_item_mock,
+    get_two_round_with_one_tentative_match_each,
     make_simple_match,
 )
 
@@ -127,3 +143,127 @@ def test_get_conflicting_matches_back_to_back_no_conflict() -> None:
     """Back-to-back matches (end1 == start2) must not be flagged."""
     stage = _make_stage(T, T + timedelta(minutes=90))
     assert get_conflicting_matches([stage]) == ({}, {-1, -2})
+
+
+def test_get_match_conflict_flags_marks_match_before_winner_feeder() -> None:
+    """A match that starts before one of its winner-of feeder matches ends is flagged."""
+    tournament_id = TournamentId(-1)
+    stage_item_inputs = get_stage_item_inputs_mock(tournament_id)
+    feeder1, feeder2, final, consolation = get_2_definitive_and_2_tentative_matches_mock(
+        stage_item_inputs
+    )
+    final = final.model_copy(
+        update={
+            "court_id": CourtId(-3),
+            "start_time": T + timedelta(minutes=30),
+        }
+    )
+    first_round = get_one_round_with_two_definitive_matches(feeder1, feeder2)
+    final_round, _ = get_two_round_with_one_tentative_match_each(final, consolation)
+    stage = StageWithStageItems(
+        id=StageId(-1),
+        tournament_id=tournament_id,
+        name="",
+        created=MOCK_NOW,
+        is_active=False,
+        stage_items=[get_stage_item_mock(stage_item_inputs, [first_round, final_round])],
+    )
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=5)
+
+    assert flags[final.id].precedence_conflict is True
+    assert flags[feeder1.id].precedence_conflict is False
+    assert flags[feeder2.id].precedence_conflict is False
+
+
+def test_get_match_conflict_flags_marks_match_before_feeding_stage_item_finishes() -> None:
+    """A match using a previous stage item's ranking waits for that group's last match."""
+    tournament_id = TournamentId(-1)
+    source_inputs = get_stage_item_inputs_mock(tournament_id)
+    source_match1, source_match2 = get_2_definitive_matches_mock(
+        source_inputs,
+        match1_start_time=T,
+        match2_start_time=T + timedelta(minutes=10),
+        duration_minutes=10,
+    )
+    source_round = get_one_round_with_two_definitive_matches(source_match1, source_match2)
+    source_stage_item = get_stage_item_mock(source_inputs, [source_round])
+
+    target_input = StageItemInputTentative(
+        id=StageItemInputId(-10),
+        slot=1,
+        tournament_id=tournament_id,
+        stage_item_id=StageItemId(-2),
+        winner_from_stage_item_id=source_stage_item.id,
+        winner_position=1,
+    )
+    target_match = MatchWithDetailsDefinitive(
+        id=MatchId(-3),
+        stage_item_input1=target_input,
+        stage_item_input2=source_inputs[1],
+        stage_item_input1_id=target_input.id,
+        stage_item_input2_id=source_inputs[1].id,
+        created=T,
+        start_time=T + timedelta(minutes=15),
+        duration_minutes=10,
+        round_id=RoundId(-4),
+        court_id=CourtId(-3),
+        stage_item_input1_score=0,
+        stage_item_input2_score=0,
+        stage_item_input1_conflict=False,
+        stage_item_input2_conflict=False,
+        state=MatchState.NOT_STARTED,
+        completed_at=None,
+    )
+    target_round = RoundWithMatches(
+        id=RoundId(-4),
+        matches=[target_match],
+        stage_item_id=StageItemId(-2),
+        created=T,
+        is_draft=False,
+        name="",
+    )
+    target_stage_item = get_stage_item_mock(source_inputs, [target_round]).model_copy(
+        update={"id": StageItemId(-2), "inputs": [target_input, source_inputs[1]]}
+    )
+    stage = StageWithStageItems(
+        id=StageId(-1),
+        tournament_id=tournament_id,
+        name="",
+        created=MOCK_NOW,
+        is_active=False,
+        stage_items=[source_stage_item, target_stage_item],
+    )
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=5)
+
+    assert flags[target_match.id].precedence_conflict is True
+    assert flags[source_match1.id].precedence_conflict is False
+    assert flags[source_match2.id].precedence_conflict is False
+
+
+def test_get_match_conflict_flags_marks_sub_default_break_on_later_match() -> None:
+    """A court gap shorter than the default break flags the later match only."""
+    tournament_id = TournamentId(-1)
+    stage_item_inputs = get_stage_item_inputs_mock(tournament_id)
+    match1, match2 = get_2_definitive_matches_mock(
+        stage_item_inputs,
+        match1_start_time=T,
+        match2_start_time=T + timedelta(minutes=12),
+        duration_minutes=10,
+    )
+    match2 = match2.model_copy(update={"court_id": match1.court_id})
+    round_ = get_one_round_with_two_definitive_matches(match1, match2)
+    stage = StageWithStageItems(
+        id=StageId(-1),
+        tournament_id=tournament_id,
+        name="",
+        created=MOCK_NOW,
+        is_active=False,
+        stage_items=[get_stage_item_mock(stage_item_inputs, [round_])],
+    )
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=5)
+
+    assert flags[match1.id].short_break_conflict is False
+    assert flags[match2.id].short_break_conflict is True

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -196,6 +196,8 @@
     "password_input_label": "Passwort",
     "password_input_placeholder": "Ihr Passwort",
     "placement_conflict_preview_label": "Würde ein Team doppelt belegen",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "plan_next_round_button": "Nächste Runde planen",
     "plan_next_stage_button": "Nächste Phase starten",
     "plan_previous_stage_button": "Zur vorherigen Phase zurückgehen",

--- a/frontend/public/locales/el/common.json
+++ b/frontend/public/locales/el/common.json
@@ -216,6 +216,8 @@
     "save_players_button": "Αποθήκευση παικτών",
     "save_ranking_button": "Αποθήκευση Κατάταξης",
     "schedule_description": "Προγραμματισμός Όλων Των Μη Προγραμματισμένων Αγώνων",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "schedule_title": "Χρονοδιάγραμμα",
     "score_of_label": "Βαθμολογία από",
     "search_placeholder": "Αναζήτηση ...",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -155,6 +155,8 @@
     "match_filter_option_past": "Hide past matches",
     "max_results_input_label": "Max results",
     "match_scheduled_before_previous_stage_label": "Scheduled before a match of an earlier stage on this court",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "members_table_header": "Members",
     "minutes": "minutes",
     "miscellaneous_label": "Allow players to be in multiple teams",

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -216,6 +216,8 @@
     "save_players_button": "Guardar jugadores",
     "save_ranking_button": "Guardar Clasificación",
     "schedule_description": "Programar todas las partidas no programadas",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "schedule_title": "Programar",
     "score_of_label": "Puntaje de",
     "search_placeholder": "Buscar...",

--- a/frontend/public/locales/fa/common.json
+++ b/frontend/public/locales/fa/common.json
@@ -216,6 +216,8 @@
     "save_players_button": "ذخیره بازیکنان",
     "save_ranking_button": "ذخیره رتبه‌بندی",
     "schedule_description": "برنامه‌ریزی بازی‌ها",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "schedule_title": "برنامه‌ریزی",
     "score_of_label": "امتیاز",
     "search_placeholder": "جستجو...",

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -216,6 +216,8 @@
     "save_players_button": "Enregistrer les joueurs",
     "save_ranking_button": "Enregistrer le barème",
     "schedule_description": "Planifier tous les matchs non programmés",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "schedule_title": "Planifier",
     "score_of_label": "Points de",
     "search_placeholder": "Rechercher...",

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -216,6 +216,8 @@
     "save_players_button": "Salva giocatori",
     "save_ranking_button": "Salva Classifica",
     "schedule_description": "Pianifica Tutte Le Partite Non Programmate",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "schedule_title": "Pianifica",
     "score_of_label": "Punteggio di",
     "search_placeholder": "Cerca ...",

--- a/frontend/public/locales/ja/common.json
+++ b/frontend/public/locales/ja/common.json
@@ -216,6 +216,8 @@
     "save_players_button": "プレイヤーを保存",
     "save_ranking_button": "保存ランキング",
     "schedule_description": "全ての予定されていない試合をスケジュール",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "schedule_title": "スケジュール",
     "score_of_label": "得点：",
     "search_placeholder": "検索...",

--- a/frontend/public/locales/nl/common.json
+++ b/frontend/public/locales/nl/common.json
@@ -216,6 +216,8 @@
     "save_players_button": "Spelers opslaan",
     "save_ranking_button": "Sla Ranglijst op",
     "schedule_description": "Plan alle ongeplande wedstrijden",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "schedule_title": "Schema",
     "score_of_label": "Score van",
     "search_placeholder": "Zoeken ...",

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -216,6 +216,8 @@
     "save_players_button": "Salvar jogadores",
     "save_ranking_button": "Salvar Ranking",
     "schedule_description": "Agendar todos os jogos não agendados",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "schedule_title": "Agendamento",
     "score_of_label": "Pontuação de",
     "search_placeholder": "Pesquisar ...",

--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -216,6 +216,8 @@
     "save_players_button": "Spara spelare",
     "save_ranking_button": "Spara Ranking",
     "schedule_description": "Schemalägg alla oschemalagda matchningar",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "schedule_title": "Schema",
     "score_of_label": "Poäng av",
     "search_placeholder": "Sök ...",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -216,6 +216,8 @@
     "save_players_button": "保存玩家",
     "save_ranking_button": "保存排名",
     "schedule_description": "安排所有未安排的比赛",
+    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "short_break_conflict_label": "Break before this match is shorter than the default",
     "schedule_title": "安排",
     "score_of_label": "得分",
     "search_placeholder": "搜索...",

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -190,13 +190,29 @@ function MatchCard({
       {label}
     </Badge>
   );
-  const violationIcon = isViolation ? (
-    <Tooltip label={t('match_scheduled_before_previous_stage_label')}>
+  const precedenceWarningLabel = match.precedence_conflict
+    ? t('precedence_conflict_label', 'Starts before a feeder match has finished')
+    : t('match_scheduled_before_previous_stage_label');
+  const violationIcon =
+    isViolation || match.precedence_conflict ? (
+      <Tooltip label={precedenceWarningLabel}>
+        <Box
+          component="span"
+          style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}
+        >
+          <AiFillWarning color="orange" />
+        </Box>
+      </Tooltip>
+    ) : null;
+  const shortBreakIcon = match.short_break_conflict ? (
+    <Tooltip
+      label={t('short_break_conflict_label', 'Break before this match is shorter than the default')}
+    >
       <Box
         component="span"
         style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}
       >
-        <AiFillWarning color="orange" />
+        <AiFillWarning color="var(--mantine-color-yellow-filled)" />
       </Box>
     </Tooltip>
   ) : null;
@@ -272,6 +288,7 @@ function MatchCard({
               ? contextBadge(contextParts.join(' · '))
               : null}
             {placementWarningIcon}
+            {shortBreakIcon}
             {violationIcon}
           </Flex>
         )}
@@ -285,6 +302,7 @@ function MatchCard({
           {rows < 3 && statusIndicator}
           {match.stage_item_input1_conflict && <AiFillWarning color="red" />}
           {rows < 3 && placementWarningIcon}
+          {rows < 3 && shortBreakIcon}
           {rows === 1 &&
             match.stage_item_input2_conflict &&
             !(mergeConflictIcons && match.stage_item_input1_conflict) && (

--- a/frontend/src/openapi/types.gen.ts
+++ b/frontend/src/openapi/types.gen.ts
@@ -286,9 +286,17 @@ export type Match = {
    */
   id: number;
   /**
+   * Precedence Conflict
+   */
+  precedence_conflict: boolean;
+  /**
    * Round Id
    */
   round_id: number;
+  /**
+   * Short Break Conflict
+   */
+  short_break_conflict: boolean;
   /**
    * Stage Item Input1
    */
@@ -489,9 +497,17 @@ export type MatchWithDetails = {
    */
   level_id: number | null;
   /**
+   * Precedence Conflict
+   */
+  precedence_conflict: boolean;
+  /**
    * Round Id
    */
   round_id: number;
+  /**
+   * Short Break Conflict
+   */
+  short_break_conflict: boolean;
   /**
    * Stage Item Input1
    */
@@ -573,9 +589,17 @@ export type MatchWithDetailsDefinitive = {
    */
   level_id: number | null;
   /**
+   * Precedence Conflict
+   */
+  precedence_conflict: boolean;
+  /**
    * Round Id
    */
   round_id: number;
+  /**
+   * Short Break Conflict
+   */
+  short_break_conflict: boolean;
   /**
    * Stage Item Input1
    */


### PR DESCRIPTION
## Summary
- add persisted advisory flags for precedence violations and sub-default breaks
- detect winner-of, cross-stage feeder, and short-break conflicts during planner mutations
- expose new flags through OpenAPI/client and render planner warning icons

Closes #76
Part of #73

## Tests
- backend: `ENVIRONMENT=CI uv run pytest . -q`
- backend: `ENVIRONMENT=CI uv run mypy bracket tests cli.py`
- backend: `ruff check` / `ruff format --check` on touched files via nixpkgs ruff
- frontend: `pnpm run typecheck`
- frontend: `pnpm run prettier:check`
- frontend: `pnpm run test:unit`

Note: `uv run pyrefly check` could not run on this NixOS environment because the venv executable hits the dynamic-linker/stub-ld issue.