### PR TITLE
✨ Schedule optimizer objective blend + later-stage precedence fix

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -25,7 +25,14 @@ from bracket.sql.matches import (
 )
 from bracket.sql.stages import get_full_tournament_details
 from bracket.sql.tournaments import sql_get_tournament
-from bracket.utils.id_types import CourtId, MatchId, StageItemId, StageItemInputId, TournamentId
+from bracket.utils.id_types import (
+    CourtId,
+    MatchId,
+    StageId,
+    StageItemId,
+    StageItemInputId,
+    TournamentId,
+)
 from bracket.utils.logging import logger
 from bracket.utils.types import assert_some
 
@@ -41,11 +48,31 @@ ScheduleMatch = MatchWithDetails | MatchWithDetailsDefinitive
 SOLVER_TIME_LIMIT_SECONDS = 5.0
 SOLVER_RANDOM_SEED = 77
 
+# Objective blend (PRD #73, issue #78). The schedule minimises a single weighted sum.
+# Makespan is the headline term; team rest keeps a player from going straight from one
+# match into the next; court locality keeps a group on few courts; group sync keeps the
+# stage items of a stage finishing each round at a similar time. The weights are fixed
+# constants (not user-configurable) and intentionally tunable here: every term is measured
+# in minutes (locality in court-count, scaled up to matter against minute-sized terms), so
+# the ratios below are what set the priorities. They were chosen so makespan and team rest
+# lead and locality/sync bend the schedule only where it is otherwise free; retune on a
+# realistic fixture (e.g. the dev-db seed) if the balance feels off.
+WEIGHT_MAKESPAN = 100
+WEIGHT_TEAM_REST = 10
+WEIGHT_COURT_LOCALITY = 5
+WEIGHT_GROUP_SYNC = 3
+
+# A team is considered rested once this many minutes separate the end of one of its matches
+# and the start of the next; gaps shorter than this are penalised, longer gaps are free.
+COMFORTABLE_REST_MINUTES = 30
+
 
 @dataclass(frozen=True)
 class _MatchContext:
     match: ScheduleMatch
+    stage_id: StageId
     stage_item_id: StageItemId
+    round_index: int
     input_ids: tuple[StageItemInputId, ...]
     cross_stage_source_ids: tuple[StageItemId, ...]
 
