### PR TITLE
Use colourblind-safe win/loss score colours

### DIFF
--- a/frontend/src/logic/colors.test.ts
+++ b/frontend/src/logic/colors.test.ts
@@ -6,6 +6,10 @@ import {
   levelColour,
   levelHue,
   levelSwatchColour,
+  SCORE_DRAW_COLOUR,
+  SCORE_LOSE_COLOUR,
+  SCORE_WIN_COLOUR,
+  scoreColour,
   stringToColour,
 } from './colors';
 
@@ -136,5 +140,23 @@ describe('levelSwatchColour', () => {
 describe('stringToColour', () => {
   it('is deterministic for a given key', () => {
     expect(stringToColour('team-5')).toBe(stringToColour('team-5'));
+  });
+});
+
+describe('scoreColour', () => {
+  it('maps higher / lower / equal scores to win / loss / draw', () => {
+    expect(scoreColour(2, 1)).toBe(SCORE_WIN_COLOUR);
+    expect(scoreColour(1, 2)).toBe(SCORE_LOSE_COLOUR);
+    expect(scoreColour(1, 1)).toBe(SCORE_DRAW_COLOUR);
+  });
+
+  it('uses a colourblind-safe win/loss pair, not a pure red/green one', () => {
+    // The three outcomes must be mutually distinct…
+    const colours = [SCORE_WIN_COLOUR, SCORE_LOSE_COLOUR, SCORE_DRAW_COLOUR];
+    expect(new Set(colours).size).toBe(3);
+    // …and win/loss are the Okabe-Ito bluish-green / vermillion pair, chosen to
+    // stay apart under red–green colour-vision deficiency.
+    expect(SCORE_WIN_COLOUR).toBe('#009e73');
+    expect(SCORE_LOSE_COLOUR).toBe('#d55e00');
   });
 });

--- a/frontend/src/logic/colors.ts
+++ b/frontend/src/logic/colors.ts
@@ -223,11 +223,23 @@ export { NEUTRAL as NEUTRAL_STAGE_ITEM_COLOUR };
 
 // ── Score colours ───────────────────────────────────────────────────────────
 
-/** Winner / draw / loser score colours, used as solid chip backgrounds with
- * white text so the score keeps strong contrast on top of any stage-item tint. */
-export const SCORE_WIN_COLOUR = '#2a8f37';
+/**
+ * Winner / draw / loser score colours, used as solid chip backgrounds with
+ * white text so the score keeps strong contrast on top of any stage-item tint.
+ *
+ * Colourblind-safe by construction: win/loss are the Okabe-Ito bluish-green and
+ * vermillion, a pair designed to stay distinct under deuteranopia/protanopia
+ * (red–green deficiency, ~8% of men) while still reading as "green-ish good /
+ * red-ish bad" to everyone. We deliberately avoid a pure red/green pair, which
+ * collapses to near-identical khaki under those deficiencies. Draw stays a
+ * neutral grey that is darker than both, so it separates by lightness (the cue
+ * every CVD type keeps) as well as by chroma. Colour is never the only signal —
+ * the score number sits inside the chip — so this only sharpens the at-a-glance
+ * read; it isn't load-bearing for correctness.
+ */
+export const SCORE_WIN_COLOUR = '#009e73';
 export const SCORE_DRAW_COLOUR = '#656565';
-export const SCORE_LOSE_COLOUR = '#af4034';
+export const SCORE_LOSE_COLOUR = '#d55e00';
 /** Live (in-progress) and pending (not-started) score chip backgrounds. */
 const SCORE_LIVE_COLOUR = '#74c0fc';
 const SCORE_PENDING_COLOUR = '#868e96';


### PR DESCRIPTION
The win/loss score chips used a pure green/red pair (#2a8f37 / #af4034),
the textbook red-green confusion case: under deuteranopia/protanopia
(~8% of men) both desaturate toward near-identical khaki, and the red
was nearly equiluminant with the draw grey, so draw vs loss could also
merge.

Switch win/loss to the Okabe-Ito bluish-green (#009e73) and vermillion
(#d55e00), a pair designed to stay distinct under red-green colour-vision
deficiency while still reading as "green-ish good / red-ish bad" to
everyone. Vermillion stays chromatic (not grey-collapsing) under CVD, so
it also separates cleanly from the neutral draw grey. Colour was already
redundant with the score number printed inside the chip, so this only
sharpens the at-a-glance read.

Level-colour CVD safety is tracked separately in #95.