### PR TITLE
Remove "Now" jump button from planning view

### DIFF
--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -30,7 +30,6 @@ import {
   computeBreaks,
   computeInsertionLines,
 } from '@logic/planning/layout';
-import { nowLineScrollTop } from '@logic/planning/now_line';
 import { FocusTarget, GridMatchRef, PlannerEvent, SelectionState } from '@logic/planning/selection';
 import {
   ZOOM_PX_PER_MINUTE,
@@ -771,7 +770,6 @@ export default function ScheduleGrid({
   zoom,
   focus,
   nowOffsetMinutes,
-  nowScrollNonce,
   onSelectionEvent,
 }: {
   layout: ScheduleGridLayout<Court, MatchWithDetails>;
@@ -785,7 +783,6 @@ export default function ScheduleGrid({
   zoom: ZoomLevel;
   focus: (FocusTarget & { nonce: number }) | null;
   nowOffsetMinutes: number | null;
-  nowScrollNonce: number;
   onSelectionEvent: (event: PlannerEvent) => void;
 }) {
   const pxPerMinute = ZOOM_PX_PER_MINUTE[zoom];
@@ -841,23 +838,6 @@ export default function ScheduleGrid({
     // Only re-run per navigation event; gridHeight is already the post-zoom scale.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focus?.nonce]);
-
-  useEffect(() => {
-    if (nowScrollNonce === 0 || nowOffsetMinutes == null) return;
-    const container = containerRef.current;
-    if (container == null) return;
-
-    container.scrollTo({
-      top: nowLineScrollTop({
-        offsetMinutes: nowOffsetMinutes,
-        pxPerMinute,
-        viewportHeightPx: container.clientHeight,
-        headerHeightPx: HEADER_HEIGHT_PX,
-        gridTopInsetPx: GRID_TOP_INSET_PX,
-      }),
-      behavior: 'smooth',
-    });
-  }, [nowOffsetMinutes, nowScrollNonce, pxPerMinute]);
 
   return (
     <Box

--- a/frontend/src/logic/planning/now_line.test.ts
+++ b/frontend/src/logic/planning/now_line.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { currentTimeOffsetMinutes, nowLineScrollTop } from './now_line';
+import { currentTimeOffsetMinutes } from './now_line';
 
 describe('currentTimeOffsetMinutes', () => {
   const tournamentStartTime = '2026-06-10T09:00:00Z';
@@ -47,31 +47,5 @@ describe('currentTimeOffsetMinutes', () => {
         now: new Date('2026-06-10T11:01:00Z'),
       })
     ).toBeNull();
-  });
-});
-
-describe('nowLineScrollTop', () => {
-  it('centers the current-time line in the scroll viewport', () => {
-    expect(
-      nowLineScrollTop({
-        offsetMinutes: 45,
-        pxPerMinute: 3,
-        viewportHeightPx: 300,
-        headerHeightPx: 40,
-        gridTopInsetPx: 32,
-      })
-    ).toBe(57);
-  });
-
-  it('clamps above-the-top scroll targets to zero', () => {
-    expect(
-      nowLineScrollTop({
-        offsetMinutes: 0,
-        pxPerMinute: 3,
-        viewportHeightPx: 300,
-        headerHeightPx: 40,
-        gridTopInsetPx: 32,
-      })
-    ).toBe(0);
   });
 });

--- a/frontend/src/logic/planning/now_line.ts
+++ b/frontend/src/logic/planning/now_line.ts
@@ -14,20 +14,3 @@ export function currentTimeOffsetMinutes({
   if (offsetMinutes < 0 || offsetMinutes > totalMinutes) return null;
   return offsetMinutes;
 }
-
-export function nowLineScrollTop({
-  offsetMinutes,
-  pxPerMinute,
-  viewportHeightPx,
-  headerHeightPx,
-  gridTopInsetPx,
-}: {
-  offsetMinutes: number;
-  pxPerMinute: number;
-  viewportHeightPx: number;
-  headerHeightPx: number;
-  gridTopInsetPx: number;
-}): number {
-  const targetY = headerHeightPx + gridTopInsetPx + offsetMinutes * pxPerMinute;
-  return Math.max(0, targetY - viewportHeightPx / 2);
-}

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -15,7 +15,7 @@ import {
   Title,
 } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { IconCalendarPlus, IconClock, IconWand } from '@tabler/icons-react';
+import { IconCalendarPlus, IconWand } from '@tabler/icons-react';
 import { isAxiosError } from 'axios';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -95,7 +95,6 @@ export default function SchedulePage() {
   );
   const [highlightValue, setHighlightValue] = useState<string | null>(null);
   const [now, setNow] = useState(() => new Date());
-  const [nowScrollNonce, setNowScrollNonce] = useState(0);
   const [trayOpened, setTrayOpened] = useState(false);
   const [focus, setFocus] = useState<(FocusTarget & { nonce: number }) | null>(null);
   // Details modal opened from the action sheet; holds the match id (not the
@@ -386,17 +385,6 @@ export default function SchedulePage() {
                 courts={courts}
                 matchesByCourtId={matchesByCourtId}
               />
-              <Button
-                color="red"
-                size="sm"
-                variant="light"
-                style={{ marginBottom: 10 }}
-                leftSection={<IconClock size={18} />}
-                disabled={nowOffsetMinutes == null}
-                onClick={() => setNowScrollNonce((nonce) => nonce + 1)}
-              >
-                {t('jump_to_now_label', 'Now')}
-              </Button>
               {courts.length < 1 ? null : (
                 <Button
                   color="indigo"
@@ -467,7 +455,6 @@ export default function SchedulePage() {
               zoom={planner.zoom}
               focus={focus}
               nowOffsetMinutes={nowOffsetMinutes}
-              nowScrollNonce={nowScrollNonce}
               onSelectionEvent={handlePlannerEvent}
             />
             <UnscheduledSheet


### PR DESCRIPTION
Drop the toolbar button that scrolled the schedule grid to the current
time line. The now line marker itself stays; only the jump-to-now button
and its supporting code (scroll nonce state, scroll effect, and the now
unused nowLineScrollTop helper) are removed.

https://claude.ai/code/session_01Y6661zy1xMsoTgNYrm1xVe