### PR TITLE
Order team finder by teams first and show up to 100 options

### DIFF
--- a/frontend/src/logic/planning/highlight.test.ts
+++ b/frontend/src/logic/planning/highlight.test.ts
@@ -117,4 +117,27 @@ describe('stageHighlightOptions', () => {
       },
     ]);
   });
+
+  it('lists teams before placeholder inputs, each sorted alphabetically', () => {
+    expect(
+      stageHighlightOptions([
+        {
+          stage_items: [
+            { id: 10, name: 'Group A', inputs: [] },
+            { id: 20, name: 'Group B', inputs: [] },
+            {
+              id: 30,
+              name: 'Final',
+              inputs: [
+                { ...input(301, null), winner_from_stage_item_id: 20, winner_position: 1 },
+                { ...input(302, null), winner_from_stage_item_id: 10, winner_position: 1 },
+                input(103, 12, 'Zeta'),
+                input(104, 11, 'Alpha'),
+              ],
+            },
+          ],
+        },
+      ]).map((option) => option.label)
+    ).toEqual(['Alpha', 'Zeta', '1st of Group A', '1st of Group B']);
+  });
 });

--- a/frontend/src/logic/planning/highlight.ts
+++ b/frontend/src/logic/planning/highlight.ts
@@ -111,9 +111,10 @@ export function stageHighlightOptions(stages: StageLike[]): HighlightOption[] {
     }
   }
 
-  return [...byTeamId.values(), ...byInputId.values()].sort((a, b) =>
-    a.label.localeCompare(b.label)
-  );
+  const byLabel = (a: HighlightOption, b: HighlightOption) => a.label.localeCompare(b.label);
+  // Teams first, then placeholder inputs ("1st of group A"), each sorted alphabetically.
+  // Actual teams are what users usually want to find, so they take precedence.
+  return [...[...byTeamId.values()].sort(byLabel), ...[...byInputId.values()].sort(byLabel)];
 }
 
 function positionName(position: number): string {

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -374,7 +374,7 @@ export default function SchedulePage() {
                 onChange={setHighlightValue}
                 searchable
                 clearable
-                limit={24}
+                limit={100}
                 w={220}
                 size="sm"
                 mb={10}


### PR DESCRIPTION
In the planning view's team finder dropdown, list actual teams before
placeholder inputs (e.g. "1st of group A") instead of mixing them
alphabetically, since users usually want to find real teams. Each group
is still sorted alphabetically.

Also raise the dropdown limit from 24 to 100 so the full team list is
browsable without typing, which is faster on mobile.

https://claude.ai/code/session_01URzzQ1Nbw7PrBM8rNJsLZ4