### PR TITLE
feat(referees): conflict detection for team playing and refereeing overlap (#36)

### DIFF
--- a/backend/alembic/versions/f2a4c8e1b9d3_add_referee_conflict_to_matches.py
+++ b/backend/alembic/versions/f2a4c8e1b9d3_add_referee_conflict_to_matches.py
@@ -1,0 +1,31 @@
+"""add referee_conflict to matches
+
+Revision ID: f2a4c8e1b9d3
+Revises: d3f1a2b9c4e7
+Create Date: 2026-06-15 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str | None = "f2a4c8e1b9d3"
+down_revision: str | None = "d3f1a2b9c4e7"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "matches",
+        sa.Column("referee_conflict", sa.Boolean(), nullable=True, server_default="f"),
+    )
+    op.execute(text("UPDATE matches SET referee_conflict=false"))
+    op.alter_column("matches", "referee_conflict", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("matches", "referee_conflict")

--- a/backend/bracket/logic/planning/conflicts.py
+++ b/backend/bracket/logic/planning/conflicts.py
@@ -44,6 +44,7 @@ class MatchConflictFlags:
     stage_item_input2_conflict: bool = False
     precedence_conflict: bool = False
     short_break_conflict: bool = False
+    referee_conflict: bool = False
 
 
 def _get_all_matches(
@@ -175,6 +176,34 @@ def _set_short_break_conflicts(
                 flags[match.id].short_break_conflict = True
 
 
+def _set_referee_overlap_conflicts(
+    stages: list[StageWithStageItems],
+    flags: dict[MatchId, MatchConflictFlags],
+) -> None:
+    team_playing_windows = get_team_playing_windows(stages)
+
+    for match in _get_all_matches(stages):
+        if match.start_time is None:
+            continue
+        referee = match.referee
+        if referee is None or referee.team_id is None:
+            continue
+
+        for playing_match, playing_window in team_playing_windows.get(referee.team_id, []):
+            if playing_match.id == match.id:
+                continue
+            if not _time_ranges_overlap(
+                match.start_time,
+                match.end_time,
+                playing_window.start_time,
+                playing_window.end_time,
+            ):
+                continue
+            flags[match.id].referee_conflict = True
+            if isinstance(playing_match, MatchWithDetailsDefinitive):
+                _set_stage_item_input_conflict(playing_match, playing_window, flags)
+
+
 def get_match_conflict_flags(
     stages: list[StageWithStageItems], default_break_minutes: int
 ) -> dict[MatchId, MatchConflictFlags]:
@@ -182,6 +211,7 @@ def get_match_conflict_flags(
     flags = {match.id: MatchConflictFlags() for match in matches}
 
     _set_team_overlap_conflicts(stages, flags)
+    _set_referee_overlap_conflicts(stages, flags)
     _set_winner_of_precedence_conflicts(matches, flags)
     _set_cross_stage_precedence_conflicts(stages, flags)
     _set_short_break_conflicts(matches, default_break_minutes, flags)
@@ -221,7 +251,8 @@ async def set_conflicts(match_conflicts: dict[MatchId, MatchConflictFlags]) -> N
                 stage_item_input1_conflict = :stage_item_input1_conflict,
                 stage_item_input2_conflict = :stage_item_input2_conflict,
                 precedence_conflict = :precedence_conflict,
-                short_break_conflict = :short_break_conflict
+                short_break_conflict = :short_break_conflict,
+                referee_conflict = :referee_conflict
             WHERE id = :match_id
             """,
             values={
@@ -230,6 +261,7 @@ async def set_conflicts(match_conflicts: dict[MatchId, MatchConflictFlags]) -> N
                 "stage_item_input2_conflict": conflict.stage_item_input2_conflict,
                 "precedence_conflict": conflict.precedence_conflict,
                 "short_break_conflict": conflict.short_break_conflict,
+                "referee_conflict": conflict.referee_conflict,
             },
         )
 

--- a/backend/bracket/models/db/match.py
+++ b/backend/bracket/models/db/match.py
@@ -42,6 +42,7 @@ class MatchBaseInsertable(BaseModelORM):
     stage_item_input2_conflict: bool
     precedence_conflict: bool = False
     short_break_conflict: bool = False
