### PR TITLE
Add loading overlay during auto-planning SAT runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,11 @@ Alembic migrations live in `backend/alembic/versions/`. Migrations auto-run on s
 - **`openapi/`** — Auto-generated TypeScript types from backend OpenAPI schema (via `@hey-api/openapi-ts`). Regenerate with `pnpm run openapi-ts`
 - **`components/`** — UI components organized by feature (brackets, builder, dashboard, scheduling, etc.)
 - **`pages/`** — Route pages. Tournament pages under `pages/tournaments/[id]/`
+- **`public/locales/<lang>/common.json`** — i18n translation strings, one file per language
+
+#### Translations
+
+When you add a user-facing string, always add the new translation key to **both** the English (`public/locales/en/common.json`) and German (`public/locales/de/common.json`) locales. Keys are kept in alphabetical order within each file.
 
 ### Data Model Hierarchy
 

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -202,6 +202,7 @@
     "number_required": "Beinhaltet Nummer",
     "only_recommended_input_group_label": "Nur Teams anzeigen, die weniger Spiele gespielt haben.",
     "only_recommended_radio_label": "Nur empfohlen",
+    "optimizing_schedule_label": "Spielplan wird optimiert …",
     "password_input_label": "Passwort",
     "password_input_placeholder": "Ihr Passwort",
     "placement_conflict_preview_label": "Würde ein Team doppelt belegen",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -212,6 +212,7 @@
     "number_required": "Includes number",
     "only_recommended_input_group_label": "Only show teams that played less matches",
     "only_recommended_radio_label": "Only recommended",
+    "optimizing_schedule_label": "Optimizing schedule …",
     "password_input_label": "Password",
     "password_input_placeholder": "Your password",
     "placement_conflict_preview_label": "Would double-book a team",

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -5,6 +5,8 @@ import {
   Button,
   Grid,
   Group,
+  Loader,
+  LoadingOverlay,
   Modal,
   Paper,
   Select,
@@ -111,6 +113,9 @@ export default function SchedulePage() {
   const [reoptimizeWeights, setReoptimizeWeights] =
     useState<SchedulerWeights>(DEFAULT_SCHEDULER_WEIGHTS);
   const [reoptimizeAdvancedOpened, setReoptimizeAdvancedOpened] = useState(false);
+  // Set while an optimize-all / schedule-unscheduled SAT run is in flight; dims
+  // the planning view behind a spinner so the long solve reads as deliberate.
+  const [isOptimizing, setIsOptimizing] = useState(false);
   // Captures pinch and ctrl+wheel over the whole planning content, so a pinch
   // that starts next to the grid zooms the schedule instead of the page.
   const pinchRef = usePinchZoom(handlePlannerEvent);
@@ -337,7 +342,22 @@ export default function SchedulePage() {
 
   return (
     <TournamentLayout tournament_id={tournamentData.id}>
-      <Box ref={pinchRef} style={{ touchAction: 'pan-x pan-y' }}>
+      <Box ref={pinchRef} pos="relative" style={{ touchAction: 'pan-x pan-y' }}>
+        <LoadingOverlay
+          visible={isOptimizing}
+          zIndex={500}
+          overlayProps={{ blur: 1, backgroundOpacity: 0.55, color: '#000' }}
+          loaderProps={{
+            children: (
+              <Stack align="center" gap="sm">
+                <Loader size="lg" />
+                <Text c="white" fw={600}>
+                  {t('optimizing_schedule_label', 'Optimizing schedule …')}
+                </Text>
+              </Stack>
+            ),
+          }}
+        />
         <Grid grow>
           <Grid.Col span={6}>
             <Title>{t('planning_title')}</Title>
@@ -508,8 +528,13 @@ export default function SchedulePage() {
                     leftSection={<IconCalendarPlus size={18} />}
                     onClick={async () => {
                       setScheduleModalOpened(false);
-                      await scheduleMatches(tournamentData.id, scheduleWeights);
-                      await swrStagesResponse.mutate();
+                      setIsOptimizing(true);
+                      try {
+                        await scheduleMatches(tournamentData.id, scheduleWeights);
+                        await swrStagesResponse.mutate();
+                      } finally {
+                        setIsOptimizing(false);
+                      }
                     }}
                   >
                     {t('schedule_modal_confirm')}
@@ -539,8 +564,13 @@ export default function SchedulePage() {
                     leftSection={<IconWand size={18} />}
                     onClick={async () => {
                       setReoptimizeModalOpened(false);
-                      await reoptimizeMatches(tournamentData.id, reoptimizeWeights);
-                      await swrStagesResponse.mutate();
+                      setIsOptimizing(true);
+                      try {
+                        await reoptimizeMatches(tournamentData.id, reoptimizeWeights);
+                        await swrStagesResponse.mutate();
+                      } finally {
+                        setIsOptimizing(false);
+                      }
                     }}
                   >
                     {t('reoptimize_modal_confirm')}

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -6,8 +6,8 @@ import {
   Grid,
   Group,
   Loader,
-  LoadingOverlay,
   Modal,
+  Overlay,
   Paper,
   Select,
   Stack,
@@ -342,22 +342,20 @@ export default function SchedulePage() {
 
   return (
     <TournamentLayout tournament_id={tournamentData.id}>
-      <Box ref={pinchRef} pos="relative" style={{ touchAction: 'pan-x pan-y' }}>
-        <LoadingOverlay
-          visible={isOptimizing}
-          zIndex={500}
-          overlayProps={{ blur: 1, backgroundOpacity: 0.55, color: '#000' }}
-          loaderProps={{
-            children: (
-              <Stack align="center" gap="sm">
-                <Loader size="lg" />
-                <Text c="white" fw={600}>
-                  {t('optimizing_schedule_label', 'Optimizing schedule …')}
-                </Text>
-              </Stack>
-            ),
-          }}
-        />
+      <Box ref={pinchRef} style={{ touchAction: 'pan-x pan-y' }}>
+        {/* A SAT solve is a single synchronous request, so dim the whole
+            viewport — header and navbar included — behind a spinner to make the
+            wait read as deliberate and discourage navigating away mid-solve. */}
+        {isOptimizing && (
+          <Overlay fixed color="#000" backgroundOpacity={0.55} blur={1} zIndex={1000} center>
+            <Stack align="center" gap="sm">
+              <Loader size="lg" />
+              <Text c="white" fw={600}>
+                {t('optimizing_schedule_label', 'Optimizing schedule …')}
+              </Text>
+            </Stack>
+          </Overlay>
+        )}
         <Grid grow>
           <Grid.Col span={6}>
             <Title>{t('planning_title')}</Title>


### PR DESCRIPTION
On the planning view, dim the schedule behind a spinner while the
'Schedule all unscheduled' and 'Re-optimize everything' SAT solves are
in flight, so the long-running optimize reads as deliberate progress
rather than a frozen page.

Closes #88

https://claude.ai/code/session_019gw7LtaAWuphxWnLVecihQ