### PR TITLE
feat(referees): show referee in public dashboard and score-tracking views (#35)

### DIFF
--- a/backend/bracket/routes/models.py
+++ b/backend/bracket/routes/models.py
@@ -146,6 +146,7 @@ class ScoreTrackingInfo(BaseModel):
     tournament_name: str
     matches: list[MatchWithDetails]
     has_active_stage: bool
+    referees_enabled: bool = False
     levels: list[LevelResponse] = []
     courts: list[Court] = []
 

--- a/backend/bracket/routes/score_tracking.py
+++ b/backend/bracket/routes/score_tracking.py
@@ -57,6 +57,7 @@ async def get_score_tracking_info(
             tournament_name=tournament.name,
             matches=matches,
             has_active_stage=has_active_stage,
+            referees_enabled=tournament.referees_enabled,
             levels=[LevelResponse.model_validate(level) for level in levels],
             courts=courts,
         )
@@ -105,6 +106,7 @@ async def get_authenticated_score_tracking_info(
             tournament_name=tournament.name,
             matches=matches,
             has_active_stage=has_active_stage,
+            referees_enabled=tournament.referees_enabled,
             levels=[LevelResponse.model_validate(level) for level in levels],
             courts=courts,
         )

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -2102,6 +2102,11 @@
             "title": "Matches",
             "type": "array"
           },
+          "referees_enabled": {
+            "default": false,
+            "title": "Referees Enabled",
+            "type": "boolean"
+          },
           "tournament_id": {
             "title": "Tournament Id",
             "type": "integer"
@@ -2116,6 +2121,7 @@
           "tournament_name",
           "matches",
           "has_active_stage",
+          "referees_enabled",
           "levels",
           "courts"
         ],

