### PR TITLE
Fix invisible Advanced button in scheduler modals on light mode

### DIFF
--- a/frontend/src/components/scheduling/scheduler_weights_form.tsx
+++ b/frontend/src/components/scheduling/scheduler_weights_form.tsx
@@ -38,7 +38,7 @@ export default function SchedulerWeightsForm({
         type="button"
         onClick={onToggle}
         size="sm"
-        c="rgba(255, 255, 255, 0.5)"
+        c="dimmed"
         style={{ alignSelf: 'flex-start' }}
       >
         {opened ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}{' '}


### PR DESCRIPTION
The Advanced toggle in the auto-optimizer modals used a hardcoded
semi-transparent white color, making it invisible against the light
background in light mode (e.g. mobile Safari). Use Mantine's
theme-aware 'dimmed' color so it adapts to both color schemes.