### PR TITLE
Fix SAT optimizer hard constraints for referee/playing overlap

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -585,6 +585,7 @@ def _add_referee_assignment(
     ends: dict[MatchId, Any],
     input_intervals: dict[StageItemInputId, list[Any]],
     pinned_by_input: dict[StageItemInputId, list[_PinnedMatch]],
+    pinned_by_referee_team: dict[TeamId, list[_PinnedMatch]],
     team_level_ids: dict[TeamId, LevelId | None],
     horizon: int,
 ) -> tuple[dict[MatchId, dict[TeamId, Any]], list[Any]]:
@@ -654,11 +655,12 @@ def _add_referee_assignment(
         team_id for choices in ref_choices.values() for team_id in choices
     )
 
-    # Per-team interval lists: playing (movable) + referee (optional, movable)
+    # Per-team interval lists: playing (movable) + referee (optional, movable) + pinned referee
     team_all_intervals: dict[TeamId, list[Any]] = defaultdict(list)
 
-    # Add movable playing intervals for each eligible team
-    for team_id in all_eligible_teams:
+    # Add movable playing intervals for eligible teams AND teams with pinned referee assignments
+    # (both groups need conflict-checking against each other's intervals)
+    for team_id in all_eligible_teams | set(pinned_by_referee_team.keys()):
         for input_id in team_to_input_ids.get(team_id, set()):
             team_all_intervals[team_id].extend(input_intervals.get(input_id, []))
 
@@ -681,7 +683,23 @@ def _add_referee_assignment(
                 )
             )
 
-    # No-overlap: a team cannot play and referee simultaneously (movable vs movable)
+    # Add fixed intervals for pinned referee assignments so AddNoOverlap covers:
+    #   - movable playing vs pinned referee (team plays a movable match while refereeing a pinned one)
+    #   - movable referee vs pinned referee (team referees both a movable and a pinned match)
+    for team_id, pinned_ref_matches in pinned_by_referee_team.items():
+        for pinned in pinned_ref_matches:
+            duration = pinned.end_minutes - pinned.start_minutes
+            if duration > 0:
+                team_all_intervals[team_id].append(
+                    model.NewFixedSizeIntervalVar(
+                        pinned.start_minutes,
+                        duration,
+                        f"pinned_ref_match_{pinned.context.match.id}_team_{team_id}",
+                    )
+                )
+
+    # No-overlap: a team cannot play or referee two overlapping intervals (movable vs movable,
+    # movable vs pinned-referee; pinned-playing vs movable-referee is handled separately below)
     for team_id, intervals in team_all_intervals.items():
         if len(intervals) >= 2:
             model.AddNoOverlap(intervals)
