### PR TITLE
Fix referee/playing conflict for preserved referees in CP-SAT scheduler

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -593,8 +593,11 @@ def _add_referee_assignment(
 
     For each movable match without a referee, optionally assigns one team (same level,
     not currently playing). Hard constraints prevent a team from refereeing when it is
-    playing or already refereeing another overlapping match. The fairness term minimises
-    the spread of per-team referee counts across all eligible teams.
+    playing or already refereeing another overlapping match. This covers preserved
+    referees on movable matches too: a match that already has a referee keeps it, but its
+    start time is still re-flowed, so the fixed referee team is constrained from playing or
+    refereeing elsewhere at the chosen time. The fairness term minimises the spread of
+    per-team referee counts across all eligible teams.
 
     Returns (ref_choices, [spread_var]) where ref_choices[match_id][team_id] is the
     BoolVar indicating whether that team referees that match, and spread_var (if any
@@ -625,10 +628,20 @@ def _add_referee_assignment(
     # Create referee decision variables for each movable match lacking a referee
     ref_choices: dict[MatchId, dict[TeamId, Any]] = {}
     match_durations: dict[MatchId, int] = {}
+    # Movable matches whose referee is already assigned: we keep the referee, but the match
+    # start time is still re-flowed by the solver, so the fixed referee team must not be
+    # playing (or refereeing) at the chosen time. Record team_id per match so the no-overlap
+    # and pinned-playing constraints below cover these preserved assignments too.
+    preserved_ref_team: dict[MatchId, TeamId] = {}
     for context in movable_contexts:
         match = context.match
         if match.referee_id is not None:
-            continue  # already assigned manually — preserve it
+            # Already assigned — preserve it, but still constrain it against playing overlaps.
+            referee = match.referee
+            if referee is not None and referee.team_id is not None:
+                preserved_ref_team[match.id] = referee.team_id
+                match_durations[match.id] = match.duration_minutes
+            continue
 
         match_level = context.level_id
         playing_teams = match_playing_teams[match.id]
@@ -648,19 +661,23 @@ def _add_referee_assignment(
         ref_choices[match.id] = choices
         match_durations[match.id] = match.duration_minutes
 
-    if not ref_choices:
+    if not ref_choices and not preserved_ref_team:
         return {}, []
 
     all_eligible_teams: set[TeamId] = set(
         team_id for choices in ref_choices.values() for team_id in choices
     )
 
-    # Per-team interval lists: playing (movable) + referee (optional, movable) + pinned referee
+    # Per-team interval lists: playing (movable) + referee (optional new, mandatory preserved,
+    # movable) + pinned referee
     team_all_intervals: dict[TeamId, list[Any]] = defaultdict(list)
 
-    # Add movable playing intervals for eligible teams AND teams with pinned referee assignments
-    # (both groups need conflict-checking against each other's intervals)
-    for team_id in all_eligible_teams | set(pinned_by_referee_team.keys()):
+    # Add movable playing intervals for every team that participates in a referee constraint:
+    # eligible candidates, teams refereeing a pinned match, and teams whose preserved referee
+    # assignment sits on a movable match. Each needs conflict-checking against the others.
+    for team_id in (
+        all_eligible_teams | set(pinned_by_referee_team.keys()) | set(preserved_ref_team.values())
+    ):
         for input_id in team_to_input_ids.get(team_id, set()):
             team_all_intervals[team_id].extend(input_intervals.get(input_id, []))
 
@@ -683,8 +700,27 @@ def _add_referee_assignment(
                 )
             )
 
+    # Add mandatory referee intervals for preserved assignments on movable matches. The team
+    # is fixed, but the start is a variable, so a plain (non-optional) interval at the match's
+    # start makes AddNoOverlap forbid the team from playing or refereeing anything else then.
+    for match_id, team_id in preserved_ref_team.items():
+        duration = match_durations[match_id]
+        ref_end = model.NewIntVar(
+            0,
+            horizon + duration,
+            f"preserved_ref_end_match_{match_id}_team_{team_id}",
+        )
+        team_all_intervals[team_id].append(
+            model.NewIntervalVar(
+                starts[match_id],
+                duration,
+                ref_end,
+                f"preserved_ref_interval_match_{match_id}_team_{team_id}",
+            )
+        )
+
     # Add fixed intervals for pinned referee assignments so AddNoOverlap covers:
-    #   - movable playing vs pinned referee (team plays a movable match while refereeing a pinned one)
+    #   - movable playing vs pinned referee (team plays a movable match, referees a pinned one)
     #   - movable referee vs pinned referee (team referees both a movable and a pinned match)
     for team_id, pinned_ref_matches in pinned_by_referee_team.items():
         for pinned in pinned_ref_matches:
@@ -720,6 +756,24 @@ def _add_referee_assignment(
                     model.Add(ends[match_id] <= pinned.start_minutes).OnlyEnforceIf([var, before])
                     model.Add(starts[match_id] >= pinned.end_minutes).OnlyEnforceIf([var, after])
                     model.AddBoolOr([before, after, var.Not()])
+
+    # Same constraint for preserved (fixed) referees on movable matches: the team is committed
+    # unconditionally, so the movable match must sit entirely before or after each pinned match
+    # the referee team plays in.
+    for match_id, team_id in preserved_ref_team.items():
+        for input_id in team_to_input_ids.get(team_id, set()):
+            for pinned in pinned_by_input.get(input_id, []):
+                before = model.NewBoolVar(
+                    f"preserved_ref_match_{match_id}_team_{team_id}_"
+                    f"before_pinned_{pinned.context.match.id}"
+                )
+                after = model.NewBoolVar(
+                    f"preserved_ref_match_{match_id}_team_{team_id}_"
+                    f"after_pinned_{pinned.context.match.id}"
+                )
+                model.Add(ends[match_id] <= pinned.start_minutes).OnlyEnforceIf(before)
+                model.Add(starts[match_id] >= pinned.end_minutes).OnlyEnforceIf(after)
+                model.AddBoolOr([before, after])
 
     # Fixed referee load from pinned matches (already assigned, can't change)
     fixed_ref_count: dict[TeamId, int] = defaultdict(int)

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -1112,6 +1112,80 @@ def test_existing_referee_assignment_not_overwritten() -> None:
     assert ops[0].referee_team_id is None
 
 
+def test_preserved_referee_not_overlapped_with_its_own_playing_match() -> None:
+    """A re-flowed match keeps its referee, and that team must not play an overlapping match.
+
+    Both matches are movable (reoptimize), so the solver chooses their start times. m1 keeps
+    its preserved referee team 3, but team 3 also plays m2. The solver must not place m1 and
+    m2 at overlapping times, or team 3 would referee m1 while playing m2.
+    """
+    level = LevelId(1)
+    # m1: teams 1 vs 2, refereed by team 3. m2: teams 3 vs 4 (team 3 plays here).
+    m1 = _match_with_referee(_match_with_teams(1, 1, 2, level), team_id=3)
+    m2 = _match_with_teams(2, 3, 4, level)
+    inputs = [
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
+        _final_input(14, 4, level),
+    ]
+    stages = [_stage_with_inputs(1, [m1, m2], inputs, level_id=level)]
+    tournament = _tournament_with_referees()
+
+    # Two courts let the solver place both matches in parallel unless a constraint forbids it.
+    ops = build_schedule_plan(stages, [_court(1), _court(2)], tournament, reoptimize=True)
+
+    assert len(ops) == 2
+    op_by_id = {op.match.id: op for op in ops}
+    op1, op2 = op_by_id[MatchId(1)], op_by_id[MatchId(2)]
+    end1 = op1.start_time + timedelta(minutes=DURATION)
+    end2 = op2.start_time + timedelta(minutes=DURATION)
+    overlap = op1.start_time < end2 and op2.start_time < end1
+    assert not overlap, "Team 3 referees m1 and plays m2; the two must not overlap"
+
+
+def test_preserved_referee_not_overlapped_with_pinned_playing_match() -> None:
+    """A re-flowed match's preserved referee must not overlap a pinned match the team plays.
+
+    m1 is pinned at T0 with team 3 playing. m2 is movable and keeps preserved referee team 3.
+    The solver must not place m2 overlapping m1.
+    """
+    level = LevelId(1)
+    # m1: pinned, teams 3 vs 4 at T0 on court 1. m2: movable, refereed by team 3.
+    inp31 = _final_input(31, 3, level)
+    inp32 = _final_input(32, 4, level)
+    m1 = MatchWithDetails(
+        id=MatchId(1),
+        created=T0,
+        duration_minutes=DURATION,
+        round_id=RoundId(1),
+        stage_item_input1_score=0,
+        stage_item_input2_score=0,
+        stage_item_input1_conflict=False,
+        stage_item_input2_conflict=False,
+        stage_item_input1_id=inp31.id,
+        stage_item_input2_id=inp32.id,
+        stage_item_input1=inp31,
+        stage_item_input2=inp32,
+        start_time=T0,
+        court_id=CourtId(1),
+    )
+    m2 = _match_with_referee(_match_with_teams(2, 1, 2, level), team_id=3)
+    inputs = [_final_input(11, 1, level), _final_input(12, 2, level), inp31, inp32]
+    stages = [_stage_with_inputs(1, [m1, m2], inputs, level_id=level)]
+    tournament = _tournament_with_referees()
+
+    ops = build_schedule_plan(stages, [_court(1), _court(2)], tournament, reoptimize=False)
+
+    m2_ops = [op for op in ops if op.match.id == MatchId(2)]
+    assert len(m2_ops) == 1
+    m2_start = m2_ops[0].start_time
+    m2_end = m2_start + timedelta(minutes=DURATION)
+    m1_end = T0 + timedelta(minutes=DURATION)
+    overlap = m2_start < m1_end and T0 < m2_end
+    assert not overlap, "Team 3 plays pinned m1 and referees m2; the two must not overlap"
+
+
 def test_free_text_referee_match_not_overwritten() -> None:
     """A match with a free-text referee (no team_id) is also left as-is."""
     level = LevelId(1)
@@ -1523,7 +1597,10 @@ def test_schedule_movable_playing_not_overlapping_pinned_referee() -> None:
     stages = [_stage_with_inputs(1, [m1, m2], inputs, level_id=level)]
     tournament = _tournament_with_referees()
 
-    ops = build_schedule_plan(stages, [_court(1), _court(2)], tournament, reoptimize=True)
+    # reoptimize=False keeps every already-scheduled match pinned, so m1 stays at T0 with its
+    # referee (team 3); only the unscheduled m2 is placed. (Under reoptimize=True a NOT_STARTED
+    # match is movable, so m1 would no longer be pinned and this would test a different case.)
+    ops = build_schedule_plan(stages, [_court(1), _court(2)], tournament, reoptimize=False)
 
     # m2 is the only movable match; m1 is pinned at T0 on court 1
     m2_ops = [op for op in ops if op.match.id == MatchId(2)]


### PR DESCRIPTION
## Problem

The auto-scheduler could assign a team as referee for one match while that
same team is playing another match at the same time. It worked on small
tournaments but broke on larger ones — most visibly in **"optimize all
matches"** with several levels and ~100 matches.

## Root cause

When the solver re-flows a match that **already has a referee**, it keeps
that referee (`if match.referee_id is not None: continue`) but the match's
start time is still a free variable. The preserved referee's commitment was
**never added to the team-level `AddNoOverlap` constraints**, so the solver
was free to place that match overlapping another match the referee team
plays in.

This only surfaces at scale because the bug requires movable matches that
*already carry* a referee — exactly what you get after running
auto-assign-referees (or a previous auto-schedule) and then re-optimizing.
Tournaments scheduled from scratch rarely hit it, which is why small cases
looked fine.

## Fix

In `_add_referee_assignment`:

- Track movable matches with an already-assigned team referee
  (`preserved_ref_team`).
- Model each as a **mandatory interval** at the match's (variable) start so
  the existing per-team `AddNoOverlap` forbids the referee team from playing
  or refereeing anything else at that time.
- Add the equivalent explicit guard against **pinned** matches the referee
  team plays in (mirroring the existing movable-referee-vs-pinned-playing
  constraint).

## Tests

- `test_schedule_movable_playing_not_overlapping_pinned_referee` was
  miswired: it used `reoptimize=True`, which leaves a `NOT_STARTED` match
  **movable** rather than pinned, yet asserted against the match's original
  time — so it failed regardless of the fix. Switched it to
  `reoptimize=False` so the match is genuinely pinned, matching the test's
  stated intent.
- Added `test_preserved_referee_not_overlapped_with_its_own_playing_match`
  (reoptimize) and `test_preserved_referee_not_overlapped_with_pinned_playing_match`
  (schedule-unscheduled) for the two preserved-referee directions.

Verified with a fuzzer over 1000+ mixed pinned/movable configurations
(multiple levels, pre-assigned referees, both scheduler modes): **0**
scheduler-introduced referee/playing conflicts after the fix.

All `planning_test.py` (60) and `conflicts_test.py` (26) unit tests pass;
`ruff` and `mypy` clean.

https://claude.ai/code/session_01Y3g4MTxnTeMviiyAnbgoWv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3g4MTxnTeMviiyAnbgoWv)_