### PR TITLE
feat(referees): one-click 'Assign missing referees' button (#106)

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -1077,7 +1077,7 @@ def build_referee_assignment_plan(
     # assignable match to improve the spread. A safe bound: assigning one extra
     # match saves (max_load_spread * referee_fairness + 1) units vs. the worst
     # possible change in spread that the same assignment could cause.
-    coverage_weight = (max_possible_load + 1) * (weights.referee_fairness + 1)
+    coverage_weight = weights.referee_fairness + 1
     all_choice_vars = [var for choices in ref_choices.values() for var in choices.values()]
     # total_assigned is the sum of all AtMostOne choice vars (0/1 per match)
     total_assigned_expr = sum(all_choice_vars)
@@ -1119,14 +1119,13 @@ def build_referee_assignment_plan(
 
 
 async def assign_missing_referees_only(
-    tournament_id: TournamentId,
+    tournament: Tournament,
     stages: list[StageWithStageItems],
     weights: SchedulerWeights = DEFAULT_SCHEDULER_WEIGHTS,
 ) -> None:
     """Persist referee assignments for scheduled matches that have none."""
-    tournament = await sql_get_tournament(tournament_id)
     for match_id, team_id in build_referee_assignment_plan(stages, tournament, weights).items():
-        referee = await sql_upsert_referee_by_team(tournament_id, team_id)
+        referee = await sql_upsert_referee_by_team(tournament.id, team_id)
         await sql_set_match_referee(match_id, referee.id)
 
 

--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -1099,8 +1099,12 @@ def build_referee_assignment_plan(
     solver = cp_model.CpSolver()
     solver.parameters.max_time_in_seconds = SOLVER_TIME_LIMIT_SECONDS
     if currently_testing():
+        # Single worker + fixed seed makes the referee solver fully deterministic in tests
+        # (multi-worker portfolio search is non-deterministic even with a pinned seed).
         solver.parameters.random_seed = SOLVER_RANDOM_SEED
-    solver.parameters.num_search_workers = SOLVER_SEARCH_WORKERS
+        solver.parameters.num_search_workers = 1
+    else:
+        solver.parameters.num_search_workers = SOLVER_SEARCH_WORKERS
     status_code = solver.Solve(model)
     if status_code not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
         logger.warning(

--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -699,12 +699,8 @@ def _add_referee_assignment(
                         f"ref_match_{match_id}_team_{team_id}_"
                         f"after_pinned_{pinned.context.match.id}"
                     )
-                    model.Add(ends[match_id] <= pinned.start_minutes).OnlyEnforceIf(
-                        [var, before]
-                    )
-                    model.Add(starts[match_id] >= pinned.end_minutes).OnlyEnforceIf(
-                        [var, after]
-                    )
+                    model.Add(ends[match_id] <= pinned.start_minutes).OnlyEnforceIf([var, before])
+                    model.Add(starts[match_id] >= pinned.end_minutes).OnlyEnforceIf([var, after])
                     model.AddBoolOr([before, after, var.Not()])
 
     # Fixed referee load from pinned matches (already assigned, can't change)
@@ -720,9 +716,7 @@ def _add_referee_assignment(
     for team_id in sorted(all_eligible_teams):  # sorted for determinism
         fixed = fixed_ref_count.get(team_id, 0)
         var_choices = [
-            ref_choices[mid][team_id]
-            for mid in ref_choices
-            if team_id in ref_choices[mid]
+            ref_choices[mid][team_id] for mid in ref_choices if team_id in ref_choices[mid]
         ]
         if var_choices:
             load = model.NewIntVar(fixed, fixed + len(var_choices), f"ref_load_team_{team_id}")
@@ -767,10 +761,16 @@ def _build_operations_from_solution(
         referee_team_id: TeamId | None = None
         if match_id in ref_choices:
             referee_team_id = next(
-                (team_id for team_id, var in ref_choices[match_id].items() if solver.Value(var) == 1),
+                (
+                    team_id
+                    for team_id, var in ref_choices[match_id].items()
+                    if solver.Value(var) == 1
+                ),
                 None,
             )
-        operation_to_schedule = ScheduleOperation(court_id, start_time, 0, context.match, referee_team_id)
+        operation_to_schedule = ScheduleOperation(
+            court_id, start_time, 0, context.match, referee_team_id
+        )
         scheduled_slots[court_id].append((start_time, match_id, operation_to_schedule))
 
     for context in pinned_contexts:
@@ -954,6 +954,180 @@ async def _apply_schedule_plan(
         if op.referee_team_id is not None:
             referee = await sql_upsert_referee_by_team(tournament_id, op.referee_team_id)
             await sql_set_match_referee(op.match.id, referee.id)
+
+
+def build_referee_assignment_plan(
+    stages: list[StageWithStageItems],
+    tournament: Tournament,
+    weights: SchedulerWeights = DEFAULT_SCHEDULER_WEIGHTS,
+) -> dict[MatchId, TeamId]:
+    """Assign referees to already-scheduled matches that have none, without moving any match.
+
+    Returns a mapping of match_id → team_id for each match that received a new referee.
+    Matches that already have a referee, unscheduled matches, and matches with no eligible
+    candidate are left untouched. Never fails — returns what it can.
+    """
+    if not tournament.referees_enabled:
+        return {}
+
+    contexts = _get_match_contexts(stages)
+    team_level_ids = _get_team_level_ids(stages)
+
+    # Only scheduled matches (fixed court + start_time) participate.
+    scheduled_contexts = [c for c in contexts if _is_scheduled(c)]
+    if not scheduled_contexts:
+        return {}
+
+    # Build per-team playing intervals (minute offsets) over all scheduled matches.
+    team_playing_intervals: dict[TeamId, list[tuple[int, int]]] = defaultdict(list)
+    for context in scheduled_contexts:
+        start_min = _minute_offset(tournament, assert_some(context.match.start_time))
+        end_min = start_min + context.match.duration_minutes
+        for input_ in (context.match.stage_item_input1, context.match.stage_item_input2):
+            if isinstance(input_, StageItemInputFinal):
+                team_playing_intervals[input_.team_id].append((start_min, end_min))
+
+    needs_ref = [c for c in scheduled_contexts if c.match.referee_id is None]
+    has_ref = [c for c in scheduled_contexts if c.match.referee_id is not None]
+
+    if not needs_ref:
+        return {}
+
+    model = cp_model.CpModel()
+
+    ref_choices: dict[MatchId, dict[TeamId, Any]] = {}
+    match_windows: dict[MatchId, tuple[int, int]] = {}
+
+    for context in needs_ref:
+        match = context.match
+        start_min = _minute_offset(tournament, assert_some(match.start_time))
+        end_min = start_min + match.duration_minutes
+        match_windows[match.id] = (start_min, end_min)
+
+        playing_teams: set[TeamId] = set()
+        for input_ in (match.stage_item_input1, match.stage_item_input2):
+            if isinstance(input_, StageItemInputFinal):
+                playing_teams.add(input_.team_id)
+
+        # Eligible: same level, not playing in this match, not playing in an overlapping match.
+        eligible: set[TeamId] = set()
+        for team_id, level_id in team_level_ids.items():
+            if level_id != context.level_id or team_id in playing_teams:
+                continue
+            if any(
+                start_min < p_end and p_start < end_min
+                for p_start, p_end in team_playing_intervals.get(team_id, [])
+            ):
+                continue
+            eligible.add(team_id)
+
+        if not eligible:
+            continue
+
+        choices: dict[TeamId, Any] = {
+            team_id: model.NewBoolVar(f"ref_match_{match.id}_team_{team_id}")
+            for team_id in sorted(eligible)
+        }
+        model.AddAtMostOne(choices.values())
+        ref_choices[match.id] = choices
+
+    if not ref_choices:
+        return {}
+
+    all_eligible_teams: set[TeamId] = set(
+        team_id for choices in ref_choices.values() for team_id in choices
+    )
+
+    # A team cannot referee two overlapping matches.
+    sorted_match_ids = sorted(ref_choices.keys())
+    for i, mid1 in enumerate(sorted_match_ids):
+        for mid2 in sorted_match_ids[i + 1 :]:
+            s1, e1 = match_windows[mid1]
+            s2, e2 = match_windows[mid2]
+            if s1 < e2 and s2 < e1:
+                for team_id in set(ref_choices[mid1]) & set(ref_choices[mid2]):
+                    model.AddBoolOr(
+                        [ref_choices[mid1][team_id].Not(), ref_choices[mid2][team_id].Not()]
+                    )
+
+    # Count existing assignments toward the fairness objective.
+    fixed_ref_count: dict[TeamId, int] = defaultdict(int)
+    for context in has_ref:
+        ref = context.match.referee
+        if ref is not None and ref.team_id is not None and ref.team_id in all_eligible_teams:
+            fixed_ref_count[ref.team_id] += 1
+
+    max_possible_load = len(needs_ref) + (max(fixed_ref_count.values(), default=0))
+    team_loads: list[Any] = []
+    for team_id in sorted(all_eligible_teams):
+        fixed = fixed_ref_count.get(team_id, 0)
+        var_choices = [
+            ref_choices[mid][team_id] for mid in ref_choices if team_id in ref_choices[mid]
+        ]
+        if var_choices:
+            load = model.NewIntVar(fixed, fixed + len(var_choices), f"ref_load_team_{team_id}")
+            model.Add(load == fixed + sum(var_choices))
+        else:
+            load = model.NewIntVar(fixed, fixed, f"ref_load_team_{team_id}")
+        team_loads.append(load)
+
+    # Primary objective: maximize coverage (fill as many matches as possible).
+    # Secondary objective: minimize fairness spread.
+    # Coverage weight must dominate fairness so the solver never skips an
+    # assignable match to improve the spread. A safe bound: assigning one extra
+    # match saves (max_load_spread * referee_fairness + 1) units vs. the worst
+    # possible change in spread that the same assignment could cause.
+    coverage_weight = (max_possible_load + 1) * (weights.referee_fairness + 1)
+    all_choice_vars = [var for choices in ref_choices.values() for var in choices.values()]
+    # total_assigned is the sum of all AtMostOne choice vars (0/1 per match)
+    total_assigned_expr = sum(all_choice_vars)
+
+    if len(team_loads) >= 2:
+        max_load = model.NewIntVar(0, max_possible_load, "ref_max_load")
+        min_load = model.NewIntVar(0, max_possible_load, "ref_min_load")
+        model.AddMaxEquality(max_load, team_loads)
+        model.AddMinEquality(min_load, team_loads)
+        spread = model.NewIntVar(0, max_possible_load, "ref_spread")
+        model.Add(spread == max_load - min_load)
+        model.Minimize(
+            -coverage_weight * total_assigned_expr
+            + (weights.referee_fairness * spread if weights.referee_fairness > 0 else 0)
+        )
+    else:
+        model.Minimize(-coverage_weight * total_assigned_expr)
+
+    solver = cp_model.CpSolver()
+    solver.parameters.max_time_in_seconds = SOLVER_TIME_LIMIT_SECONDS
+    if currently_testing():
+        solver.parameters.random_seed = SOLVER_RANDOM_SEED
+    solver.parameters.num_search_workers = SOLVER_SEARCH_WORKERS
+    status_code = solver.Solve(model)
+    if status_code not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        logger.warning(
+            "Referee-only assignment found no solution (status %s); leaving matches unassigned",
+            solver.StatusName(status_code),
+        )
+        return {}
+
+    result: dict[MatchId, TeamId] = {}
+    for match_id, choices in ref_choices.items():
+        for team_id, var in choices.items():
+            if solver.Value(var) == 1:
+                result[match_id] = team_id
+                break
+    return result
+
+
+async def assign_missing_referees_only(
+    tournament_id: TournamentId,
+    stages: list[StageWithStageItems],
+    weights: SchedulerWeights = DEFAULT_SCHEDULER_WEIGHTS,
+) -> None:
+    """Persist referee assignments for scheduled matches that have none."""
+    tournament = await sql_get_tournament(tournament_id)
+    for match_id, team_id in build_referee_assignment_plan(stages, tournament, weights).items():
+        referee = await sql_upsert_referee_by_team(tournament_id, team_id)
+        await sql_set_match_referee(match_id, referee.id)
 
 
 async def schedule_all_unscheduled_matches(

--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -272,7 +272,7 @@ async def auto_assign_referees(
             detail="Referees are not enabled for this tournament",
         )
     stages = await get_full_tournament_details(tournament_id)
-    await assign_missing_referees_only(tournament_id, stages, weights)
+    await assign_missing_referees_only(tournament, stages, weights)
     await reconcile_conflicts(tournament_id)
     return SuccessResponse()
 

--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -6,6 +6,7 @@ from bracket.config import config
 from bracket.database import database
 from bracket.logic.planning.conflicts import reconcile_conflicts
 from bracket.logic.planning.matches import (
+    assign_missing_referees_only,
     get_scheduled_matches,
     handle_match_reschedule,
     handle_match_resize_break,
@@ -252,6 +253,26 @@ async def reoptimize_matches(
 ) -> SuccessResponse:
     stages = await get_full_tournament_details(tournament_id)
     await reoptimize_all_matches(tournament_id, stages, weights)
+    await reconcile_conflicts(tournament_id)
+    return SuccessResponse()
+
+
+@router.post(
+    "/tournaments/{tournament_id}/matches/auto-assign-referees", response_model=SuccessResponse
+)
+async def auto_assign_referees(
+    tournament_id: TournamentId,
+    weights: SchedulerWeights = SchedulerWeights(),
+    _: UserPublic = Depends(user_authenticated_for_tournament),
+    tournament: Tournament = Depends(disallow_archived_tournament),
+) -> SuccessResponse:
+    if not tournament.referees_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Referees are not enabled for this tournament",
+        )
+    stages = await get_full_tournament_details(tournament_id)
+    await assign_missing_referees_only(tournament_id, stages, weights)
     await reconcile_conflicts(tournament_id)
     return SuccessResponse()
 

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -5397,6 +5397,70 @@
         ]
       }
     },
+    "/tournaments/{tournament_id}/matches/auto-assign-referees": {
+      "post": {
+        "operationId": "auto_assign_referees_tournaments__tournament_id__matches_auto_assign_referees_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tournament_id",
+            "required": true,
+            "schema": {
+              "title": "Tournament Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SchedulerWeights",
+                "default": {
+                  "comfortable_rest_minutes": 30,
+                  "court_locality": 4,
+                  "group_sync": 8,
+                  "makespan": 150,
+                  "referee_fairness": 200,
+                  "team_rest": 13
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Auto Assign Referees",
+        "tags": [
+          "Matches"
+        ]
+      }
+    },
     "/tournaments/{tournament_id}/matches/swap": {
       "post": {
         "operationId": "swap_matches_tournaments__tournament_id__matches_swap_post",

--- a/backend/tests/integration_tests/api/auto_assign_referees_test.py
+++ b/backend/tests/integration_tests/api/auto_assign_referees_test.py
@@ -2,24 +2,54 @@ import pytest
 
 from bracket.database import database
 from bracket.logic.scheduling.builder import build_matches_for_stage_item
-from bracket.models.db.stage_item import StageItemWithInputsCreate
+from bracket.models.db.stage_item import StageItem, StageItemWithInputsCreate
 from bracket.models.db.stage_item_inputs import StageItemInputCreateBodyFinal
 from bracket.schema import tournaments
+from bracket.sql.referees import sql_set_match_referee, sql_upsert_referee_by_team
 from bracket.sql.shared import sql_delete_stage_item_with_foreign_keys
 from bracket.sql.stage_items import sql_create_stage_item_with_inputs
 from bracket.sql.stages import get_full_tournament_details
 from bracket.utils.dummy_records import DUMMY_COURT1, DUMMY_STAGE1, DUMMY_STAGE_ITEM1, DUMMY_TEAM1
 from bracket.utils.http import HTTPMethod
-from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
+from bracket.utils.id_types import StageId, TeamId, TournamentId
+from tests.integration_tests.api.shared import (
+    SUCCESS_RESPONSE,
+    send_request,
+    send_tournament_request,
+)
 from tests.integration_tests.models import AuthContext
 from tests.integration_tests.sql import inserted_court, inserted_stage, inserted_team
 
+_ENDPOINT = "matches/auto-assign-referees"
+
+
+async def _setup_round_robin_3teams(
+    tid: TournamentId, stage_id: StageId, t1_id: TeamId, t2_id: TeamId, t3_id: TeamId
+) -> StageItem:
+    """3-team round-robin: each team can ref the match it isn't playing in."""
+    si = await sql_create_stage_item_with_inputs(
+        tid,
+        StageItemWithInputsCreate(
+            stage_id=stage_id,
+            name=DUMMY_STAGE_ITEM1.name,
+            team_count=3,
+            type=DUMMY_STAGE_ITEM1.type,
+            inputs=[
+                StageItemInputCreateBodyFinal(slot=1, team_id=t1_id),
+                StageItemInputCreateBodyFinal(slot=2, team_id=t2_id),
+                StageItemInputCreateBodyFinal(slot=3, team_id=t3_id),
+            ],
+        ),
+    )
+    await build_matches_for_stage_item(si, tid)
+    return si
+
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_auto_assign_referees(
+async def test_auto_assign_referees_fills_missing_only(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:
-    """Endpoint fills referee slots on scheduled matches without moving them."""
+    """Endpoint fills referee slots on matches that have none, leaving schedule intact."""
     tid = auth_context.tournament.id
 
     await database.execute(
@@ -33,28 +63,23 @@ async def test_auto_assign_referees(
             inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t2,
             inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t3,
         ):
-            si = await sql_create_stage_item_with_inputs(
-                tid,
-                StageItemWithInputsCreate(
-                    stage_id=stage.id,
-                    name=DUMMY_STAGE_ITEM1.name,
-                    team_count=3,
-                    type=DUMMY_STAGE_ITEM1.type,
-                    inputs=[
-                        StageItemInputCreateBodyFinal(slot=1, team_id=t1.id),
-                        StageItemInputCreateBodyFinal(slot=2, team_id=t2.id),
-                        StageItemInputCreateBodyFinal(slot=3, team_id=t3.id),
-                    ],
-                ),
-            )
-            await build_matches_for_stage_item(si, tid)
+            si = await _setup_round_robin_3teams(tid, stage.id, t1.id, t2.id, t3.id)
+            # Schedule matches so they have court_id / start_time
             await send_tournament_request(HTTPMethod.POST, "schedule_matches", auth_context)
 
-            response = await send_tournament_request(
-                HTTPMethod.POST, "matches/auto-assign-referees", auth_context
-            )
+            stages_before = await get_full_tournament_details(tid)
+            scheduled_before = [
+                (m.id, m.court_id, m.start_time)
+                for s in stages_before
+                for si_ in s.stage_items
+                for r in si_.rounds
+                for m in r.matches
+                if m.court_id is not None and m.start_time is not None
+            ]
 
-            stages = await get_full_tournament_details(tid)
+            response = await send_tournament_request(HTTPMethod.POST, _ENDPOINT, auth_context)
+
+            stages_after = await get_full_tournament_details(tid)
             await sql_delete_stage_item_with_foreign_keys(si.id)
     finally:
         await database.execute(
@@ -63,13 +88,101 @@ async def test_auto_assign_referees(
 
     assert response == SUCCESS_RESPONSE
 
-    scheduled = [
-        match
-        for stage in stages
-        for stage_item in stage.stage_items
-        for round_ in stage_item.rounds
-        for match in round_.matches
-        if match.court_id is not None and match.start_time is not None
+    scheduled_after = [
+        m
+        for s in stages_after
+        for si_ in s.stage_items
+        for r in si_.rounds
+        for m in r.matches
+        if m.court_id is not None and m.start_time is not None
     ]
-    assert len(scheduled) > 0
-    assert all(match.referee_id is not None for match in scheduled)
+
+    # Every scheduled match now has a referee
+    assert len(scheduled_after) > 0
+    assert all(m.referee_id is not None for m in scheduled_after)
+
+    # Court and start_time are unchanged (schedule was not moved)
+    scheduled_after_map = {m.id: (m.court_id, m.start_time) for m in scheduled_after}
+    for match_id, court_id, start_time in scheduled_before:
+        assert scheduled_after_map[match_id] == (court_id, start_time)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_auto_assign_referees_preserves_existing_assignment(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """A match that already has a referee keeps the same referee after the call."""
+    tid = auth_context.tournament.id
+
+    await database.execute(
+        query=tournaments.update().where(tournaments.c.id == tid).values(referees_enabled=True)
+    )
+    try:
+        async with (
+            inserted_court(DUMMY_COURT1.model_copy(update={"tournament_id": tid})),
+            inserted_stage(DUMMY_STAGE1.model_copy(update={"tournament_id": tid})) as stage,
+            inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t1,
+            inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t2,
+            inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t3,
+        ):
+            si = await _setup_round_robin_3teams(tid, stage.id, t1.id, t2.id, t3.id)
+            await send_tournament_request(HTTPMethod.POST, "schedule_matches", auth_context)
+
+            stages_before = await get_full_tournament_details(tid)
+            scheduled_before = [
+                m
+                for s in stages_before
+                for si_ in s.stage_items
+                for r in si_.rounds
+                for m in r.matches
+                if m.court_id is not None and m.start_time is not None
+            ]
+            assert len(scheduled_before) > 0
+
+            # Pre-assign t3 as referee on the first match
+            first_match = scheduled_before[0]
+            pre_ref = await sql_upsert_referee_by_team(tid, t3.id)
+            await sql_set_match_referee(first_match.id, pre_ref.id)
+
+            response = await send_tournament_request(HTTPMethod.POST, _ENDPOINT, auth_context)
+
+            stages_after = await get_full_tournament_details(tid)
+            await sql_delete_stage_item_with_foreign_keys(si.id)
+    finally:
+        await database.execute(
+            query=tournaments.update().where(tournaments.c.id == tid).values(referees_enabled=False)
+        )
+
+    assert response == SUCCESS_RESPONSE
+
+    after_map = {
+        m.id: m.referee_id
+        for s in stages_after
+        for si_ in s.stage_items
+        for r in si_.rounds
+        for m in r.matches
+    }
+    # The pre-assigned match still has the same referee
+    assert after_map[first_match.id] == pre_ref.id
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_auto_assign_referees_disabled_returns_409(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Returns 409 when referees_enabled is False for the tournament."""
+    # auth_context.tournament has referees_enabled=False by default
+    response = await send_tournament_request(HTTPMethod.POST, _ENDPOINT, auth_context)
+    assert response == {"detail": "Referees are not enabled for this tournament"}
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_auto_assign_referees_requires_auth(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Unauthenticated request is rejected."""
+    response = await send_request(
+        HTTPMethod.POST,
+        f"tournaments/{auth_context.tournament.id}/{_ENDPOINT}",
+    )
+    assert response == {"detail": "Not authenticated"}

--- a/backend/tests/integration_tests/api/auto_assign_referees_test.py
+++ b/backend/tests/integration_tests/api/auto_assign_referees_test.py
@@ -1,0 +1,75 @@
+import pytest
+
+from bracket.database import database
+from bracket.logic.scheduling.builder import build_matches_for_stage_item
+from bracket.models.db.stage_item import StageItemWithInputsCreate
+from bracket.models.db.stage_item_inputs import StageItemInputCreateBodyFinal
+from bracket.schema import tournaments
+from bracket.sql.shared import sql_delete_stage_item_with_foreign_keys
+from bracket.sql.stage_items import sql_create_stage_item_with_inputs
+from bracket.sql.stages import get_full_tournament_details
+from bracket.utils.dummy_records import DUMMY_COURT1, DUMMY_STAGE1, DUMMY_STAGE_ITEM1, DUMMY_TEAM1
+from bracket.utils.http import HTTPMethod
+from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
+from tests.integration_tests.models import AuthContext
+from tests.integration_tests.sql import inserted_court, inserted_stage, inserted_team
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_auto_assign_referees(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Endpoint fills referee slots on scheduled matches without moving them."""
+    tid = auth_context.tournament.id
+
+    await database.execute(
+        query=tournaments.update().where(tournaments.c.id == tid).values(referees_enabled=True)
+    )
+    try:
+        async with (
+            inserted_court(DUMMY_COURT1.model_copy(update={"tournament_id": tid})),
+            inserted_stage(DUMMY_STAGE1.model_copy(update={"tournament_id": tid})) as stage,
+            inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t1,
+            inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t2,
+            inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t3,
+        ):
+            si = await sql_create_stage_item_with_inputs(
+                tid,
+                StageItemWithInputsCreate(
+                    stage_id=stage.id,
+                    name=DUMMY_STAGE_ITEM1.name,
+                    team_count=3,
+                    type=DUMMY_STAGE_ITEM1.type,
+                    inputs=[
+                        StageItemInputCreateBodyFinal(slot=1, team_id=t1.id),
+                        StageItemInputCreateBodyFinal(slot=2, team_id=t2.id),
+                        StageItemInputCreateBodyFinal(slot=3, team_id=t3.id),
+                    ],
+                ),
+            )
+            await build_matches_for_stage_item(si, tid)
+            await send_tournament_request(HTTPMethod.POST, "schedule_matches", auth_context)
+
+            response = await send_tournament_request(
+                HTTPMethod.POST, "matches/auto-assign-referees", auth_context
+            )
+
+            stages = await get_full_tournament_details(tid)
+            await sql_delete_stage_item_with_foreign_keys(si.id)
+    finally:
+        await database.execute(
+            query=tournaments.update().where(tournaments.c.id == tid).values(referees_enabled=False)
+        )
+
+    assert response == SUCCESS_RESPONSE
+
+    scheduled = [
+        match
+        for stage in stages
+        for stage_item in stage.stage_items
+        for round_ in stage_item.rounds
+        for match in round_.matches
+        if match.court_id is not None and match.start_time is not None
+    ]
+    assert len(scheduled) > 0
+    assert all(match.referee_id is not None for match in scheduled)

--- a/backend/tests/integration_tests/api/scheduling_matches_test.py
+++ b/backend/tests/integration_tests/api/scheduling_matches_test.py
@@ -695,9 +695,7 @@ async def test_auto_scheduling_assigns_referees_when_enabled(
     """When referees_enabled, both scheduling endpoints assign team referees to matches."""
     tid = auth_context.tournament.id
     await database.execute(
-        query=tournaments.update()
-        .where(tournaments.c.id == tid)
-        .values(referees_enabled=True),
+        query=tournaments.update().where(tournaments.c.id == tid).values(referees_enabled=True),
     )
     try:
         async with (
@@ -731,7 +729,6 @@ async def test_auto_scheduling_assigns_referees_when_enabled(
             await sql_delete_stage_item_with_foreign_keys(si.id)
 
         assert response == SUCCESS_RESPONSE
-        all_matches = _all_matches(stages)
         scheduled = _scheduled_matches(stages)
         assert len(scheduled) > 0
         # At least some matches should have a referee when referees_enabled is on
@@ -745,7 +742,9 @@ async def test_auto_scheduling_assigns_referees_when_enabled(
             playing_team_ids = {
                 inp.team_id
                 for inp in (match.stage_item_input1, match.stage_item_input2)
-                if hasattr(inp, "team_id") and inp is not None and getattr(inp, "team_id", None) is not None
+                if hasattr(inp, "team_id")
+                and inp is not None
+                and getattr(inp, "team_id", None) is not None
             }
             assert match.referee.team_id not in playing_team_ids, (
                 f"Match {match.id} has a referee who is also a playing team"
@@ -760,14 +759,13 @@ async def test_auto_scheduling_assigns_referees_when_enabled(
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_auto_scheduling_preserves_existing_referee_assignments(
-    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext,
+    startup_and_shutdown_uvicorn_server: None,
+    auth_context: AuthContext,
 ) -> None:
     """Existing (manual) referee assignments are never overwritten by the scheduler."""
     tid = auth_context.tournament.id
     await database.execute(
-        query=tournaments.update()
-        .where(tournaments.c.id == tid)
-        .values(referees_enabled=True),
+        query=tournaments.update().where(tournaments.c.id == tid).values(referees_enabled=True),
     )
     try:
         async with (

--- a/backend/tests/integration_tests/api/score_tracking_test.py
+++ b/backend/tests/integration_tests/api/score_tracking_test.py
@@ -47,7 +47,11 @@ async def test_score_tracking_response_includes_referees_enabled_true_when_set(
     await database.execute(
         query=tournaments.update()
         .where(tournaments.c.id == auth_context.tournament.id)
-        .values(referees_enabled=True, score_tracking_enabled=True, score_tracking_token="ref-enabled-token"),
+        .values(
+            referees_enabled=True,
+            score_tracking_enabled=True,
+            score_tracking_token="ref-enabled-token",
+        ),
     )
     try:
         authenticated_response = await send_tournament_request(
@@ -60,7 +64,9 @@ async def test_score_tracking_response_includes_referees_enabled_true_when_set(
         await database.execute(
             query=tournaments.update()
             .where(tournaments.c.id == auth_context.tournament.id)
-            .values(referees_enabled=False, score_tracking_enabled=False, score_tracking_token=None),
+            .values(
+                referees_enabled=False, score_tracking_enabled=False, score_tracking_token=None
+            ),
         )
 
 

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -8,12 +8,17 @@ from bracket.logic.planning import matches as planning_matches
 from bracket.logic.planning.matches import (
     MatchPosition,
     ScheduleOperation,
-    SchedulerWeights,
+    build_referee_assignment_plan,
     build_schedule_plan,
     reorder_all_matches,
 )
 from bracket.models.db.court import Court
-from bracket.models.db.match import MatchState, MatchWithDetails, MatchWithDetailsDefinitive
+from bracket.models.db.match import (
+    MatchState,
+    MatchWithDetails,
+    MatchWithDetailsDefinitive,
+    SchedulerWeights,
+)
 from bracket.models.db.referee import Referee
 from bracket.models.db.stage_item import StageType
 from bracket.models.db.stage_item_inputs import (
@@ -910,12 +915,11 @@ def _stage_with_inputs(
     level_id: LevelId | None = None,
 ) -> StageWithStageItems:
     """Stage with one stage item, the given matches, and explicit team inputs."""
-    item_id = stage_id * 100
     return _stage_with_rounds(
         stage_id,
         [[matches]],
         level_id=level_id,
-        inputs_per_item=[list(inputs)],  # type: ignore[list-item]
+        inputs_per_item=[list(inputs)],
     )
 
 
@@ -943,7 +947,14 @@ def test_referee_only_assigned_to_teams_of_own_level() -> None:
     # Teams 1,2 play in level A; team 3 is in level B
     m = _match_with_teams(1, 1, 2, level_a)
     inp_3 = _final_input(99, 3, level_b)
-    stages = [_stage_with_inputs(1, [m], [_final_input(11, 1, level_a), _final_input(12, 2, level_a), inp_3], level_id=level_a)]
+    stages = [
+        _stage_with_inputs(
+            1,
+            [m],
+            [_final_input(11, 1, level_a), _final_input(12, 2, level_a), inp_3],
+            level_id=level_a,
+        )
+    ]
     tournament = _tournament_with_referees()
 
     ops = build_schedule_plan(stages, [_court(1)], tournament)
@@ -989,9 +1000,12 @@ def test_referee_not_assigned_when_playing_overlapping_match() -> None:
     m1 = _match_with_teams(1, 1, 2, level)
     m2 = _match_with_teams(2, 3, 4, level)
     inputs = [
-        _final_input(11, 1, level), _final_input(12, 2, level),
-        _final_input(13, 3, level), _final_input(14, 4, level),
-        _final_input(15, 5, level), _final_input(16, 6, level),
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
+        _final_input(14, 4, level),
+        _final_input(15, 5, level),
+        _final_input(16, 6, level),
     ]
     stages = [_stage_with_inputs(1, [m1, m2], inputs, level_id=level)]
     tournament = _tournament_with_referees()
@@ -1023,8 +1037,10 @@ def test_referee_team_never_plays_and_referees_same_time_window() -> None:
     m1 = _match_with_teams(1, 1, 2, level)
     m2 = _match_with_teams(2, 3, 4, level)
     inputs = [
-        _final_input(11, 1, level), _final_input(12, 2, level),
-        _final_input(13, 3, level), _final_input(14, 4, level),
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
+        _final_input(14, 4, level),
         _final_input(15, 5, level),
     ]
     stages = [_stage_with_inputs(1, [m1, m2], inputs, level_id=level)]
@@ -1081,7 +1097,9 @@ def test_existing_referee_assignment_not_overwritten() -> None:
     m = _match_with_teams(1, 1, 2, level)
     m_with_ref = _match_with_referee(m, team_id=3)
     inputs = [
-        _final_input(11, 1, level), _final_input(12, 2, level), _final_input(13, 3, level),
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
         _final_input(14, 4, level),
     ]
     stages = [_stage_with_inputs(1, [m_with_ref], inputs, level_id=level)]
@@ -1130,8 +1148,10 @@ def test_refereeing_does_not_add_rest_penalty() -> None:
     m1 = _match_with_teams(1, 1, 2, level)
     m2 = _match_with_teams(2, 3, 4, level)
     inputs = [
-        _final_input(11, 1, level), _final_input(12, 2, level),
-        _final_input(13, 3, level), _final_input(14, 4, level),
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
+        _final_input(14, 4, level),
     ]
 
     # With referees_enabled: team 1 might referee m2
@@ -1177,3 +1197,221 @@ def test_no_eligible_referee_leaves_match_unassigned() -> None:
 
     assert len(ops) == 1
     assert ops[0].referee_team_id is None
+
+
+# ── build_referee_assignment_plan (assign-missing-only, schedule pinned) ─────
+
+
+def _scheduled_match_with_teams(
+    id_: int,
+    team_a_id: int,
+    team_b_id: int,
+    level_id: LevelId | None = None,
+    start_offset_minutes: int = 0,
+    court_id: int = 1,
+) -> MatchWithDetails:
+    """Match with two defined teams, already scheduled at a fixed time on a court."""
+    inp_a = _final_input(id_ * 10 + 1, team_a_id, level_id)
+    inp_b = _final_input(id_ * 10 + 2, team_b_id, level_id)
+    return MatchWithDetails(
+        id=MatchId(id_),
+        created=T0,
+        duration_minutes=DURATION,
+        round_id=RoundId(id_),
+        stage_item_input1_score=0,
+        stage_item_input2_score=0,
+        stage_item_input1_conflict=False,
+        stage_item_input2_conflict=False,
+        stage_item_input1_id=inp_a.id,
+        stage_item_input2_id=inp_b.id,
+        stage_item_input1=inp_a,
+        stage_item_input2=inp_b,
+        start_time=T0 + timedelta(minutes=start_offset_minutes),
+        court_id=CourtId(court_id),
+    )
+
+
+def test_assign_referees_only_fills_missing_not_existing() -> None:
+    """Only fills matches with no referee; never overwrites existing assignments."""
+    level = LevelId(1)
+    m1 = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0)
+    m2 = _scheduled_match_with_teams(2, 3, 4, level, start_offset_minutes=SLOT)
+    m3 = _scheduled_match_with_teams(3, 5, 6, level, start_offset_minutes=2 * SLOT)
+    m2_with_ref = _match_with_referee(m2, team_id=9)
+    inputs = [_final_input(i * 10, i, level) for i in range(1, 11)]
+    stages = [_stage_with_inputs(1, [m1, m2_with_ref, m3], inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    assert MatchId(2) not in result, "Should not overwrite existing referee"
+    assert MatchId(1) in result
+    assert MatchId(3) in result
+
+
+def test_assign_referees_schedule_unchanged() -> None:
+    """Returns a plain dict of match_id→team_id; no court or time information."""
+    level = LevelId(1)
+    m = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0)
+    inputs = [_final_input(11, 1, level), _final_input(12, 2, level), _final_input(13, 3, level)]
+    stages = [_stage_with_inputs(1, [m], inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    assert isinstance(result, dict)
+    for v in result.values():
+        assert isinstance(v, int)
+
+
+def test_assign_referees_level_restriction() -> None:
+    """Teams of a different level than the match are excluded as candidates."""
+    level_a = LevelId(1)
+    level_b = LevelId(2)
+    m = _scheduled_match_with_teams(1, 1, 2, level_a, start_offset_minutes=0)
+    inputs = [
+        _final_input(11, 1, level_a),
+        _final_input(12, 2, level_a),
+        _final_input(13, 3, level_b),
+    ]
+    stages = [_stage_with_inputs(1, [m], inputs, level_id=level_a)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    assert result == {}
+
+
+def test_assign_referees_excludes_playing_team() -> None:
+    """A team playing in the match is not assigned as its referee."""
+    level = LevelId(1)
+    m1 = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0)
+    m2 = _scheduled_match_with_teams(2, 3, 4, level, start_offset_minutes=SLOT)
+    inputs = [
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
+        _final_input(14, 4, level),
+        _final_input(15, 5, level),
+    ]
+    stages = [_stage_with_inputs(1, [m1, m2], inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    assert result.get(MatchId(1)) not in (TeamId(1), TeamId(2))
+    assert result.get(MatchId(2)) not in (TeamId(3), TeamId(4))
+
+
+def test_assign_referees_excludes_team_playing_overlapping_match() -> None:
+    """A team playing in a simultaneously-scheduled match cannot referee the other."""
+    level = LevelId(1)
+    m1 = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0, court_id=1)
+    m2 = _scheduled_match_with_teams(2, 3, 4, level, start_offset_minutes=0, court_id=2)
+    inputs = [
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
+        _final_input(14, 4, level),
+        _final_input(15, 5, level),
+        _final_input(16, 6, level),
+    ]
+    stages = [_stage_with_inputs(1, [m1, m2], inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    if MatchId(1) in result and MatchId(2) in result:
+        assert result[MatchId(1)] != result[MatchId(2)]
+
+
+def test_assign_referees_no_candidate_leaves_match_unassigned() -> None:
+    """A match is left unassigned when no eligible team is available; no error raised."""
+    level = LevelId(1)
+    m = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0)
+    inputs = [_final_input(11, 1, level), _final_input(12, 2, level)]
+    stages = [_stage_with_inputs(1, [m], inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    assert result == {}
+
+
+def test_assign_referees_balanced_load() -> None:
+    """Referee load is balanced across eligible teams (max − min ≤ 1)."""
+    level = LevelId(1)
+    matches = [
+        _scheduled_match_with_teams(i, i * 2 - 1, i * 2, level, start_offset_minutes=(i - 1) * SLOT)
+        for i in range(1, 5)
+    ]
+    inputs = [_final_input(i * 10, i, level) for i in range(1, 11)]
+    stages = [_stage_with_inputs(1, matches, inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    assert len(result) == 4
+    load: dict[TeamId, int] = defaultdict(int)
+    for team_id in result.values():
+        load[team_id] += 1
+    if load:
+        assert max(load.values()) - min(load.values()) <= 1
+
+
+def test_assign_referees_no_free_text() -> None:
+    """All result values are integer TeamIds, never free-text strings."""
+    level = LevelId(1)
+    m = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0)
+    inputs = [_final_input(11, 1, level), _final_input(12, 2, level), _final_input(13, 3, level)]
+    stages = [_stage_with_inputs(1, [m], inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    for team_id in result.values():
+        assert isinstance(team_id, int)
+
+
+def test_assign_referees_disabled_returns_empty() -> None:
+    """When referees_enabled is False the function returns an empty dict immediately."""
+    level = LevelId(1)
+    m = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0)
+    inputs = [_final_input(11, 1, level), _final_input(12, 2, level), _final_input(13, 3, level)]
+    stages = [_stage_with_inputs(1, [m], inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament())
+
+    assert result == {}
+
+
+def test_assign_referees_skips_unscheduled_matches() -> None:
+    """Unscheduled matches (no start_time / court_id) are not considered."""
+    level = LevelId(1)
+    m_scheduled = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0)
+    m_unscheduled = _match_with_teams(2, 3, 4, level)
+    inputs = [
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
+        _final_input(14, 4, level),
+        _final_input(15, 5, level),
+    ]
+    stages = [_stage_with_inputs(1, [m_scheduled, m_unscheduled], inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    assert MatchId(2) not in result
+
+
+def test_assign_referees_existing_counts_toward_fairness() -> None:
+    """Existing referee assignments are counted toward the fairness balance."""
+    level = LevelId(1)
+    m1 = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0)
+    m2 = _scheduled_match_with_teams(2, 3, 4, level, start_offset_minutes=SLOT)
+    m3 = _scheduled_match_with_teams(3, 5, 6, level, start_offset_minutes=2 * SLOT)
+    m1_with_ref = _match_with_referee(m1, team_id=9)
+    inputs = [_final_input(i * 10, i, level) for i in range(1, 11)]
+    stages = [_stage_with_inputs(1, [m1_with_ref, m2, m3], inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    assert MatchId(1) not in result
+    load: dict[TeamId, int] = defaultdict(int)
+    load[TeamId(9)] = 1  # already assigned
+    for team_id in result.values():
+        load[team_id] += 1
+    if load:
+        assert max(load.values()) - min(load.values()) <= 1

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -1299,8 +1299,10 @@ def test_assign_referees_excludes_playing_team() -> None:
 
     result = build_referee_assignment_plan(stages, _tournament_with_referees())
 
-    assert result.get(MatchId(1)) not in (TeamId(1), TeamId(2))
-    assert result.get(MatchId(2)) not in (TeamId(3), TeamId(4))
+    assert MatchId(1) in result
+    assert result[MatchId(1)] not in (TeamId(1), TeamId(2))
+    assert MatchId(2) in result
+    assert result[MatchId(2)] not in (TeamId(3), TeamId(4))
 
 
 def test_assign_referees_excludes_team_playing_overlapping_match() -> None:
@@ -1320,8 +1322,9 @@ def test_assign_referees_excludes_team_playing_overlapping_match() -> None:
 
     result = build_referee_assignment_plan(stages, _tournament_with_referees())
 
-    if MatchId(1) in result and MatchId(2) in result:
-        assert result[MatchId(1)] != result[MatchId(2)]
+    assert MatchId(1) in result
+    assert MatchId(2) in result
+    assert result[MatchId(1)] != result[MatchId(2)]
 
 
 def test_assign_referees_no_candidate_leaves_match_unassigned() -> None:

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -1249,17 +1249,21 @@ def test_assign_referees_only_fills_missing_not_existing() -> None:
 
 
 def test_assign_referees_schedule_unchanged() -> None:
-    """Returns a plain dict of match_id→team_id; no court or time information."""
+    """Match court_id and start_time in the stage objects are untouched after the call."""
     level = LevelId(1)
-    m = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0)
+    m = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0, court_id=7)
     inputs = [_final_input(11, 1, level), _final_input(12, 2, level), _final_input(13, 3, level)]
     stages = [_stage_with_inputs(1, [m], inputs, level_id=level)]
 
-    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+    court_before = m.court_id
+    time_before = m.start_time
 
-    assert isinstance(result, dict)
-    for v in result.values():
-        assert isinstance(v, int)
+    build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    # The match object in the stage is the same reference — verify it was not mutated
+    match_after = stages[0].stage_items[0].rounds[0].matches[0]
+    assert match_after.court_id == court_before
+    assert match_after.start_time == time_before
 
 
 def test_assign_referees_level_restriction() -> None:
@@ -1350,6 +1354,25 @@ def test_assign_referees_balanced_load() -> None:
         load[team_id] += 1
     if load:
         assert max(load.values()) - min(load.values()) <= 1
+
+
+def test_assign_referees_deterministic_tiebreak() -> None:
+    """Repeated calls with the same inputs and fixed seed yield identical assignments."""
+    level = LevelId(1)
+    # 2 non-overlapping matches, 4 eligible teams — multiple balanced solutions exist,
+    # so the tie-break (fixed solver seed) must select the same one every time.
+    matches = [
+        _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0, court_id=1),
+        _scheduled_match_with_teams(2, 3, 4, level, start_offset_minutes=SLOT, court_id=1),
+    ]
+    inputs = [_final_input(i * 10, i, level) for i in range(1, 7)]
+    stages = [_stage_with_inputs(1, matches, inputs, level_id=level)]
+    tournament = _tournament_with_referees()
+
+    result_a = build_referee_assignment_plan(stages, tournament)
+    result_b = build_referee_assignment_plan(stages, tournament)
+
+    assert result_a == result_b
 
 
 def test_assign_referees_no_free_text() -> None:

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -37,6 +37,7 @@
     "archived_label": "Archiviert",
     "at_least_one_player_validation": "Mindestens einen Spieler eingeben",
     "at_least_one_team_validation": "Mindestens ein Team eingeben",
+    "assign_missing_referees_description": "Fehlende Schiedsrichter zuweisen",
     "at_least_two_team_validation": "Es werden mindestens zwei Teams benötigt",
     "auto_assign_courts_label": "Spielfelder automatisch für Spiele zuweisen",
     "auto_assign_teams_label": "Teams automatisch zuweisen",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -37,6 +37,7 @@
     "archived_label": "Archived",
     "at_least_one_player_validation": "Enter at least one player",
     "at_least_one_team_validation": "Enter at least one team",
+    "assign_missing_referees_description": "Assign missing referees",
     "at_least_two_team_validation": "Need at least two teams",
     "auto_assign_courts_label": "Automatically assign courts to matches",
     "auto_assign_teams_label": "Auto-assign teams",

--- a/frontend/src/components/scheduling/planner_tools_sheet.tsx
+++ b/frontend/src/components/scheduling/planner_tools_sheet.tsx
@@ -1,5 +1,11 @@
 import { Button, Divider, Drawer, Select, Stack } from '@mantine/core';
-import { IconCalendarPlus, IconPlus, IconTrash, IconWand } from '@tabler/icons-react';
+import {
+  IconCalendarPlus,
+  IconPlus,
+  IconTrash,
+  IconUserCheck,
+  IconWand,
+} from '@tabler/icons-react';
 import { ComponentProps, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SWRResponse } from 'swr';
@@ -28,6 +34,8 @@ export default function PlannerToolsSheet({
   onHighlightChange,
   onSchedule,
   onReoptimize,
+  refereesEnabled,
+  onAssignReferees,
 }: {
   opened: boolean;
   onClose: () => void;
@@ -40,6 +48,8 @@ export default function PlannerToolsSheet({
   onHighlightChange: (value: string | null) => void;
   onSchedule: () => void;
   onReoptimize: () => void;
+  refereesEnabled: boolean;
+  onAssignReferees: () => void;
 }) {
   const { t } = useTranslation();
   const [addOpened, setAddOpened] = useState(false);
@@ -134,6 +144,20 @@ export default function PlannerToolsSheet({
           >
             {t('reoptimize_description')}
           </Button>
+          {refereesEnabled && (
+            <Button
+              variant="light"
+              color="teal"
+              justify="flex-start"
+              leftSection={<IconUserCheck size={20} />}
+              onClick={() => {
+                onClose();
+                onAssignReferees();
+              }}
+            >
+              {t('assign_missing_referees_description')}
+            </Button>
+          )}
         </Stack>
       </Drawer>
     </>

--- a/frontend/src/openapi/index.ts
+++ b/frontend/src/openapi/index.ts
@@ -2,6 +2,7 @@
 
 export {
   activateNextStageTournamentsTournamentIdStagesActivatePost,
+  autoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPost,
   changeStatusTournamentsTournamentIdChangeStatusPost,
   createCourtTournamentsTournamentIdCourtsPost,
   createMatchTournamentsTournamentIdMatchesPost,
@@ -84,6 +85,11 @@ export type {
   ActivateNextStageTournamentsTournamentIdStagesActivatePostErrors,
   ActivateNextStageTournamentsTournamentIdStagesActivatePostResponse,
   ActivateNextStageTournamentsTournamentIdStagesActivatePostResponses,
+  AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostData,
+  AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostError,
+  AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostErrors,
+  AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostResponse,
+  AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostResponses,
   BodyLoginForAccessTokenTokenPost,
   BodyUpdateTeamLogoTournamentsTournamentIdTeamsTeamIdLogoPost,
   BodyUploadLogoTournamentsTournamentIdLogoPost,

--- a/frontend/src/openapi/sdk.gen.ts
+++ b/frontend/src/openapi/sdk.gen.ts
@@ -12,6 +12,9 @@ import type {
   ActivateNextStageTournamentsTournamentIdStagesActivatePostData,
   ActivateNextStageTournamentsTournamentIdStagesActivatePostErrors,
   ActivateNextStageTournamentsTournamentIdStagesActivatePostResponses,
+  AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostData,
+  AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostErrors,
+  AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostResponses,
   ChangeStatusTournamentsTournamentIdChangeStatusPostData,
   ChangeStatusTournamentsTournamentIdChangeStatusPostErrors,
   ChangeStatusTournamentsTournamentIdChangeStatusPostResponses,
@@ -743,6 +746,32 @@ export const createMatchTournamentsTournamentIdMatchesPost = <ThrowOnError exten
     responseType: 'json',
     security: [{ scheme: 'bearer', type: 'http' }],
     url: '/tournaments/{tournament_id}/matches',
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+
+/**
+ * Auto Assign Referees
+ */
+export const autoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPost = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostData,
+    ThrowOnError
+  >
+) =>
+  (options.client ?? client).post<
+    AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostResponses,
+    AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostErrors,
+    ThrowOnError
+  >({
+    responseType: 'json',
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/tournaments/{tournament_id}/matches/auto-assign-referees',
     ...options,
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/openapi/types.gen.ts
+++ b/frontend/src/openapi/types.gen.ts
@@ -3104,6 +3104,38 @@ export type CreateMatchTournamentsTournamentIdMatchesPostResponses = {
 export type CreateMatchTournamentsTournamentIdMatchesPostResponse =
   CreateMatchTournamentsTournamentIdMatchesPostResponses[keyof CreateMatchTournamentsTournamentIdMatchesPostResponses];
 
+export type AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostData = {
+  body?: SchedulerWeights;
+  path: {
+    /**
+     * Tournament Id
+     */
+    tournament_id: number;
+  };
+  query?: never;
+  url: '/tournaments/{tournament_id}/matches/auto-assign-referees';
+};
+
+export type AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostError =
+  AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostErrors[keyof AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostErrors];
+
+export type AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: SuccessResponse;
+};
+
+export type AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostResponse =
+  AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostResponses[keyof AutoAssignRefereesTournamentsTournamentIdMatchesAutoAssignRefereesPostResponses];
+
 export type SwapMatchesTournamentsTournamentIdMatchesSwapPostData = {
   body: MatchSwapBody;
   path: {

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -297,6 +297,16 @@ export default function SchedulePage() {
     }
   }
 
+  async function handleAssignReferees() {
+    setIsOptimizing(true);
+    try {
+      await autoAssignReferees(tournamentData.id);
+      await swrStagesResponse.mutate();
+    } finally {
+      setIsOptimizing(false);
+    }
+  }
+
   async function performAction(action: PlanningAction) {
     switch (action.type) {
       case 'swap':
@@ -531,15 +541,7 @@ export default function SchedulePage() {
                     variant="light"
                     style={{ marginBottom: 10 }}
                     leftSection={<IconUserCheck size={24} />}
-                    onClick={async () => {
-                      setIsOptimizing(true);
-                      try {
-                        await autoAssignReferees(tournamentData.id);
-                        await swrStagesResponse.mutate();
-                      } finally {
-                        setIsOptimizing(false);
-                      }
-                    }}
+                    onClick={handleAssignReferees}
                   >
                     {t('assign_missing_referees_description')}
                   </Button>
@@ -638,16 +640,8 @@ export default function SchedulePage() {
                 onHighlightChange={setHighlightValue}
                 onSchedule={() => setScheduleModalOpened(true)}
                 onReoptimize={() => setReoptimizeModalOpened(true)}
-                refereesEnabled={tournament.referees_enabled}
-                onAssignReferees={async () => {
-                  setIsOptimizing(true);
-                  try {
-                    await autoAssignReferees(tournamentData.id);
-                    await swrStagesResponse.mutate();
-                  } finally {
-                    setIsOptimizing(false);
-                  }
-                }}
+                refereesEnabled={tournament.referees_enabled && courts.length > 0}
+                onAssignReferees={handleAssignReferees}
               />
             )}
             <Modal

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -23,6 +23,7 @@ import {
   IconCalendarPlus,
   IconListDetails,
   IconTools,
+  IconUserCheck,
   IconWand,
 } from '@tabler/icons-react';
 import { isAxiosError } from 'axios';
@@ -80,6 +81,7 @@ import {
   getUnscheduledMatches,
 } from '@services/lookups';
 import {
+  autoAssignReferees,
   reoptimizeMatches,
   rescheduleMatch,
   resizeMatchBreak,
@@ -522,6 +524,26 @@ export default function SchedulePage() {
                     {t('reoptimize_description')}
                   </Button>
                 )}
+                {courts.length < 1 || !tournament.referees_enabled ? null : (
+                  <Button
+                    color="teal"
+                    size="md"
+                    variant="light"
+                    style={{ marginBottom: 10 }}
+                    leftSection={<IconUserCheck size={24} />}
+                    onClick={async () => {
+                      setIsOptimizing(true);
+                      try {
+                        await autoAssignReferees(tournamentData.id);
+                        await swrStagesResponse.mutate();
+                      } finally {
+                        setIsOptimizing(false);
+                      }
+                    }}
+                  >
+                    {t('assign_missing_referees_description')}
+                  </Button>
+                )}
               </Group>
             </Grid.Col>
           )}
@@ -616,6 +638,16 @@ export default function SchedulePage() {
                 onHighlightChange={setHighlightValue}
                 onSchedule={() => setScheduleModalOpened(true)}
                 onReoptimize={() => setReoptimizeModalOpened(true)}
+                refereesEnabled={tournament.referees_enabled}
+                onAssignReferees={async () => {
+                  setIsOptimizing(true);
+                  try {
+                    await autoAssignReferees(tournamentData.id);
+                    await swrStagesResponse.mutate();
+                  } finally {
+                    setIsOptimizing(false);
+                  }
+                }}
               />
             )}
             <Modal

--- a/frontend/src/services/match.tsx
+++ b/frontend/src/services/match.tsx
@@ -88,6 +88,12 @@ export async function resizeMatchBreak(
   return createAxios().post(`tournaments/${tournament_id}/matches/${match_id}/resize_break`, body);
 }
 
+export async function autoAssignReferees(tournament_id: number, weights?: SchedulerWeights) {
+  return createAxios()
+    .post(`tournaments/${tournament_id}/matches/auto-assign-referees`, weights)
+    .catch((response: any) => handleRequestError(response));
+}
+
 export async function scheduleMatches(tournament_id: number, weights?: SchedulerWeights) {
   return createAxios()
     .post(`tournaments/${tournament_id}/schedule_matches`, weights)


### PR DESCRIPTION
Adds a dedicated endpoint and UI button that fills referee slots on
already-scheduled matches using CP-SAT without touching the match
schedule.

Backend:
- `build_referee_assignment_plan` – pure CP-SAT function; pins schedule,
  maximises coverage, balances load with a dominance-weighted objective
- `assign_missing_referees_only` – async persistence helper
- `POST /tournaments/{id}/matches/auto-assign-referees` route, gated on
  `referees_enabled`
- 11 new unit tests; integration test scaffolded

Frontend:
- `autoAssignReferees` service function
- Desktop toolbar button (teal, gated on `referees_enabled`)
- Mobile `PlannerToolsSheet` entry (`refereesEnabled` prop)
- i18n keys added to `en` and `de` locales

Closes #106

https://claude.ai/code/session_01J7DmTdLeQ6miuc1M4TAjoj