@@ -85,13 +112,15 @@ def _get_match_contexts(stages: list[StageWithStageItems]) -> list[_MatchContext
     return [
         _MatchContext(
             match=match,
+            stage_id=stage.id,
             stage_item_id=stage_item.id,
+            round_index=round_index,
             input_ids=_input_ids(match),
             cross_stage_source_ids=_cross_stage_source_ids(match),
         )
         for stage in stages
         for stage_item in stage.stage_items
-        for round_ in stage_item.rounds
+        for round_index, round_ in enumerate(stage_item.rounds)
         for match in round_.matches
     ]
 
@@ -186,7 +215,9 @@ def _add_movable_match_variables(
         match = context.match
         match_id = match.id
         start = model.NewIntVar(0, horizon, f"match_{match_id}_start")
-        start_slot = model.NewIntVar(0, horizon // block_minutes + 1, f"match_{match_id}_start_slot")
+        start_slot = model.NewIntVar(
+            0, horizon // block_minutes + 1, f"match_{match_id}_start_slot"
+        )
         model.Add(start == start_slot * block_minutes)
         end = model.NewIntVar(0, horizon + match.duration_minutes, f"match_{match_id}_end")
         model.Add(end == start + match.duration_minutes)
@@ -356,6 +387,115 @@ def _add_precedence_constraints(
         model.Add(starts[successor.match.id] >= ends[feeder.match.id] + default_break_minutes)
 
 
+def _add_team_rest_penalty(
+    model: Any,
+    movable_contexts: list[_MatchContext],
+    starts: dict[MatchId, Any],
+    ends: dict[MatchId, Any],
+    horizon: int,
+) -> list[Any]:
+    """Penalise how far each team's consecutive matches fall short of a comfortable rest.
+
+    For every pair of a team's movable matches the gap between them (later start minus
+    earlier end) is known to be non-negative because they already cannot overlap. The
+    shortfall ``max(0, COMFORTABLE_REST_MINUTES - gap)`` is summed and minimised, so the
+    solver spreads a team's matches whenever doing so is cheap on the headline terms.
+    """
+    matches_by_input: dict[StageItemInputId, list[MatchId]] = defaultdict(list)
+    for context in movable_contexts:
+        for input_id in set(context.input_ids):
+            matches_by_input[input_id].append(context.match.id)
+
+    shortfalls = []
+    for match_ids in matches_by_input.values():
+        for index, first_id in enumerate(match_ids):
+            for second_id in match_ids[index + 1 :]:
+                gap = model.NewIntVar(-horizon, horizon, f"rest_gap_{first_id}_{second_id}")
+                model.AddMaxEquality(
+                    gap,
+                    [starts[second_id] - ends[first_id], starts[first_id] - ends[second_id]],
+                )
+                shortfall = model.NewIntVar(
+                    0, COMFORTABLE_REST_MINUTES, f"rest_shortfall_{first_id}_{second_id}"
+                )
+                model.Add(shortfall >= COMFORTABLE_REST_MINUTES - gap)
+                shortfalls.append(shortfall)
+    return shortfalls
+
+
+def _add_court_locality_penalty(
+    model: Any,
+    movable_contexts: list[_MatchContext],
+    court_choices: dict[MatchId, dict[CourtId, Any]],
+) -> list[Any]:
+    """Penalise the number of distinct courts each stage item (group/bracket) spreads over.
+
+    For every (stage item, court) pair a boolean is forced on when any of the item's
+    matches is placed on that court, and the sum of those booleans is minimised. A group
+    that fits on one court without hurting the headline terms therefore stays put.
+    """
+    matches_by_item: dict[StageItemId, list[MatchId]] = defaultdict(list)
+    for context in movable_contexts:
+        matches_by_item[context.stage_item_id].append(context.match.id)
+
+    used_court_vars = []
+    for stage_item_id, match_ids in matches_by_item.items():
+        courts_in_item = {
+            court_id for match_id in match_ids for court_id in court_choices[match_id]
+        }
+        for court_id in courts_in_item:
+            used = model.NewBoolVar(f"item_{stage_item_id}_uses_court_{court_id}")
+            for match_id in match_ids:
+                model.Add(used >= court_choices[match_id][court_id])
+            used_court_vars.append(used)
+    return used_court_vars
+
+
+def _add_group_sync_penalty(
+    model: Any,
+    movable_contexts: list[_MatchContext],
+    ends: dict[MatchId, Any],
+    horizon: int,
+) -> list[Any]:
+    """Penalise divergence in round progress across the stage items of a stage.
+
+    Round progress is keyed by (stage, round index): for each round index present in at
+    least two of a stage's items, the spread between the earliest- and latest-finishing
+    item at that round is minimised. Keying on the round index (rather than assuming equal
+    round counts) keeps the term well-defined when stage items have different numbers of
+    rounds — items simply stop contributing once their rounds run out.
+    """
+    ends_by_stage_round_item: dict[tuple[StageId, int], dict[StageItemId, list[Any]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for context in movable_contexts:
+        key = (context.stage_id, context.round_index)
+        ends_by_stage_round_item[key][context.stage_item_id].append(ends[context.match.id])
+
+    spreads = []
+    for (stage_id, round_index), ends_by_item in ends_by_stage_round_item.items():
+        if len(ends_by_item) < 2:
+            continue
+        item_round_ends = []
+        for stage_item_id, match_ends in ends_by_item.items():
+            round_end = model.NewIntVar(
+                0, horizon, f"round_end_stage_{stage_id}_round_{round_index}_item_{stage_item_id}"
+            )
+            model.AddMaxEquality(round_end, match_ends)
+            item_round_ends.append(round_end)
+
+        latest = model.NewIntVar(0, horizon, f"round_latest_stage_{stage_id}_round_{round_index}")
+        earliest = model.NewIntVar(
+            0, horizon, f"round_earliest_stage_{stage_id}_round_{round_index}"
+        )
+        model.AddMaxEquality(latest, item_round_ends)
+        model.AddMinEquality(earliest, item_round_ends)
+        spread = model.NewIntVar(0, horizon, f"round_spread_stage_{stage_id}_round_{round_index}")
+        model.Add(spread == latest - earliest)
+        spreads.append(spread)
+    return spreads
+
+
 def _build_operations_from_solution(
     solver: Any,
     movable_contexts: list[_MatchContext],
@@ -460,7 +600,18 @@ def build_schedule_plan(
     )
     for context in movable_contexts:
         model.Add(makespan >= ends[context.match.id])
-    model.Minimize(makespan)
+
+    objective = WEIGHT_MAKESPAN * makespan
+    rest_shortfalls = _add_team_rest_penalty(model, movable_contexts, starts, ends, horizon)
+    if rest_shortfalls:
+        objective += WEIGHT_TEAM_REST * sum(rest_shortfalls)
+    used_court_vars = _add_court_locality_penalty(model, movable_contexts, court_choices)
+    if used_court_vars:
+        objective += WEIGHT_COURT_LOCALITY * sum(used_court_vars)
+    sync_spreads = _add_group_sync_penalty(model, movable_contexts, ends, horizon)
+    if sync_spreads:
+        objective += WEIGHT_GROUP_SYNC * sum(sync_spreads)
+    model.Minimize(objective)
 
     solver = cp_model.CpSolver()
     solver.parameters.max_time_in_seconds = SOLVER_TIME_LIMIT_SECONDS

--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -59,10 +59,10 @@ SOLVER_RANDOM_SEED = 77
 # the ratios below are what set the priorities. They were chosen so makespan and team rest
 # lead and locality/sync bend the schedule only where it is otherwise free; retune on a
 # realistic fixture (e.g. the dev-db seed) if the balance feels off.
-WEIGHT_MAKESPAN = 20
-WEIGHT_TEAM_REST = 10
+WEIGHT_MAKESPAN = 100
+WEIGHT_TEAM_REST = 13
+WEIGHT_GROUP_SYNC = 8
 WEIGHT_COURT_LOCALITY = 5
-WEIGHT_GROUP_SYNC = 3
 
 # A team is considered rested once this many minutes separate the end of one of its matches
 # and the start of the next; gaps shorter than this are penalised, longer gaps are free.

--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -16,8 +16,9 @@ from bracket.models.db.match import (
     MatchWithDetails,
     MatchWithDetailsDefinitive,
 )
+from bracket.models.db.stage_item_inputs import StageItemInputEmpty
 from bracket.models.db.tournament import Tournament
-from bracket.models.db.util import StageWithStageItems
+from bracket.models.db.util import StageItemWithRounds, StageWithStageItems
 from bracket.sql.courts import get_all_courts_in_tournament
 from bracket.sql.matches import (
     sql_reschedule_match_and_determine_duration,
@@ -27,6 +28,7 @@ from bracket.sql.stages import get_full_tournament_details
 from bracket.sql.tournaments import sql_get_tournament
 from bracket.utils.id_types import (
     CourtId,
+    LevelId,
     MatchId,
     StageId,
     StageItemId,
@@ -57,7 +59,7 @@ SOLVER_RANDOM_SEED = 77
 # the ratios below are what set the priorities. They were chosen so makespan and team rest
 # lead and locality/sync bend the schedule only where it is otherwise free; retune on a
 # realistic fixture (e.g. the dev-db seed) if the balance feels off.
-WEIGHT_MAKESPAN = 100
+WEIGHT_MAKESPAN = 20
 WEIGHT_TEAM_REST = 10
 WEIGHT_COURT_LOCALITY = 5
 WEIGHT_GROUP_SYNC = 3
@@ -70,11 +72,15 @@ COMFORTABLE_REST_MINUTES = 30
 @dataclass(frozen=True)
 class _MatchContext:
     match: ScheduleMatch
+    level_id: LevelId | None
     stage_id: StageId
     stage_item_id: StageItemId
     round_index: int
     input_ids: tuple[StageItemInputId, ...]
     cross_stage_source_ids: tuple[StageItemId, ...]
+    # True when the match's stage item has at least one unwired (empty) input slot, e.g. a
+    # knockout place filled manually only once the previous stage is fully played.
+    stage_item_has_open_slot: bool
 
 
 @dataclass(frozen=True)
@@ -108,15 +114,21 @@ def _cross_stage_source_ids(match: ScheduleMatch) -> tuple[StageItemId, ...]:
     return tuple(dict.fromkeys(source_ids))
 
 
+def _has_open_slot(stage_item: StageItemWithRounds) -> bool:
+    return any(isinstance(input_, StageItemInputEmpty) for input_ in stage_item.inputs)
+
+
 def _get_match_contexts(stages: list[StageWithStageItems]) -> list[_MatchContext]:
     return [
         _MatchContext(
             match=match,
+            level_id=stage.level_id,
             stage_id=stage.id,
             stage_item_id=stage_item.id,
             round_index=round_index,
             input_ids=_input_ids(match),
             cross_stage_source_ids=_cross_stage_source_ids(match),
+            stage_item_has_open_slot=_has_open_slot(stage_item),
         )
         for stage in stages
         for stage_item in stage.stage_items
@@ -331,6 +343,39 @@ def _add_movable_vs_pinned_input_constraints(
                 model.AddBoolOr([before, after])
 
 
+def _open_slot_precedence_ids(contexts: list[_MatchContext]) -> set[tuple[MatchId, MatchId]]:
+    """Pair each open-slot stage item's matches with its whole immediately-preceding stage.
+
+    A stage item with an unwired input slot has no explicit feeder to follow, but it still
+    cannot be played before the stage that fills that slot is over. Lacking a specific
+    source, we conservatively make every match of such a stage item wait for every match of
+    the immediately-preceding stage in the same level. Cross-level scheduling is unaffected,
+    and fully-wired stage items keep their tighter, feeder-specific dependencies.
+    """
+    contexts_by_stage: dict[StageId, list[_MatchContext]] = defaultdict(list)
+    stages_by_level: dict[LevelId | None, set[StageId]] = defaultdict(set)
+    for context in contexts:
+        contexts_by_stage[context.stage_id].append(context)
+        stages_by_level[context.level_id].add(context.stage_id)
+
+    ordered_stages_by_level = {
+        level_id: sorted(stage_ids) for level_id, stage_ids in stages_by_level.items()
+    }
+
+    pair_ids = set()
+    for successor in contexts:
+        if not successor.stage_item_has_open_slot:
+            continue
+        ordered_stages = ordered_stages_by_level[successor.level_id]
+        position = ordered_stages.index(successor.stage_id)
+        if position == 0:
+            continue  # first stage in the level — nothing precedes it
+        preceding_stage_id = ordered_stages[position - 1]
+        for feeder in contexts_by_stage[preceding_stage_id]:
+            pair_ids.add((feeder.match.id, successor.match.id))
+    return pair_ids
+
+
 def _precedence_pairs(contexts: list[_MatchContext]) -> list[tuple[_MatchContext, _MatchContext]]:
     contexts_by_match_id = {context.match.id: context for context in contexts}
     contexts_by_stage_item: dict[StageItemId, list[_MatchContext]] = defaultdict(list)
@@ -350,6 +395,8 @@ def _precedence_pairs(contexts: list[_MatchContext]) -> list[tuple[_MatchContext
             for feeder in contexts_by_stage_item[source_stage_item_id]:
                 if feeder.match.id != successor.match.id:
                     pair_ids.add((feeder.match.id, successor.match.id))
+
+    pair_ids |= _open_slot_precedence_ids(contexts)
 
     return [
         (contexts_by_match_id[feeder_id], contexts_by_match_id[successor_id])

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -14,7 +14,11 @@ from bracket.logic.planning.matches import (
 from bracket.models.db.court import Court
 from bracket.models.db.match import MatchWithDetails, MatchWithDetailsDefinitive
 from bracket.models.db.stage_item import StageType
-from bracket.models.db.stage_item_inputs import StageItemInputTentative
+from bracket.models.db.stage_item_inputs import (
+    StageItemInput,
+    StageItemInputEmpty,
+    StageItemInputTentative,
+)
 from bracket.models.db.tournament import Tournament
 from bracket.models.db.util import RoundWithMatches, StageItemWithRounds, StageWithStageItems
 from bracket.utils.dummy_records import DUMMY_MOCK_TIME, DUMMY_TOURNAMENT
@@ -53,11 +57,13 @@ def _stage(
     stage_id: int,
     matches_per_item: list[list[MatchWithDetails]],
     level_id: LevelId | None = None,
+    inputs_per_item: list[list[StageItemInput]] | None = None,
 ) -> StageWithStageItems:
     return _stage_with_rounds(
         stage_id,
         [[matches] for matches in matches_per_item],
         level_id=level_id,
+        inputs_per_item=inputs_per_item,
     )
 
 
@@ -65,6 +71,7 @@ def _stage_with_rounds(
     stage_id: int,
     rounds_per_item: list[list[list[MatchWithDetails]]],
     level_id: LevelId | None = None,
+    inputs_per_item: list[list[StageItemInput]] | None = None,
 ) -> StageWithStageItems:
     stage_items = []
     for item_idx, rounds in enumerate(rounds_per_item):
@@ -87,7 +94,7 @@ def _stage_with_rounds(
                 id=StageItemId(item_id),
                 stage_id=StageId(stage_id),
                 rounds=rounds_with_matches,
-                inputs=[],
+                inputs=inputs_per_item[item_idx] if inputs_per_item is not None else [],
                 type_name="Single Elimination",
                 team_count=2,
                 ranking_id=None,
@@ -336,6 +343,80 @@ def test_cross_stage_input_waits_for_source_stage_item_plus_default_break() -> N
     source_end = max(_end_time(op) for op in ops if op.match.id in {source1.id, source2.id})
     target_start = next(op.start_time for op in ops if op.match.id == target.id)
     assert target_start >= source_end + timedelta(minutes=MARGIN)
+
+
+def _empty_input(input_id: int, stage_item_id: int) -> StageItemInputEmpty:
+    return StageItemInputEmpty(
+        id=StageItemInputId(input_id),
+        slot=1,
+        tournament_id=TournamentId(-1),
+        stage_item_id=StageItemId(stage_item_id),
+    )
+
+
+def test_open_slot_stage_item_waits_for_full_preceding_stage() -> None:
+    """A later-stage item with an unwired (empty) input waits for its whole preceding stage.
+
+    Mirrors the best-runner-up case: a knockout spot is filled manually only once the
+    group stage is fully played, so the input is left empty and the scheduler cannot
+    place the knockout match before every group match has finished — even though there
+    is no explicit feeder link to follow.
+    """
+    level = LevelId(1)
+    group = [_match(1), _match(2), _match(3)]
+    final = _match(4)
+    final_item_id = 200
+    final_stage = _stage_with_rounds(
+        2,
+        [[[final]]],
+        level_id=level,
+        inputs_per_item=[[_empty_input(500, final_item_id)]],
+    )
+    stages = [_stage(1, [group], level_id=level), final_stage]
+
+    ops = build_schedule_plan(stages, [_court(1), _court(2)], _tournament())
+
+    by_id = {op.match.id: op for op in ops}
+    group_end = max(_end_time(by_id[m.id]) for m in group)
+    assert by_id[final.id].start_time >= group_end + timedelta(minutes=MARGIN)
+
+
+def test_fully_wired_later_stage_item_is_not_forced_after_whole_preceding_stage() -> None:
+    """A fully-wired later-stage item keeps its tight feeder dependency and may start early.
+
+    Group A is a single match; group B is four matches in the same first stage. The
+    knockout only consumes group A's winner, so it can slot in alongside group B and the
+    whole tournament finishes in three slots. If the conservative fallback wrongly forced
+    the knockout to wait for the entire preceding stage (group A + group B), it could not
+    start until group B finished, costing an extra slot. Asserting on the makespan pins
+    down that the tight dependency is preserved.
+    """
+    level = LevelId(1)
+    group_a = _match(1)
+    group_b = [_match(2), _match(3), _match(4), _match(5)]
+    source_item_id = StageItemId(100)  # group A is the first stage's first stage item
+    wired_input = StageItemInputTentative(
+        id=StageItemInputId(600),
+        slot=1,
+        tournament_id=TournamentId(-1),
+        stage_item_id=StageItemId(200),
+        winner_from_stage_item_id=source_item_id,
+        winner_position=1,
+    )
+    knockout = _match(6).model_copy(
+        update={"stage_item_input1_id": wired_input.id, "stage_item_input1": wired_input}
+    )
+    first_stage = _stage(1, [[group_a], group_b], level_id=level)
+    second_stage = _stage_with_rounds(
+        2, [[[knockout]]], level_id=level, inputs_per_item=[[wired_input]]
+    )
+    stages = [first_stage, second_stage]
+
+    ops = build_schedule_plan(stages, [_court(1), _court(2)], _tournament())
+
+    _assert_match_ids_scheduled(ops, [group_a, *group_b, knockout])
+    # Six matches on two courts with only group A blocking the knockout fit in three slots.
+    assert max(_end_time(op) for op in ops) == T0 + timedelta(minutes=DURATION + 2 * SLOT)
 
 
 def test_single_level_no_idle_court_gap_between_stages() -> None:

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -409,6 +409,90 @@ def test_optimizer_uses_shared_courts_without_idle_gaps_in_simple_case() -> None
     assert max(_end_time(op) for op in ops) == T0 + timedelta(minutes=DURATION + 2 * SLOT)
 
 
+# ── Objective blend: team rest ───────────────────────────────────────────────
+
+
+def _team_input(match: MatchWithDetails, team_id: int) -> MatchWithDetails:
+    return match.model_copy(
+        update={"stage_item_input1_id": StageItemInputId(team_id), "stage_item_input2_id": None}
+    )
+
+
+def test_team_rest_spaces_back_to_back_matches_when_it_is_free() -> None:
+    """A team's two matches get a gap when spacing them costs no makespan.
+
+    One court, three matches: a team plays the first and the last, with an
+    unrelated match available to slot between them. Every ordering finishes in
+    the same three slots, so the rest objective should pull the team's matches
+    apart rather than leave them back-to-back.
+    """
+    m1 = _team_input(_match(1), team_id=1)
+    m2 = _match(2).model_copy(
+        update={"stage_item_input1_id": StageItemInputId(2), "stage_item_input2_id": None}
+    )
+    m3 = _team_input(_match(3), team_id=1)
+    stages = [_stage(1, [[m1, m2, m3]])]
+
+    ops = build_schedule_plan(stages, [_court(1)], _tournament())
+
+    _assert_match_ids_scheduled(ops, [m1, m2, m3])
+    by_id = {op.match.id: op for op in ops}
+    earlier, later = sorted((by_id[m1.id], by_id[m3.id]), key=lambda op: op.start_time)
+    # At least one match sits between the team's two matches (a full slot of rest).
+    assert later.start_time - _end_time(earlier) >= timedelta(minutes=SLOT)
+
+
+# ── Objective blend: court locality ──────────────────────────────────────────
+
+
+def _courts_used_by(ops: list[ScheduleOperation], matches: list[MatchWithDetails]) -> set[CourtId]:
+    match_ids = {match.id for match in matches}
+    return {op.court_id for op in ops if op.match.id in match_ids}
+
+
+def test_each_group_stays_on_one_court_when_makespan_allows() -> None:
+    """With two courts and two groups of two matches, each group stays on a single court.
+
+    Both groups fit in two slots either way, so confining each group to one court costs
+    no makespan; the locality objective should prefer that over the naive spread that
+    scatters a group across both courts.
+    """
+    group_a = [_match(10), _match(11)]
+    group_b = [_match(20), _match(21)]
+    stages = [_stage(1, [group_a, group_b])]
+
+    ops = build_schedule_plan(stages, [_court(1), _court(2)], _tournament())
+
+    _assert_match_ids_scheduled(ops, group_a + group_b)
+    _assert_default_break_between_court_matches(ops)
+    assert len(_courts_used_by(ops, group_a)) == 1
+    assert len(_courts_used_by(ops, group_b)) == 1
+
+
+# ── Objective blend: group sync ──────────────────────────────────────────────
+
+
+def test_groups_in_a_stage_progress_round_for_round_when_free() -> None:
+    """Two groups in one stage keep the same round finishing at the same time.
+
+    Each group has two single-match rounds; with two courts every layout finishes in
+    two slots, so keeping the groups in lockstep (round 1 of both, then round 2 of both)
+    costs no makespan. The group-sync objective should pick that over letting one group
+    race a round ahead.
+    """
+    a1, a2 = _match(10), _match(11)
+    b1, b2 = _match(20), _match(21)
+    stages = [_stage_with_rounds(1, [[[a1], [a2]], [[b1], [b2]]])]
+
+    ops = build_schedule_plan(stages, [_court(1), _court(2)], _tournament())
+
+    _assert_match_ids_scheduled(ops, [a1, a2, b1, b2])
+    by_id = {op.match.id: op for op in ops}
+    # Each round's matches across the two groups finish at the same time (zero spread).
+    assert _end_time(by_id[a1.id]) == _end_time(by_id[b1.id])
+    assert _end_time(by_id[a2.id]) == _end_time(by_id[b2.id])
+
+
 # ── Edge cases ────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #78 (parent PRD #73).

## What this does

Extends the CP-SAT scheduler from #77 (makespan-only) to the full weighted objective blend, and fixes a precedence hole found during HITL review.

### Objective blend
The schedule now minimises a single weighted sum of:
- **Makespan** (dominant) — finish the tournament as early as possible.
- **Team rest** — penalise a team's consecutive matches falling short of a comfortable rest gap.
- **Group sync** — penalise round-progress divergence across a stage's items, keyed on round index so it stays well-defined when stage items have different round counts.
- **Court locality** — penalise the number of distinct courts a stage item spans.

Weights are fixed, tunable constants documented inline (`WEIGHT_*`), settled after reviewing example schedules: makespan dominant, team rest leads the secondary terms, group sync just ahead of court locality.

### Precedence fix
The scheduler previously enforced cross-stage precedence only through explicit feeder links. A stage item with an **unwired placeholder slot** (e.g. a knockout place decided manually only after the group stage — the best-runner-up case) carried no link, so the solver could schedule it before the preceding stage finished (the dev-DB beginner Final landed mid-group-stage). Now any stage item with an empty input slot waits for its **whole immediately-preceding stage in the same level**; fully-wired stage items keep their tighter, feeder-specific dependencies and can still start early, and cross-level scheduling is unaffected.

## Testing
Built test-first (red→green per slice). New property-style tests assert each behaviour on fixtures where the improvement costs no makespan, so they survive weight tuning and don't encode a single layout:
- team rest spacing, court locality, group sync round alignment
- open-slot stage item waits for full preceding stage (bug repro)
- fully-wired later stage item is **not** forced after the whole preceding stage (tightness guard, asserts on makespan)

All hard guarantees from #77 still hold. Full backend unit suite: **108 passed**. ruff + mypy clean (pyrefly only flags a pre-existing `template_test.py` issue). Verified end-to-end against the dev DB: the beginner Final now schedules after the Group Stage.

## Acceptance criteria (#78)
- [x] Hard guarantees from #77 hold (no conflicts, precedence, breaks, grid, pins).
- [x] Team's back-to-back matches get spaced when makespan allows.
- [x] Each group stays on fewer courts than the naive spread.
- [x] Groups in a stage progress at a similar pace.
- [x] Qualitative property assertions; reproducible (fixed seed + single worker); within CI budget (<2s).
- [x] Weights + rationale documented for future tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)