### PR TITLE
Lock browser page zoom on mobile planning view

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,9 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bracket</title>
-    <meta charSet="UTF-8" />
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" href="/favicon.svg" />
   </head>
   <body>

--- a/frontend/src/components/scheduling/use_lock_viewport_zoom.ts
+++ b/frontend/src/components/scheduling/use_lock_viewport_zoom.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+
+/**
+ * Below this width we treat the device as a phone, matching `defaultZoomLevel`.
+ */
+const MOBILE_MAX_WIDTH_PX = 768;
+/** Pins the page to 1:1 with browser zoom disabled while the planner is open. */
+const LOCKED_VIEWPORT_CONTENT =
+  'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no';
+
+/**
+ * Locks the browser's page zoom while the planning view is mounted on mobile.
+ *
+ * The planner captures pinch gestures on its content to switch between the
+ * agenda/compact/overview zoom levels, so the browser's own pinch-zoom only
+ * gets in the way: once the page drifts zoomed-in (on first paint, or after
+ * iOS auto-zooms when a form field like the custom match duration is focused),
+ * the content gesture handler eats the pinch and the only way back out is to
+ * pinch on the navbar. Pinning the viewport to 1:1 with zooming disabled keeps
+ * the page from ever zooming, leaving the planner's semantic zoom in sole
+ * control. The original viewport meta is restored on unmount so the rest of
+ * the app keeps normal accessibility zoom.
+ */
+export function useLockViewportZoom() {
+  useEffect(() => {
+    if (window.innerWidth >= MOBILE_MAX_WIDTH_PX) return undefined;
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+    if (meta == null) return undefined;
+
+    const previousContent = meta.getAttribute('content');
+    meta.setAttribute('content', LOCKED_VIEWPORT_CONTENT);
+    return () => {
+      if (previousContent == null) meta.removeAttribute('content');
+      else meta.setAttribute('content', previousContent);
+    };
+  }, []);
+}

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -85,6 +85,7 @@ import SchedulerWeightsForm, {
   DEFAULT_SCHEDULER_WEIGHTS,
 } from '@components/scheduling/scheduler_weights_form';
 import UnscheduledSheet from '@components/scheduling/unscheduled_sheet';
+import { useLockViewportZoom } from '@components/scheduling/use_lock_viewport_zoom';
 import { usePinchZoom } from '@components/scheduling/use_pinch_zoom';
 import ZoomControls from '@components/scheduling/zoom_controls';
 
@@ -119,6 +120,10 @@ export default function SchedulePage() {
   // Captures pinch and ctrl+wheel over the whole planning content, so a pinch
   // that starts next to the grid zooms the schedule instead of the page.
   const pinchRef = usePinchZoom(handlePlannerEvent);
+  // Lock the browser's page zoom on mobile so the planner's own zoom levels are
+  // the only thing that changes scale; otherwise the page drifts zoomed-in and
+  // the content pinch handler leaves no way to zoom back out.
+  useLockViewportZoom();
 
   useEffect(() => {
     const intervalId = window.setInterval(() => setNow(new Date()), 60_000);


### PR DESCRIPTION
On mobile the planner captures pinch gestures on its content to switch
between agenda/compact/overview zoom levels. The browser's own page zoom
fought this: the view drifted zoomed-in on first paint and after iOS
auto-zoomed on focusing a form field (e.g. the custom match duration
input), and the content gesture handler then ate the pinch, so the only
way to zoom back out was to pinch on the navbar.

Pin the viewport to 1:1 with zooming disabled while the planning page is
mounted on a phone-width viewport, restoring the original viewport meta
on unmount so the rest of the app keeps normal accessibility zoom. Also
drop the accidental duplicate viewport/charset meta tags so there is a
single viewport source of truth to toggle.