+    referee_conflict: bool = False
     state: MatchState = MatchState.NOT_STARTED
     completed_at: datetime_utc | None = None
 

--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -360,6 +360,7 @@ async def update_match_by_id(
             await sql_set_match_referee(match_id, referee.id)
         else:
             await sql_set_match_referee(match_id, None)
+        await reconcile_conflicts(tournament_id)
 
     round_ = await get_round_by_id(tournament_id, match.round_id)
     stage_item = await get_stage_item(tournament_id, round_.stage_item_id)

--- a/backend/bracket/schema.py
+++ b/backend/bracket/schema.py
@@ -166,6 +166,7 @@ matches = Table(
     Column("stage_item_input2_conflict", Boolean, nullable=False),
     Column("precedence_conflict", Boolean, nullable=False, server_default="f"),
     Column("short_break_conflict", Boolean, nullable=False, server_default="f"),
+    Column("referee_conflict", Boolean, nullable=False, server_default="f"),
     Column(
         "stage_item_input1_winner_from_match_id",
         BigInteger,

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -463,6 +463,11 @@
             "title": "Precedence Conflict",
             "type": "boolean"
           },
+          "referee_conflict": {
+            "default": false,
+            "title": "Referee Conflict",
+            "type": "boolean"
+          },
           "referee_id": {
             "anyOf": [
               {
@@ -608,6 +613,7 @@
           "stage_item_input2_conflict",
           "precedence_conflict",
           "short_break_conflict",
+          "referee_conflict",
           "state",
           "completed_at",
           "stage_item_input1_id",
@@ -979,6 +985,11 @@
               }
             ]
           },
+          "referee_conflict": {
+            "default": false,
+            "title": "Referee Conflict",
+            "type": "boolean"
+          },
           "referee_id": {
             "anyOf": [
               {
@@ -1124,6 +1135,7 @@
           "stage_item_input2_conflict",
           "precedence_conflict",
           "short_break_conflict",
+          "referee_conflict",
           "state",
           "completed_at",
           "stage_item_input1_id",
@@ -1225,6 +1237,11 @@
               }
             ]
           },
+          "referee_conflict": {
+            "default": false,
+            "title": "Referee Conflict",
+            "type": "boolean"
+          },
           "referee_id": {
             "anyOf": [
               {
@@ -1364,6 +1381,7 @@
           "stage_item_input2_conflict",
           "precedence_conflict",
           "short_break_conflict",
+          "referee_conflict",
           "state",
           "completed_at",
           "stage_item_input1_id",

--- a/backend/tests/unit_tests/conflicts_test.py
+++ b/backend/tests/unit_tests/conflicts_test.py
@@ -9,12 +9,22 @@ from bracket.logic.planning.conflicts import (
 )
 from bracket.logic.planning.team_windows import get_team_playing_windows
 from bracket.models.db.match import MatchState, MatchWithDetailsDefinitive
-from bracket.models.db.stage_item_inputs import StageItemInputTentative
-from bracket.models.db.util import RoundWithMatches, StageWithStageItems
-from bracket.utils.dummy_records import DUMMY_MOCK_TIME
+from bracket.models.db.referee import Referee
+from bracket.models.db.stage_item import StageType
+from bracket.models.db.stage_item_inputs import StageItemInputFinal, StageItemInputTentative
+from bracket.models.db.team import Team
+from bracket.models.db.util import RoundWithMatches, StageItemWithRounds, StageWithStageItems
+from bracket.utils.dummy_records import (
+    DUMMY_MOCK_TIME,
+    DUMMY_TEAM1,
+    DUMMY_TEAM2,
+    DUMMY_TEAM3,
+    DUMMY_TEAM4,
+)
 from bracket.utils.id_types import (
     CourtId,
     MatchId,
+    RefereeId,
     RoundId,
     StageId,
     StageItemId,
@@ -320,3 +330,249 @@ def test_get_match_conflict_flags_marks_sub_default_break_on_later_match() -> No
 
     assert flags[match1.id].short_break_conflict is False
     assert flags[match2.id].short_break_conflict is True
+
+
+# ---------------------------------------------------------------------------
+# Referee conflict tests
+# ---------------------------------------------------------------------------
+
+
+def _make_definitive_match(
+    match_id: MatchId,
+    input1: StageItemInputFinal,
+    input2: StageItemInputFinal,
+    round_id: RoundId,
+    court_id: CourtId,
+    start_time: object,
+    duration_minutes: int = 60,
+    referee: Referee | None = None,
+) -> MatchWithDetailsDefinitive:
+    return MatchWithDetailsDefinitive(
+        id=match_id,
+        stage_item_input1=input1,
+        stage_item_input2=input2,
+        stage_item_input1_id=input1.id,
+        stage_item_input2_id=input2.id,
+        created=DUMMY_MOCK_TIME,
+        start_time=start_time,  # type: ignore[arg-type]
+        duration_minutes=duration_minutes,
+        round_id=round_id,
+        court_id=court_id,
+        stage_item_input1_score=0,
+        stage_item_input2_score=0,
+        stage_item_input1_conflict=False,
+        stage_item_input2_conflict=False,
+        state=MatchState.NOT_STARTED,
+        completed_at=None,
+        referee=referee,
+    )
+
+
+def _make_stage_with_two_matches(
+    match1: MatchWithDetailsDefinitive,
+    match2: MatchWithDetailsDefinitive,
+) -> StageWithStageItems:
+    round1 = RoundWithMatches(
+        id=RoundId(-10),
+        matches=[match1],
+        stage_item_id=StageItemId(-10),
+        created=MOCK_NOW,
+        is_draft=False,
+        name="",
+    )
+    round2 = RoundWithMatches(
+        id=RoundId(-11),
+        matches=[match2],
+        stage_item_id=StageItemId(-10),
+        created=MOCK_NOW,
+        is_draft=False,
+        name="",
+    )
+    stage_item = StageItemWithRounds(
+        rounds=[round1, round2],
+        inputs=[match1.stage_item_input1, match1.stage_item_input2],
+        type_name="Single Elimination",
+        team_count=4,
+        ranking_id=None,
+        id=StageItemId(-10),
+        stage_id=StageId(-10),
+        name="",
+        created=MOCK_NOW,
+        type=StageType.SINGLE_ELIMINATION,
+    )
+    return StageWithStageItems(
+        id=StageId(-10),
+        tournament_id=TournamentId(-1),
+        name="",
+        created=MOCK_NOW,
+        is_active=False,
+        stage_items=[stage_item],
+    )
+
+
+def _make_inputs(
+    tournament_id: TournamentId,
+) -> tuple[StageItemInputFinal, StageItemInputFinal, StageItemInputFinal, StageItemInputFinal]:
+    return (
+        StageItemInputFinal(
+            id=StageItemInputId(-20),
+            team_id=TeamId(-20),
+            slot=1,
+            tournament_id=tournament_id,
+            team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(-20)),
+        ),
+        StageItemInputFinal(
+            id=StageItemInputId(-21),
+            team_id=TeamId(-21),
+            slot=2,
+            tournament_id=tournament_id,
+            team=Team(**DUMMY_TEAM2.model_dump(), id=TeamId(-21)),
+        ),
+        StageItemInputFinal(
+            id=StageItemInputId(-22),
+            team_id=TeamId(-22),
+            slot=3,
+            tournament_id=tournament_id,
+            team=Team(**DUMMY_TEAM3.model_dump(), id=TeamId(-22)),
+        ),
+        StageItemInputFinal(
+            id=StageItemInputId(-23),
+            team_id=TeamId(-23),
+            slot=4,
+            tournament_id=tournament_id,
+            team=Team(**DUMMY_TEAM4.model_dump(), id=TeamId(-23)),
+        ),
+    )
+
+
+def test_referee_conflict_flags_both_sides() -> None:
+    """A team playing and refereeing in overlapping windows flags both matches."""
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    # inp[0] (team -20) plays in playing_match; refereeing_match has team -20 as referee
+    playing_match = _make_definitive_match(
+        MatchId(-20), inp[0], inp[1], RoundId(-10), CourtId(-1), T
+    )
+    refereeing_match = _make_definitive_match(
+        MatchId(-21),
+        inp[2],
+        inp[3],
+        RoundId(-11),
+        CourtId(-2),
+        T,
+        referee=Referee(
+            id=RefereeId(-1), tournament_id=tid, team_id=TeamId(-20), created=DUMMY_MOCK_TIME
+        ),
+    )
+    stage = _make_stage_with_two_matches(playing_match, refereeing_match)
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[refereeing_match.id].referee_conflict is True
+    assert flags[playing_match.id].stage_item_input1_conflict is True
+    assert flags[playing_match.id].stage_item_input2_conflict is False
+    assert flags[playing_match.id].referee_conflict is False
+
+
+def test_referee_conflict_free_text_no_conflict() -> None:
+    """A free-text referee (no team_id) never produces a conflict."""
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    playing_match = _make_definitive_match(
+        MatchId(-20), inp[0], inp[1], RoundId(-10), CourtId(-1), T
+    )
+    refereeing_match = _make_definitive_match(
+        MatchId(-21),
+        inp[2],
+        inp[3],
+        RoundId(-11),
+        CourtId(-2),
+        T,
+        referee=Referee(
+            id=RefereeId(-1), tournament_id=tid, name="John Smith", created=DUMMY_MOCK_TIME
+        ),
+    )
+    stage = _make_stage_with_two_matches(playing_match, refereeing_match)
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[refereeing_match.id].referee_conflict is False
+    assert flags[playing_match.id].stage_item_input1_conflict is False
+    assert flags[playing_match.id].stage_item_input2_conflict is False
+
+
+def test_referee_conflict_non_overlapping_no_conflict() -> None:
+    """Non-overlapping windows (refereeing ends before playing starts) produce no conflict."""
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    # playing_match: T to T+60min; refereeing_match: T+120min onwards — no overlap
+    playing_match = _make_definitive_match(
+        MatchId(-20), inp[0], inp[1], RoundId(-10), CourtId(-1), T
+    )
+    refereeing_match = _make_definitive_match(
+        MatchId(-21),
+        inp[2],
+        inp[3],
+        RoundId(-11),
+        CourtId(-2),
+        T + timedelta(hours=2),
+        referee=Referee(
+            id=RefereeId(-1), tournament_id=tid, team_id=TeamId(-20), created=DUMMY_MOCK_TIME
+        ),
+    )
+    stage = _make_stage_with_two_matches(playing_match, refereeing_match)
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[refereeing_match.id].referee_conflict is False
+    assert flags[playing_match.id].stage_item_input1_conflict is False
+
+
+def test_referee_conflict_no_playing_match_no_conflict() -> None:
+    """A team referee whose team has no scheduled playing match produces no conflict."""
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    # Only one match: team -22 and -23 play; referee is team -20 (not playing anywhere)
+    refereeing_match = _make_definitive_match(
+        MatchId(-21),
+        inp[2],
+        inp[3],
+        RoundId(-11),
+        CourtId(-2),
+        T,
+        referee=Referee(
+            id=RefereeId(-1), tournament_id=tid, team_id=TeamId(-20), created=DUMMY_MOCK_TIME
+        ),
+    )
+    round1 = RoundWithMatches(
+        id=RoundId(-11),
+        matches=[refereeing_match],
+        stage_item_id=StageItemId(-10),
+        created=MOCK_NOW,
+        is_draft=False,
+        name="",
+    )
+    stage_item = StageItemWithRounds(
+        rounds=[round1],
+        inputs=[inp[2], inp[3]],
+        type_name="Single Elimination",
+        team_count=2,
+        ranking_id=None,
+        id=StageItemId(-10),
+        stage_id=StageId(-10),
+        name="",
+        created=MOCK_NOW,
+        type=StageType.SINGLE_ELIMINATION,
+    )
+    stage = StageWithStageItems(
+        id=StageId(-10),
+        tournament_id=tid,
+        name="",
+        created=MOCK_NOW,
+        is_active=False,
+        stage_items=[stage_item],
+    )
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[refereeing_match.id].referee_conflict is False

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -167,6 +167,7 @@
     "max_results_input_label": "Maximale Ergebnisse",
     "match_scheduled_before_previous_stage_label": "Vor einem Spiel einer früheren Phase auf diesem Spielfeld geplant",
     "precedence_conflict_label": "Beginnt, bevor ein Zubringerspiel beendet ist",
+    "referee_conflict_label": "Der Schiedsrichter spielt ebenfalls während dieses Spiels",
     "short_break_conflict_label": "Die Pause vor diesem Spiel ist kürzer als die Standardpause",
     "members_table_header": "Mitglieder",
     "minutes": "Minuten",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -167,6 +167,7 @@
     "max_results_input_label": "Max results",
     "match_scheduled_before_previous_stage_label": "Scheduled before a match of an earlier stage on this court",
     "precedence_conflict_label": "Starts before a feeder match has finished",
+    "referee_conflict_label": "Referee is also playing during this match",
     "short_break_conflict_label": "Break before this match is shorter than the default",
     "members_table_header": "Members",
     "minutes": "minutes",

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -259,6 +259,17 @@ function MatchCard({
       </Box>
     </Tooltip>
   ) : null;
+  const refereeConflictIcon =
+    refereesEnabled && match.referee_conflict ? (
+      <Tooltip label={t('referee_conflict_label', 'Referee is also playing during this match')}>
+        <Box
+          component="span"
+          style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}
+        >
+          <AiFillWarning color="orange" />
+        </Box>
+      </Tooltip>
+    ) : null;
   const placementWarningIcon = hasPlacementWarning ? (
     <Tooltip label={t('placement_conflict_preview_label', 'Would double-book a team')}>
       <Box
@@ -331,6 +342,7 @@ function MatchCard({
             {badgeLabel != null ? fullBadge(badgeLabel) : null}
             {placementWarningIcon}
             {shortBreakIcon}
+            {refereeConflictIcon}
             {violationIcon}
           </Flex>
         )}
@@ -341,6 +353,7 @@ function MatchCard({
           {match.stage_item_input1_conflict && <AiFillWarning color="red" />}
           {rows < 3 && placementWarningIcon}
           {rows < 3 && shortBreakIcon}
+          {rows < 3 && refereeConflictIcon}
           {rows === 1 &&
             match.stage_item_input2_conflict &&
             !(mergeConflictIcons && match.stage_item_input1_conflict) && (

--- a/frontend/src/openapi/types.gen.ts
+++ b/frontend/src/openapi/types.gen.ts
@@ -290,6 +290,10 @@ export type Match = {
    */
   precedence_conflict: boolean;
   /**
+   * Referee Conflict
+   */
+  referee_conflict: boolean;
+  /**
    * Referee Id
    */
   referee_id: number | null;
@@ -524,6 +528,10 @@ export type MatchWithDetails = {
   precedence_conflict: boolean;
   referee: Referee | null;
   /**
+   * Referee Conflict
+   */
+  referee_conflict: boolean;
+  /**
    * Referee Id
    */
   referee_id: number | null;
@@ -620,6 +628,10 @@ export type MatchWithDetailsDefinitive = {
    */
   precedence_conflict: boolean;
   referee: Referee | null;
+  /**
+   * Referee Conflict
+   */
+  referee_conflict: boolean;
   /**
    * Referee Id
    */


### PR DESCRIPTION
- Add `referee_conflict` boolean to matches schema, model, and migration
- Extend `conflicts.py` with `_set_referee_overlap_conflicts`: flags the
  refereeing match with `referee_conflict` and the playing match with the
  existing input-conflict indicator when windows overlap; free-text referees
  are ignored
- Update `set_conflicts` to persist the new flag
- Add four pure unit tests covering both-side flagging, free-text no-op,
  non-overlap no-op, and no-playing-match no-op
- Planning schedule cards render an orange warning indicator when
  `referee_conflict` is true and referees are enabled
- Add `referee_conflict_label` translations (EN + DE)
- Regenerate OpenAPI schema and frontend types

https://claude.ai/code/session_01R4ixTbkbDwN32DejW8zZ5P