### PR TITLE
Add mobile-optimized planner tools sheet for scheduling

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -219,6 +219,7 @@
     "plan_next_round_button": "Nächste Runde planen",
     "plan_next_stage_button": "Nächste Phase starten",
     "plan_previous_stage_button": "Zur vorherigen Phase zurückgehen",
+    "planner_tools_title": "Planungswerkzeuge",
     "planning_of_matches_description": "Beginn des Turniers",
     "planning_of_matches_legend": "Planung der Spiele",
     "planning_spotlight_description": "Spielplanung ändern",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -219,6 +219,7 @@
     "plan_next_round_button": "Plan next round",
     "plan_next_stage_button": "Start the next stage",
     "plan_previous_stage_button": "Go back to the previous stage",
+    "planner_tools_title": "Planner tools",
     "planning_of_matches_description": "Start of the tournament",
     "planning_of_matches_legend": "Planning of matches",
     "planning_spotlight_description": "Change planning of matches",

--- a/frontend/src/components/scheduling/court_delete_modal.tsx
+++ b/frontend/src/components/scheduling/court_delete_modal.tsx
@@ -1,0 +1,69 @@
+import { ActionIcon, Badge, Group, Modal, Stack, Text } from '@mantine/core';
+import { IconTrash } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
+import { SWRResponse } from 'swr';
+
+import { buildCourtManagementList } from '@logic/planning/courts';
+import { Court, CourtsResponse, MatchWithDetails } from '@openapi';
+import { deleteCourt } from '@services/court';
+
+/**
+ * Lists the tournament's courts with a delete control each. Courts still used by
+ * matches are rejected by the backend; the match-count badge warns up front.
+ * Shared by the desktop courts toolbar and the mobile planner tools sheet.
+ */
+export default function CourtDeleteModal({
+  tournamentId,
+  swrCourtsResponse,
+  courts,
+  matchesByCourtId,
+  opened,
+  setOpened,
+}: {
+  tournamentId: number;
+  swrCourtsResponse: SWRResponse<CourtsResponse>;
+  courts: Court[];
+  matchesByCourtId: Record<number, MatchWithDetails[]>;
+  opened: boolean;
+  setOpened: (opened: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  const entries = buildCourtManagementList(courts, matchesByCourtId);
+
+  return (
+    <Modal opened={opened} onClose={() => setOpened(false)} title={t('delete_court_button')}>
+      {entries.length < 1 ? (
+        <Text c="dimmed">{t('no_courts_title')}</Text>
+      ) : (
+        <Stack gap="xs">
+          {entries.map(({ court, matchCount }) => (
+            <Group key={court.id} justify="space-between" wrap="nowrap">
+              <Text fw={500} truncate>
+                {court.name}
+              </Text>
+              <Group gap="xs" wrap="nowrap">
+                {matchCount > 0 && (
+                  <Badge color="orange" variant="light">
+                    {t('court_match_count_badge', { count: matchCount })}
+                  </Badge>
+                )}
+                <ActionIcon
+                  color="red"
+                  variant="light"
+                  size="lg"
+                  aria-label={`${t('delete_court_button')} ${court.name}`}
+                  onClick={async () => {
+                    await deleteCourt(tournamentId, court.id);
+                    await swrCourtsResponse.mutate();
+                  }}
+                >
+                  <IconTrash size={18} />
+                </ActionIcon>
+              </Group>
+            </Group>
+          ))}
+        </Stack>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/components/scheduling/courts_toolbar.tsx
+++ b/frontend/src/components/scheduling/courts_toolbar.tsx
@@ -1,13 +1,12 @@
-import { ActionIcon, Badge, Button, Group, Menu, Modal, Stack, Text } from '@mantine/core';
+import { Button, Menu } from '@mantine/core';
 import { IconAdjustmentsHorizontal, IconPlus, IconTrash } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SWRResponse } from 'swr';
 
 import CourtModal from '@components/modals/create_court_modal';
-import { buildCourtManagementList } from '@logic/planning/courts';
+import CourtDeleteModal from '@components/scheduling/court_delete_modal';
 import { Court, CourtsResponse, MatchWithDetails } from '@openapi';
-import { deleteCourt } from '@services/court';
 
 /**
  * Toolbar menu for managing courts from the planning view. Court add/delete
@@ -28,7 +27,6 @@ export default function CourtsToolbar({
   const { t } = useTranslation();
   const [addOpened, setAddOpened] = useState(false);
   const [deleteOpened, setDeleteOpened] = useState(false);
-  const entries = buildCourtManagementList(courts, matchesByCourtId);
 
   return (
     <>
@@ -38,46 +36,14 @@ export default function CourtsToolbar({
         opened={addOpened}
         setOpened={setAddOpened}
       />
-      <Modal
+      <CourtDeleteModal
+        tournamentId={tournamentId}
+        swrCourtsResponse={swrCourtsResponse}
+        courts={courts}
+        matchesByCourtId={matchesByCourtId}
         opened={deleteOpened}
-        onClose={() => setDeleteOpened(false)}
-        title={t('delete_court_button')}
-      >
-        {entries.length < 1 ? (
-          <Text c="dimmed">{t('no_courts_title')}</Text>
-        ) : (
-          <Stack gap="xs">
-            {entries.map(({ court, matchCount }) => (
-              <Group key={court.id} justify="space-between" wrap="nowrap">
-                <Text fw={500} truncate>
-                  {court.name}
-                </Text>
-                <Group gap="xs" wrap="nowrap">
-                  {matchCount > 0 && (
-                    <Badge color="orange" variant="light">
-                      {t('court_match_count_badge', { count: matchCount })}
-                    </Badge>
-                  )}
-                  <ActionIcon
-                    color="red"
-                    variant="light"
-                    size="lg"
-                    aria-label={`${t('delete_court_button')} ${court.name}`}
-                    onClick={async () => {
-                      // Courts still used by matches are rejected by the backend
-                      // with an error notification; the badge warns up front.
-                      await deleteCourt(tournamentId, court.id);
-                      await swrCourtsResponse.mutate();
-                    }}
-                  >
-                    <IconTrash size={18} />
-                  </ActionIcon>
-                </Group>
-              </Group>
-            ))}
-          </Stack>
-        )}
-      </Modal>
+        setOpened={setDeleteOpened}
+      />
       <Menu shadow="md" position="bottom-end">
         <Menu.Target>
           <Button

--- a/frontend/src/components/scheduling/planner_tools_sheet.tsx
+++ b/frontend/src/components/scheduling/planner_tools_sheet.tsx
@@ -1,0 +1,141 @@
+import { Button, Divider, Drawer, Select, Stack } from '@mantine/core';
+import { IconCalendarPlus, IconPlus, IconTrash, IconWand } from '@tabler/icons-react';
+import { ComponentProps, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SWRResponse } from 'swr';
+
+import CourtModal from '@components/modals/create_court_modal';
+import CourtDeleteModal from '@components/scheduling/court_delete_modal';
+import { Court, CourtsResponse, MatchWithDetails } from '@openapi';
+
+/**
+ * Mobile-only bottom sheet that gathers the planner's top-toolbar controls —
+ * team highlight, court add/delete and the two auto-schedule actions — behind a
+ * single tools button, so the awkward inline toolbar disappears on small
+ * screens. Opening a court modal or an auto-schedule modal closes this sheet
+ * first to avoid stacking two overlays; the court modals stay mounted here so
+ * they survive that close.
+ */
+export default function PlannerToolsSheet({
+  opened,
+  onClose,
+  tournamentId,
+  swrCourtsResponse,
+  courts,
+  matchesByCourtId,
+  highlightOptions,
+  highlightValue,
+  onHighlightChange,
+  onSchedule,
+  onReoptimize,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  tournamentId: number;
+  swrCourtsResponse: SWRResponse<CourtsResponse>;
+  courts: Court[];
+  matchesByCourtId: Record<number, MatchWithDetails[]>;
+  highlightOptions: ComponentProps<typeof Select>['data'];
+  highlightValue: string | null;
+  onHighlightChange: (value: string | null) => void;
+  onSchedule: () => void;
+  onReoptimize: () => void;
+}) {
+  const { t } = useTranslation();
+  const [addOpened, setAddOpened] = useState(false);
+  const [deleteOpened, setDeleteOpened] = useState(false);
+
+  return (
+    <>
+      <CourtModal
+        tournamentId={tournamentId}
+        swrCourtsResponse={swrCourtsResponse}
+        opened={addOpened}
+        setOpened={setAddOpened}
+      />
+      <CourtDeleteModal
+        tournamentId={tournamentId}
+        swrCourtsResponse={swrCourtsResponse}
+        courts={courts}
+        matchesByCourtId={matchesByCourtId}
+        opened={deleteOpened}
+        setOpened={setDeleteOpened}
+      />
+      <Drawer
+        opened={opened}
+        onClose={onClose}
+        position="bottom"
+        // A true bottom sheet: hug the content's height so the grid stays
+        // visible behind the overlay, matching the match action sheet.
+        styles={{
+          content: { height: 'auto', borderTopLeftRadius: 12, borderTopRightRadius: 12 },
+        }}
+        zIndex={400}
+        title={t('planner_tools_title')}
+      >
+        <Stack gap="xs">
+          <Select
+            aria-label={t('team_highlight_label', 'Highlight team or input')}
+            placeholder={t('team_highlight_placeholder', 'Find team or input')}
+            data={highlightOptions}
+            value={highlightValue}
+            onChange={onHighlightChange}
+            searchable
+            clearable
+            limit={100}
+          />
+          <Divider />
+          <Button
+            variant="light"
+            color="green"
+            justify="flex-start"
+            leftSection={<IconPlus size={20} />}
+            onClick={() => {
+              onClose();
+              setAddOpened(true);
+            }}
+          >
+            {t('add_court_title')}
+          </Button>
+          <Button
+            variant="light"
+            color="red"
+            justify="flex-start"
+            leftSection={<IconTrash size={20} />}
+            onClick={() => {
+              onClose();
+              setDeleteOpened(true);
+            }}
+          >
+            {t('delete_court_button')}
+          </Button>
+          <Divider />
+          <Button
+            variant="light"
+            color="indigo"
+            justify="flex-start"
+            leftSection={<IconCalendarPlus size={20} />}
+            onClick={() => {
+              onClose();
+              onSchedule();
+            }}
+          >
+            {t('schedule_description')}
+          </Button>
+          <Button
+            variant="light"
+            color="indigo"
+            justify="flex-start"
+            leftSection={<IconWand size={20} />}
+            onClick={() => {
+              onClose();
+              onReoptimize();
+            }}
+          >
+            {t('reoptimize_description')}
+          </Button>
+        </Stack>
+      </Drawer>
+    </>
+  );
+}

--- a/frontend/src/components/scheduling/unscheduled_sheet.tsx
+++ b/frontend/src/components/scheduling/unscheduled_sheet.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   Group,
   Paper,
+  Portal,
   ScrollArea,
   Stack,
   Text,
@@ -159,59 +160,69 @@ export default function UnscheduledSheet({
   }
 
   return (
-    <Paper
-      shadow="lg"
-      radius={0}
-      withBorder
-      style={{
-        position: 'fixed',
-        bottom: 0,
-        left: '50%',
-        transform: 'translateX(-50%)',
-        width: `min(100%, ${preferredTrayWidthRem}rem)`,
-        zIndex: 150,
-        borderTopLeftRadius: 12,
-        borderTopRightRadius: 12,
-        borderBottom: 'none',
-      }}
-    >
-      <Group justify="space-between" wrap="nowrap" gap="xs" p="sm">
-        <UnstyledButton onClick={onToggle} style={{ flex: 1, minWidth: 0 }} aria-expanded={opened}>
-          <Group justify="space-between" wrap="nowrap">
-            <Group gap="xs" wrap="nowrap">
-              <Text fw={600}>{t('unscheduled_title')}</Text>
-              <Badge color={unscheduledMatches.length > 0 ? 'indigo' : 'green'} variant="filled">
-                {unscheduledMatches.length}
-              </Badge>
-            </Group>
-            {opened ? <IconChevronDown size={20} /> : <IconChevronUp size={20} />}
-          </Group>
-        </UnstyledButton>
-        {rightSection}
-      </Group>
-      <Collapse in={opened}>
-        <ScrollArea.Autosize mah="45dvh">
-          <Box px="sm" pb="sm">
-            {unscheduledMatches.length === 0 ? (
-              <Group gap="sm" py="xs" wrap="nowrap">
-                <ThemeIcon color="green" variant="light" radius="xl">
-                  <IconCheck size={18} />
-                </ThemeIcon>
-                <Box>
-                  <Text size="sm" fw={600}>
-                    {t('all_matches_scheduled_title')}
-                  </Text>
-                  <Text c="dimmed" size="sm">
-                    {t('unscheduled_column_empty_description')}
-                  </Text>
-                </Box>
+    // Portal to the body so the fixed positioning is viewport-relative: the
+    // planning page wraps the grid in a `container-type: inline-size` box, which
+    // establishes a containing block for fixed descendants and would otherwise
+    // pin this sheet to the (often short) grid's bottom instead of the screen.
+    <Portal>
+      <Paper
+        shadow="lg"
+        radius={0}
+        withBorder
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: `min(100%, ${preferredTrayWidthRem}rem)`,
+          zIndex: 150,
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+          borderBottom: 'none',
+        }}
+      >
+        <Group justify="space-between" wrap="nowrap" gap="xs" p="sm">
+          <UnstyledButton
+            onClick={onToggle}
+            style={{ flex: 1, minWidth: 0 }}
+            aria-expanded={opened}
+          >
+            <Group justify="space-between" wrap="nowrap">
+              <Group gap="xs" wrap="nowrap">
+                <Text fw={600}>{t('unscheduled_title')}</Text>
+                <Badge color={unscheduledMatches.length > 0 ? 'indigo' : 'green'} variant="filled">
+                  {unscheduledMatches.length}
+                </Badge>
               </Group>
-            ) : (
-              renderGroups(groups)
-            )}
-          </Box>
-        </ScrollArea.Autosize>
-      </Collapse>
-    </Paper>
+              {opened ? <IconChevronDown size={20} /> : <IconChevronUp size={20} />}
+            </Group>
+          </UnstyledButton>
+          {rightSection}
+        </Group>
+        <Collapse in={opened}>
+          <ScrollArea.Autosize mah="45dvh">
+            <Box px="sm" pb="sm">
+              {unscheduledMatches.length === 0 ? (
+                <Group gap="sm" py="xs" wrap="nowrap">
+                  <ThemeIcon color="green" variant="light" radius="xl">
+                    <IconCheck size={18} />
+                  </ThemeIcon>
+                  <Box>
+                    <Text size="sm" fw={600}>
+                      {t('all_matches_scheduled_title')}
+                    </Text>
+                    <Text c="dimmed" size="sm">
+                      {t('unscheduled_column_empty_description')}
+                    </Text>
+                  </Box>
+                </Group>
+              ) : (
+                renderGroups(groups)
+              )}
+            </Box>
+          </ScrollArea.Autosize>
+        </Collapse>
+      </Paper>
+    </Portal>
   );
 }

--- a/frontend/src/components/scheduling/unscheduled_sheet.tsx
+++ b/frontend/src/components/scheduling/unscheduled_sheet.tsx
@@ -13,7 +13,7 @@ import {
   UnstyledButton,
 } from '@mantine/core';
 import { IconCheck, IconChevronDown, IconChevronUp } from '@tabler/icons-react';
-import { Fragment } from 'react';
+import { Fragment, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
@@ -43,6 +43,7 @@ export default function UnscheduledSheet({
   opened,
   onToggle,
   onSelectMatch,
+  rightSection,
 }: {
   unscheduledMatches: MatchWithDetails[];
   stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
@@ -52,6 +53,9 @@ export default function UnscheduledSheet({
   opened: boolean;
   onToggle: () => void;
   onSelectMatch: (m: MatchWithDetails) => void;
+  // Optional control rendered to the right of the toggle (the mobile tools
+  // button); it sits outside the toggle so tapping it doesn't expand the tray.
+  rightSection?: ReactNode;
 }) {
   const { t } = useTranslation();
   const groups = groupUnscheduledMatchesForTray(unscheduledMatches, matchesLookup, levels);
@@ -171,17 +175,20 @@ export default function UnscheduledSheet({
         borderBottom: 'none',
       }}
     >
-      <UnstyledButton onClick={onToggle} w="100%" p="sm" aria-expanded={opened}>
-        <Group justify="space-between" wrap="nowrap">
-          <Group gap="xs" wrap="nowrap">
-            <Text fw={600}>{t('unscheduled_title')}</Text>
-            <Badge color={unscheduledMatches.length > 0 ? 'indigo' : 'green'} variant="filled">
-              {unscheduledMatches.length}
-            </Badge>
+      <Group justify="space-between" wrap="nowrap" gap="xs" p="sm">
+        <UnstyledButton onClick={onToggle} style={{ flex: 1, minWidth: 0 }} aria-expanded={opened}>
+          <Group justify="space-between" wrap="nowrap">
+            <Group gap="xs" wrap="nowrap">
+              <Text fw={600}>{t('unscheduled_title')}</Text>
+              <Badge color={unscheduledMatches.length > 0 ? 'indigo' : 'green'} variant="filled">
+                {unscheduledMatches.length}
+              </Badge>
+            </Group>
+            {opened ? <IconChevronDown size={20} /> : <IconChevronUp size={20} />}
           </Group>
-          {opened ? <IconChevronDown size={20} /> : <IconChevronUp size={20} />}
-        </Group>
-      </UnstyledButton>
+        </UnstyledButton>
+        {rightSection}
+      </Group>
       <Collapse in={opened}>
         <ScrollArea.Autosize mah="45dvh">
           <Box px="sm" pb="sm">

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionIcon,
   Affix,
   Badge,
   Box,
@@ -14,8 +15,9 @@ import {
   Text,
   Title,
 } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import { showNotification } from '@mantine/notifications';
-import { IconCalendarPlus, IconWand } from '@tabler/icons-react';
+import { IconCalendarPlus, IconTools, IconWand } from '@tabler/icons-react';
 import { isAxiosError } from 'axios';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -80,6 +82,7 @@ import {
 
 import CourtsToolbar from '@components/scheduling/courts_toolbar';
 import MatchActionSheet from '@components/scheduling/match_action_sheet';
+import PlannerToolsSheet from '@components/scheduling/planner_tools_sheet';
 import ScheduleGrid from '@components/scheduling/schedule_grid';
 import SchedulerWeightsForm, {
   DEFAULT_SCHEDULER_WEIGHTS,
@@ -96,6 +99,11 @@ export default function SchedulePage() {
   const [highlightValue, setHighlightValue] = useState<string | null>(null);
   const [now, setNow] = useState(() => new Date());
   const [trayOpened, setTrayOpened] = useState(false);
+  // On phones the inline top toolbar (team search, courts, auto-schedule) is
+  // awkward, so it collapses into a tools sheet reached from a button beside the
+  // unscheduled tray. Same breakpoint the grid uses for its mobile affordances.
+  const isMobile = useMediaQuery('(max-width: 768px)') ?? false;
+  const [toolsOpened, setToolsOpened] = useState(false);
   const [focus, setFocus] = useState<(FocusTarget & { nonce: number }) | null>(null);
   // Details modal opened from the action sheet; holds the match id (not the
   // match) so a background revalidation refreshes the modal's data instead of
@@ -364,53 +372,57 @@ export default function SchedulePage() {
           <Grid.Col span={6}>
             <Title>{t('planning_title')}</Title>
           </Grid.Col>
-          <Grid.Col span={6}>
-            <Group justify="right">
-              <Select
-                aria-label={t('team_highlight_label', 'Highlight team or input')}
-                placeholder={t('team_highlight_placeholder', 'Find team or input')}
-                data={highlightOptions}
-                value={highlightValue}
-                onChange={setHighlightValue}
-                searchable
-                clearable
-                limit={100}
-                w={220}
-                size="sm"
-                mb={10}
-              />
-              <CourtsToolbar
-                tournamentId={tournamentData.id}
-                swrCourtsResponse={swrCourtsResponse}
-                courts={courts}
-                matchesByCourtId={matchesByCourtId}
-              />
-              {courts.length < 1 ? null : (
-                <Button
-                  color="indigo"
-                  size="md"
-                  variant="filled"
-                  style={{ marginBottom: 10 }}
-                  leftSection={<IconCalendarPlus size={24} />}
-                  onClick={() => setScheduleModalOpened(true)}
-                >
-                  {t('schedule_description')}
-                </Button>
-              )}
-              {courts.length < 1 ? null : (
-                <Button
-                  color="grape"
-                  size="md"
-                  variant="light"
-                  style={{ marginBottom: 10 }}
-                  leftSection={<IconWand size={24} />}
-                  onClick={() => setReoptimizeModalOpened(true)}
-                >
-                  {t('reoptimize_description')}
-                </Button>
-              )}
-            </Group>
-          </Grid.Col>
+          {/* On mobile these controls move into the tools sheet reached from the
+              unscheduled tray, leaving the header uncluttered. */}
+          {!isMobile && (
+            <Grid.Col span={6}>
+              <Group justify="right">
+                <Select
+                  aria-label={t('team_highlight_label', 'Highlight team or input')}
+                  placeholder={t('team_highlight_placeholder', 'Find team or input')}
+                  data={highlightOptions}
+                  value={highlightValue}
+                  onChange={setHighlightValue}
+                  searchable
+                  clearable
+                  limit={100}
+                  w={220}
+                  size="sm"
+                  mb={10}
+                />
+                <CourtsToolbar
+                  tournamentId={tournamentData.id}
+                  swrCourtsResponse={swrCourtsResponse}
+                  courts={courts}
+                  matchesByCourtId={matchesByCourtId}
+                />
+                {courts.length < 1 ? null : (
+                  <Button
+                    color="indigo"
+                    size="md"
+                    variant="filled"
+                    style={{ marginBottom: 10 }}
+                    leftSection={<IconCalendarPlus size={24} />}
+                    onClick={() => setScheduleModalOpened(true)}
+                  >
+                    {t('schedule_description')}
+                  </Button>
+                )}
+                {courts.length < 1 ? null : (
+                  <Button
+                    color="grape"
+                    size="md"
+                    variant="light"
+                    style={{ marginBottom: 10 }}
+                    leftSection={<IconWand size={24} />}
+                    onClick={() => setReoptimizeModalOpened(true)}
+                  >
+                    {t('reoptimize_description')}
+                  </Button>
+                )}
+              </Group>
+            </Grid.Col>
+          )}
         </Grid>
         {courts.length < 1 ? (
           <Stack align="center" mt="1rem">
@@ -466,7 +478,34 @@ export default function SchedulePage() {
               opened={trayOpened}
               onToggle={() => setTrayOpened((opened) => !opened)}
               onSelectMatch={(m) => handlePlannerEvent({ type: 'tap-tray-match', matchId: m.id })}
+              rightSection={
+                isMobile ? (
+                  <ActionIcon
+                    variant="default"
+                    size="lg"
+                    aria-label={t('planner_tools_title')}
+                    onClick={() => setToolsOpened(true)}
+                  >
+                    <IconTools size={20} />
+                  </ActionIcon>
+                ) : null
+              }
             />
+            {isMobile && (
+              <PlannerToolsSheet
+                opened={toolsOpened}
+                onClose={() => setToolsOpened(false)}
+                tournamentId={tournamentData.id}
+                swrCourtsResponse={swrCourtsResponse}
+                courts={courts}
+                matchesByCourtId={matchesByCourtId}
+                highlightOptions={highlightOptions}
+                highlightValue={highlightValue}
+                onHighlightChange={setHighlightValue}
+                onSchedule={() => setScheduleModalOpened(true)}
+                onReoptimize={() => setReoptimizeModalOpened(true)}
+              />
+            )}
             <MatchActionSheet
               opened={sheetMatchRef != null}
               match={


### PR DESCRIPTION
## Summary
Introduces a mobile-optimized bottom sheet that consolidates the planner toolbar controls (team highlight, court management, and auto-schedule actions) into a single accessible interface on small screens, improving the mobile UX by reducing header clutter.

## Key Changes

- **New `PlannerToolsSheet` component** (`planner_tools_sheet.tsx`): A mobile-only bottom sheet that gathers team highlight selection, court add/delete, and schedule/reoptimize actions behind a single tools button. The sheet closes automatically when opening modals to avoid overlay stacking.

- **New `CourtDeleteModal` component** (`court_delete_modal.tsx`): Extracted court deletion UI from `CourtsToolbar` into a reusable modal component shared by both desktop and mobile interfaces. Displays courts with match-count badges and delete controls.

- **Updated `UnscheduledSheet` component**: 
  - Wrapped in a `Portal` to fix positioning relative to the viewport (not the grid's containing block)
  - Added optional `rightSection` prop to accommodate the mobile tools button
  - Restructured header layout to place the toggle button and right section controls in a single `Group`

- **Updated `CourtsToolbar` component**: Refactored to use the new `CourtDeleteModal` component, reducing duplication.

- **Updated schedule page** (`schedule.tsx`):
  - Added mobile breakpoint detection (`isMobile`) at 768px
  - Conditionally hides desktop toolbar on mobile devices
  - Renders `PlannerToolsSheet` on mobile with a tools button in the unscheduled tray
  - Passes all necessary props (courts, matches, highlight options, callbacks) to the sheet

- **Localization**: Added `planner_tools_title` translation key to English and German locale files.

## Implementation Details

- The tools sheet uses the same modal-closing pattern as the match action sheet to prevent overlay stacking
- Court modals remain mounted in the sheet so they survive the sheet's close action
- The unscheduled tray's fixed positioning is corrected via Portal to work properly within the grid's container query context
- Mobile detection uses Mantine's `useMediaQuery` hook for responsive behavior

https://claude.ai/code/session_01C4Usa5qa5U3jtr7oqqUo3B