### PR TITLE
Add Escape key handler to cancel match selection

### DIFF
--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -96,6 +96,27 @@ export default function SchedulePage() {
     return () => window.clearInterval(intervalId);
   }, []);
 
+  // Escape cancels an active match selection, the keyboard equivalent of the
+  // selection pill's "cancel" button. The action sheet and details modal own
+  // Escape while they're open (Mantine closes them first), so only act on the
+  // plain selected states here.
+  useEffect(() => {
+    if (
+      detailsMatchId != null ||
+      (planner.selection.kind !== 'match-selected' &&
+        planner.selection.kind !== 'tray-match-selected')
+    ) {
+      return undefined;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handlePlannerEvent({ type: 'cancel' });
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [planner.selection, detailsMatchId]);
+
   const { t } = useTranslation();
   const { tournamentData } = getTournamentIdFromRouter();
   // The schedule polls so co-organizers' changes show up, but holds still


### PR DESCRIPTION
## Summary
Added keyboard support for canceling active match selections in the tournament schedule page. Users can now press Escape to deselect a match, providing a keyboard equivalent to the cancel button on the selection pill.

## Key Changes
- Added a new `useEffect` hook that listens for Escape key presses
- The handler only activates when a match is selected (`match-selected` or `tray-match-selected` states) and no details modal is open
- Pressing Escape triggers the `cancel` event on the planner, clearing the selection
- The event listener is properly cleaned up on unmount and when selection state changes

## Implementation Details
- The effect respects modal/action sheet ownership of the Escape key—it only handles Escape when the details modal (`detailsMatchId`) is not open, allowing Mantine components to handle their own Escape behavior first
- Dependencies include `planner.selection` and `detailsMatchId` to ensure the handler reflects current UI state

https://claude.ai/code/session_01Xcrxe3x8u75Q3ducUCoWXy