--- a/backend/tests/integration_tests/api/score_tracking_test.py
+++ b/backend/tests/integration_tests/api/score_tracking_test.py
@@ -33,6 +33,38 @@ from tests.integration_tests.sql import (
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_score_tracking_response_includes_referees_enabled_false_by_default(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    response = await send_tournament_request(HTTPMethod.GET, "score-tracking", auth_context, {})
+    assert response["data"]["referees_enabled"] is False
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_score_tracking_response_includes_referees_enabled_true_when_set(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    await database.execute(
+        query=tournaments.update()
+        .where(tournaments.c.id == auth_context.tournament.id)
+        .values(referees_enabled=True, score_tracking_enabled=True, score_tracking_token="ref-enabled-token"),
+    )
+    try:
+        authenticated_response = await send_tournament_request(
+            HTTPMethod.GET, "score-tracking", auth_context, {}
+        )
+        public_response = await send_request(HTTPMethod.GET, "score-tracking/ref-enabled-token")
+        assert authenticated_response["data"]["referees_enabled"] is True
+        assert public_response["data"]["referees_enabled"] is True
+    finally:
+        await database.execute(
+            query=tournaments.update()
+            .where(tournaments.c.id == auth_context.tournament.id)
+            .values(referees_enabled=False, score_tracking_enabled=False, score_tracking_token=None),
+        )
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_authenticated_score_tracking_list_works_when_public_link_disabled(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -14,12 +14,12 @@ import {
 } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import { AiFillWarning } from '@react-icons/all-files/ai/AiFillWarning';
-import { GiWhistle } from '@react-icons/all-files/gi/GiWhistle';
 import { format } from 'date-fns';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
+import { RefereeDisplay } from '@components/utils/referee';
 import { NEUTRAL_STAGE_ITEM_COLOUR, scoreColour, type StageItemColour } from '@logic/colors';
 import { ConflictPreview, insertionLineKey } from '@logic/planning/conflict_preview';
 import { HighlightTarget, matchInvolvesHighlight } from '@logic/planning/highlight';
@@ -127,8 +127,6 @@ function MatchCard({
   // A one-row card is too narrow for everything; both conflict flags collapse
   // into a single icon.
   const mergeConflictIcons = rows === 1;
-
-  const refereeName = match.referee?.name ?? match.referee?.team_name ?? null;
 
   let input1 = formatMatchInput1(t, stageItemsLookup, matchesLookup, match);
   let input2 = formatMatchInput2(t, stageItemsLookup, matchesLookup, match);
@@ -367,14 +365,7 @@ function MatchCard({
             {showScore && pinnedScores(scoreChip(match.stage_item_input2_score, score2Colour))}
           </Flex>
         )}
-        {refereesEnabled && refereeName != null && rows >= 2 && (
-          <Flex gap={4} align="center" wrap="nowrap" c="dimmed">
-            <GiWhistle size={fontSize ?? 13} style={{ flexShrink: 0 }} />
-            <Text size="xs" fz={fontSize} lh={1.3} c="dimmed" truncate>
-              {refereeName}
-            </Text>
-          </Flex>
-        )}
+        {rows >= 2 && <RefereeDisplay referee={match.referee} refereesEnabled={refereesEnabled} />}
       </Box>
     </Box>
   );

--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -23,6 +23,7 @@ import { LevelBadge, LevelFilterSelect } from '@components/levels/levels';
 import { Time } from '@components/utils/datetime';
 import PreloadLink from '@components/utils/link';
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
+import { RefereeDisplay } from '@components/utils/referee';
 import { responseIsValid } from '@components/utils/util';
 import { getScoreColors } from '@logic/colors';
 import {
@@ -89,6 +90,7 @@ export function ScoreTrackingListView({
   const info = responseData.data;
   const levels = info.levels ?? [];
   const courts = info.courts ?? [];
+  const refereesEnabled = info.referees_enabled ?? false;
   const matches = (info.matches || []).filter(
     (match) => filteredLevelId === 'all' || `${match.level_id}` === filteredLevelId
   );
@@ -214,6 +216,7 @@ export function ScoreTrackingListView({
                   </div>
                 </Grid.Col>
               </Grid>
+              <RefereeDisplay referee={match.referee} refereesEnabled={refereesEnabled} />
               <Flex justify="center" pt="xs">
                 <Button component={PreloadLink} href={getMatchHref(match.id)}>
                   {t('open_score_tracker_button')}
@@ -233,11 +236,13 @@ export function ScoreTrackingMatchView({
   storageKey,
   saveMatch,
   levels = [],
+  refereesEnabled = false,
 }: {
   swrResponse: SWRResponse<ScoreTrackingMatchResponse>;
   backHref: string;
   storageKey: string;
   levels?: LevelResponse[];
+  refereesEnabled?: boolean;
   saveMatch: (next: {
     stage_item_input1_score: number;
     stage_item_input2_score: number;
@@ -325,6 +330,7 @@ export function ScoreTrackingMatchView({
             {t('back_to_matches_button')}
           </Button>
         </Group>
+        <RefereeDisplay referee={match.referee} refereesEnabled={refereesEnabled} />
         {match.state === 'NOT_STARTED' ? (
           <Center>
             <Button

--- a/frontend/src/components/utils/referee.tsx
+++ b/frontend/src/components/utils/referee.tsx
@@ -1,0 +1,29 @@
+import { Flex, Text } from '@mantine/core';
+import { GiWhistle } from '@react-icons/all-files/gi/GiWhistle';
+
+import { Referee } from '@openapi';
+
+export function getRefereeName(referee: Referee | null | undefined): string | null {
+  if (referee == null) return null;
+  return referee.name ?? referee.team_name ?? null;
+}
+
+export function RefereeDisplay({
+  referee,
+  refereesEnabled,
+}: {
+  referee: Referee | null | undefined;
+  refereesEnabled: boolean;
+}) {
+  const name = getRefereeName(referee);
+  if (!refereesEnabled || name == null) return null;
+
+  return (
+    <Flex gap={4} align="center" wrap="nowrap">
+      <GiWhistle size={13} style={{ flexShrink: 0, color: 'var(--mantine-color-dimmed)' }} />
+      <Text size="xs" c="dimmed" truncate>
+        {name}
+      </Text>
+    </Flex>
+  );
+}

--- a/frontend/src/openapi/types.gen.ts
+++ b/frontend/src/openapi/types.gen.ts
@@ -1118,6 +1118,10 @@ export type ScoreTrackingInfo = {
    */
   matches: Array<MatchWithDetails>;
   /**
+   * Referees Enabled
+   */
+  referees_enabled: boolean;
+  /**
    * Tournament Id
    */
   tournament_id: number;

--- a/frontend/src/pages/score_tracking_match.tsx
+++ b/frontend/src/pages/score_tracking_match.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router';
 
 import { ScoreTrackingMatchView } from '@components/score_tracking/views';
 import { updateScoreTrackingMatch } from '@services/match';
-import { getScoreTrackingMatch } from '@services/score_tracking';
+import { getScoreTrackingInfo, getScoreTrackingMatch } from '@services/score_tracking';
 
 export default function ScoreTrackingMatchPage() {
   const { score_tracking_token, match_id } = useParams<{
@@ -11,12 +11,15 @@ export default function ScoreTrackingMatchPage() {
   }>();
   const matchId = match_id != null ? parseInt(match_id, 10) : null;
   const swrResponse = getScoreTrackingMatch(score_tracking_token ?? null, matchId);
+  const swrInfoResponse = getScoreTrackingInfo(score_tracking_token ?? null, null);
+  const refereesEnabled = swrInfoResponse.data?.data.referees_enabled ?? false;
 
   return (
     <ScoreTrackingMatchView
       swrResponse={swrResponse}
       backHref={`/score-tracking/${score_tracking_token}`}
       storageKey={`score-tracking:${score_tracking_token}:${matchId}:swapped`}
+      refereesEnabled={refereesEnabled}
       saveMatch={async (next) => {
         if (score_tracking_token == null || matchId == null) return;
         await updateScoreTrackingMatch(score_tracking_token, matchId, next);

--- a/frontend/src/pages/tournaments/[id]/dashboard/index.tsx
+++ b/frontend/src/pages/tournaments/[id]/dashboard/index.tsx
@@ -14,6 +14,7 @@ import {
   formatMatchInput2,
   isMatchCompletedRecently,
 } from '@components/utils/match';
+import { RefereeDisplay } from '@components/utils/referee';
 import { Translator } from '@components/utils/types';
 import { responseIsValid, setTitle } from '@components/utils/util';
 import { getScoreColors } from '@logic/colors';
@@ -27,11 +28,13 @@ export function ScheduleRow({
   stageItemsLookup,
   matchesLookup,
   levels,
+  refereesEnabled,
 }: {
   data: any;
   stageItemsLookup: any;
   matchesLookup: any;
   levels: LevelResponse[];
+  refereesEnabled: boolean;
 }) {
   const { t } = useTranslation();
   const colors = getScoreColors(data.match);
@@ -103,6 +106,7 @@ export function ScheduleRow({
             </div>
           </Grid.Col>
         </Grid>
+        <RefereeDisplay referee={data.match.referee} refereesEnabled={refereesEnabled} />
       </Stack>
     </Card>
   );
@@ -113,11 +117,13 @@ export function Schedule({
   stageItemsLookup,
   matchesLookup,
   levels,
+  refereesEnabled,
 }: {
   t: Translator;
   stageItemsLookup: any;
   matchesLookup: any;
   levels: LevelResponse[];
+  refereesEnabled: boolean;
 }) {
   const matches: any[] = Object.values(matchesLookup)
     .map((item: any) => item)
@@ -146,6 +152,7 @@ export function Schedule({
         stageItemsLookup={stageItemsLookup}
         matchesLookup={matchesLookup}
         levels={levels}
+        refereesEnabled={refereesEnabled}
       />
     );
   }
@@ -200,6 +207,7 @@ export default function DashboardSchedulePage() {
             matchesLookup={filteredMatchesLookup}
             stageItemsLookup={stageItemsLookup}
             levels={tournamentDataFull.levels}
+            refereesEnabled={tournamentDataFull.referees_enabled}
           />
         </Group>
       </Center>

--- a/frontend/src/pages/tournaments/[id]/dashboard/matches.tsx
+++ b/frontend/src/pages/tournaments/[id]/dashboard/matches.tsx
@@ -71,6 +71,7 @@ export default function DashboardMatchesPage() {
         stageItemsLookup={stageItemsLookup}
         matchesLookup={matchesLookup}
         levels={tournamentDataFull.levels}
+        refereesEnabled={tournamentDataFull.referees_enabled}
       />
     );
   }

--- a/frontend/src/pages/tournaments/[id]/score_tracking_match.tsx
+++ b/frontend/src/pages/tournaments/[id]/score_tracking_match.tsx
@@ -21,6 +21,7 @@ export default function TournamentScoreTrackingMatchPage() {
           backHref={`/tournaments/${tournamentData.id}/score-tracking`}
           storageKey={`tournament-score-tracking:${tournamentData.id}:${matchId}:swapped`}
           levels={swrTournamentResponse.data?.data.levels ?? []}
+          refereesEnabled={swrTournamentResponse.data?.data.referees_enabled ?? false}
           saveMatch={async (next) => {
             if (matchId == null) return;
             await updateTournamentScoreTrackingMatch(tournamentData.id, matchId, next);


### PR DESCRIPTION
Adds whistle icon + referee name row (gated on referees_enabled) to the public dashboard match cards,
score-tracking list view, and score-tracking match detail — extracted into a shared RefereeDisplay
component. Also exposes referees_enabled in ScoreTrackingInfo API response (small additive change)
and adds TDD integration tests covering the new field.

https://claude.ai/code/session_01Vk5ZWcnHPyDCXDYohDsGC5