@@ -881,6 +899,19 @@ def build_schedule_plan(
     ref_choices: dict[MatchId, dict[TeamId, Any]] = {}
     if tournament.referees_enabled:
         team_level_ids = _get_team_level_ids(stages)
+        pinned_by_referee_team: dict[TeamId, list[_PinnedMatch]] = defaultdict(list)
+        for context in pinned_contexts:
+            ref = context.match.referee
+            if ref is None or ref.team_id is None:
+                continue
+            start_minutes = _minute_offset(tournament, assert_some(context.match.start_time))
+            pinned_by_referee_team[ref.team_id].append(
+                _PinnedMatch(
+                    context=context,
+                    start_minutes=start_minutes,
+                    end_minutes=start_minutes + context.match.duration_minutes,
+                )
+            )
         ref_choices, ref_spreads = _add_referee_assignment(
             model,
             movable_contexts,
@@ -889,6 +920,7 @@ def build_schedule_plan(
             ends,
             input_intervals,
             pinned_by_input,
+            pinned_by_referee_team,
             team_level_ids,
             horizon,
         )
@@ -993,6 +1025,16 @@ def build_referee_assignment_plan(
     if not needs_ref:
         return {}
 
+    # Build per-team refereeing intervals from already-assigned matches so we can
+    # exclude teams that are already committed as referee at an overlapping time.
+    team_refereeing_intervals: dict[TeamId, list[tuple[int, int]]] = defaultdict(list)
+    for context in has_ref:
+        ref = context.match.referee
+        if ref is not None and ref.team_id is not None:
+            start_min = _minute_offset(tournament, assert_some(context.match.start_time))
+            end_min = start_min + context.match.duration_minutes
+            team_refereeing_intervals[ref.team_id].append((start_min, end_min))
+
     model = cp_model.CpModel()
 
     ref_choices: dict[MatchId, dict[TeamId, Any]] = {}
@@ -1009,7 +1051,7 @@ def build_referee_assignment_plan(
             if isinstance(input_, StageItemInputFinal):
                 playing_teams.add(input_.team_id)
 
-        # Eligible: same level, not playing in this match, not playing in an overlapping match.
+        # Eligible: same level, not playing in this match, not playing or refereeing at overlap.
         eligible: set[TeamId] = set()
         for team_id, level_id in team_level_ids.items():
             if level_id != context.level_id or team_id in playing_teams:
@@ -1017,6 +1059,11 @@ def build_referee_assignment_plan(
             if any(
                 start_min < p_end and p_start < end_min
                 for p_start, p_end in team_playing_intervals.get(team_id, [])
+            ):
+                continue
+            if any(
+                start_min < r_end and r_start < end_min
+                for r_start, r_end in team_refereeing_intervals.get(team_id, [])
             ):
                 continue
             eligible.add(team_id)

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -1441,3 +1441,99 @@ def test_assign_referees_existing_counts_toward_fairness() -> None:
         load[team_id] += 1
     if load:
         assert max(load.values()) - min(load.values()) <= 1
+
+
+def test_assign_referees_excludes_team_already_refereeing_overlapping_match() -> None:
+    """A team already assigned as referee for a match cannot referee another simultaneous match.
+
+    m1 and m2 run at the same time on different courts. m1 already has team 5 as referee.
+    Team 5 must not be assigned to also referee m2.
+    """
+    level = LevelId(1)
+    m1 = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0, court_id=1)
+    m2 = _scheduled_match_with_teams(2, 3, 4, level, start_offset_minutes=0, court_id=2)
+    m1_with_ref = _match_with_referee(m1, team_id=5)
+    inputs = [
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
+        _final_input(14, 4, level),
+        _final_input(15, 5, level),
+        _final_input(16, 6, level),
+    ]
+    stages = [_stage_with_inputs(1, [m1_with_ref, m2], inputs, level_id=level)]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    assert MatchId(1) not in result, "Should not overwrite existing referee"
+    if MatchId(2) in result:
+        assert result[MatchId(2)] != TeamId(5), "Team 5 already referees m1 at the same time"
+
+
+# ── build_schedule_plan: pinned-referee vs movable-playing conflict ────────────
+
+
+def test_schedule_movable_playing_not_overlapping_pinned_referee() -> None:
+    """A movable match must not be placed at the same time as a pinned match refereed by
+    one of its playing teams.
+
+    Setup: m1 is pinned with team 3 as referee. m2 is movable, with team 3 playing.
+    The optimizer must not place m2 overlapping m1.
+    """
+    level = LevelId(1)
+    inp3_a = _final_input(31, 3, level)
+    inp3_b = _final_input(32, 4, level)
+    m1_base = MatchWithDetails(
+        id=MatchId(1),
+        created=T0,
+        duration_minutes=DURATION,
+        round_id=RoundId(1),
+        stage_item_input1_score=0,
+        stage_item_input2_score=0,
+        stage_item_input1_conflict=False,
+        stage_item_input2_conflict=False,
+        stage_item_input1_id=_final_input(11, 1, level).id,
+        stage_item_input2_id=_final_input(12, 2, level).id,
+        stage_item_input1=_final_input(11, 1, level),
+        stage_item_input2=_final_input(12, 2, level),
+        start_time=T0,
+        court_id=CourtId(1),
+    )
+    m1 = _match_with_referee(m1_base, team_id=3)
+    m2 = MatchWithDetails(
+        id=MatchId(2),
+        created=T0,
+        duration_minutes=DURATION,
+        round_id=RoundId(2),
+        stage_item_input1_score=0,
+        stage_item_input2_score=0,
+        stage_item_input1_conflict=False,
+        stage_item_input2_conflict=False,
+        stage_item_input1_id=inp3_a.id,
+        stage_item_input2_id=inp3_b.id,
+        stage_item_input1=inp3_a,
+        stage_item_input2=inp3_b,
+    )
+    inputs = [
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        inp3_a,
+        inp3_b,
+    ]
+    stages = [_stage_with_inputs(1, [m1, m2], inputs, level_id=level)]
+    tournament = _tournament_with_referees()
+
+    ops = build_schedule_plan(stages, [_court(1), _court(2)], tournament, reoptimize=True)
+
+    # m2 is the only movable match; m1 is pinned at T0 on court 1
+    m2_ops = [op for op in ops if op.match.id == MatchId(2)]
+    assert len(m2_ops) == 1
+    m2_op = m2_ops[0]
+    m2_end = m2_op.start_time + timedelta(minutes=DURATION)
+    m1_end = T0 + timedelta(minutes=DURATION)
+    # m2 must not overlap with m1 (team 3 referees m1 and plays m2)
+    overlap = m2_op.start_time < m1_end and T0 < m2_end
+    assert not overlap, (
+        f"m2 (team 3 playing) overlaps m1 (team 3 refereeing): "
+        f"m2 starts {m2_op.start_time}, m1 ends {m1_end}"
+    )


### PR DESCRIPTION
Two gaps allowed a team to simultaneously referee one match and play in another:

1. In _add_referee_assignment (build_schedule_plan): when a pinned match has a
   team assigned as referee, the optimizer had no constraint preventing a movable
   match where that same team plays from being placed at the same time. Fixed by
   computing pinned_by_referee_team and adding NewFixedSizeIntervalVar entries for
   those pinned referee slots into team_all_intervals, so the existing AddNoOverlap
   constraint covers the pinned-referee vs movable-playing case as well as
   movable-referee vs pinned-referee.

2. In build_referee_assignment_plan: eligibility filtering excluded teams playing
   in overlapping matches but not teams already assigned as referee for overlapping
   has_ref matches. Fixed by building team_refereeing_intervals from has_ref
   contexts and checking it in the eligibility loop.

https://claude.ai/code/session_01LDKtTw9kGm5wAgzKDs33Af