### PR TITLE
Defer referee assignment for placeholder matches (#121)

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -136,6 +136,22 @@ def _has_open_slot(stage_item: StageItemWithRounds) -> bool:
     return any(isinstance(input_, StageItemInputEmpty) for input_ in stage_item.inputs)
 
 
+def _opponents_are_known(match: ScheduleMatch) -> bool:
+    """True only when both opponents are concrete teams.
+
+    Matches in later stages get their opponents from placeholders (e.g. "winner of stage
+    item 2 of stage 1"), modelled as ``StageItemInputTentative``. Those resolve to a real
+    team only once the prior stage is activated. While a match still has a placeholder (or
+    empty) input we don't know who will play it, so the referee optimizer must not assign a
+    concrete team as its referee — that team might turn out to be one of the players
+    (issue #121). Such matches are left without a referee until their stage activates and
+    the optimizer (or the "assign missing referees" action) is run again.
+    """
+    return isinstance(match.stage_item_input1, StageItemInputFinal) and isinstance(
+        match.stage_item_input2, StageItemInputFinal
+    )
+
+
 def _get_match_contexts(stages: list[StageWithStageItems]) -> list[_MatchContext]:
     return [
         _MatchContext(
@@ -635,6 +651,9 @@ def _add_referee_assignment(
     preserved_ref_team: dict[MatchId, TeamId] = {}
     for context in movable_contexts:
         match = context.match
+        if not _opponents_are_known(match):
+            # Defer: a placeholder match's players aren't known yet, so don't pick a referee.
+            continue
         if match.referee_id is not None:
             # Already assigned — preserve it, but still constrain it against playing overlaps.
             referee = match.referee
@@ -1096,6 +1115,9 @@ def build_referee_assignment_plan(
 
     for context in needs_ref:
         match = context.match
+        if not _opponents_are_known(match):
+            # Defer: a placeholder match's players aren't known yet, so don't pick a referee.
+            continue
         start_min = _minute_offset(tournament, assert_some(match.start_time))
         end_min = start_min + match.duration_minutes
         match_windows[match.id] = (start_min, end_min)

--- a/backend/tests/integration_tests/api/auto_assign_referees_test.py
+++ b/backend/tests/integration_tests/api/auto_assign_referees_test.py
@@ -3,13 +3,22 @@ import pytest
 from bracket.database import database
 from bracket.logic.scheduling.builder import build_matches_for_stage_item
 from bracket.models.db.stage_item import StageItem, StageItemWithInputsCreate
-from bracket.models.db.stage_item_inputs import StageItemInputCreateBodyFinal
+from bracket.models.db.stage_item_inputs import (
+    StageItemInputCreateBodyFinal,
+    StageItemInputCreateBodyTentative,
+)
 from bracket.schema import tournaments
 from bracket.sql.referees import sql_set_match_referee, sql_upsert_referee_by_team
 from bracket.sql.shared import sql_delete_stage_item_with_foreign_keys
 from bracket.sql.stage_items import sql_create_stage_item_with_inputs
 from bracket.sql.stages import get_full_tournament_details
-from bracket.utils.dummy_records import DUMMY_COURT1, DUMMY_STAGE1, DUMMY_STAGE_ITEM1, DUMMY_TEAM1
+from bracket.utils.dummy_records import (
+    DUMMY_COURT1,
+    DUMMY_STAGE1,
+    DUMMY_STAGE2,
+    DUMMY_STAGE_ITEM1,
+    DUMMY_TEAM1,
+)
 from bracket.utils.http import HTTPMethod
 from bracket.utils.id_types import StageId, TeamId, TournamentId
 from tests.integration_tests.api.shared import (
@@ -164,6 +173,92 @@ async def test_auto_assign_referees_preserves_existing_assignment(
     }
     # The pre-assigned match still has the same referee
     assert after_map[first_match.id] == pre_ref.id
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_auto_assign_referees_skips_placeholder_matches(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Matches whose opponents are still placeholders get no referee (issue #121).
+
+    A later stage's matches reference the previous stage's results via tentative inputs.
+    Until that stage is activated we don't know who will play, so assigning a concrete team
+    as referee risks picking one of the eventual players. Those matches must stay
+    referee-less; the concrete first-stage matches still get referees.
+    """
+    tid = auth_context.tournament.id
+
+    await database.execute(
+        query=tournaments.update().where(tournaments.c.id == tid).values(referees_enabled=True)
+    )
+    try:
+        async with (
+            inserted_court(DUMMY_COURT1.model_copy(update={"tournament_id": tid})),
+            inserted_stage(DUMMY_STAGE1.model_copy(update={"tournament_id": tid})) as stage_one,
+            inserted_stage(DUMMY_STAGE2.model_copy(update={"tournament_id": tid})) as stage_two,
+            inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t1,
+            inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t2,
+            inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t3,
+        ):
+            si_first = await _setup_round_robin_3teams(tid, stage_one.id, t1.id, t2.id, t3.id)
+            # Second-stage item whose two opponents are placeholders from the first stage.
+            si_placeholder = await sql_create_stage_item_with_inputs(
+                tid,
+                StageItemWithInputsCreate(
+                    stage_id=stage_two.id,
+                    name="Finals",
+                    team_count=2,
+                    type=DUMMY_STAGE_ITEM1.type,
+                    inputs=[
+                        StageItemInputCreateBodyTentative(
+                            slot=1, winner_from_stage_item_id=si_first.id, winner_position=1
+                        ),
+                        StageItemInputCreateBodyTentative(
+                            slot=2, winner_from_stage_item_id=si_first.id, winner_position=2
+                        ),
+                    ],
+                ),
+            )
+            await build_matches_for_stage_item(si_placeholder, tid)
+            await send_tournament_request(HTTPMethod.POST, "schedule_matches", auth_context)
+
+            response = await send_tournament_request(HTTPMethod.POST, _ENDPOINT, auth_context)
+
+            stages_after = await get_full_tournament_details(tid)
+            await sql_delete_stage_item_with_foreign_keys(si_placeholder.id)
+            await sql_delete_stage_item_with_foreign_keys(si_first.id)
+    finally:
+        await database.execute(
+            query=tournaments.update().where(tournaments.c.id == tid).values(referees_enabled=False)
+        )
+
+    assert response == SUCCESS_RESPONSE
+
+    first_stage_matches = [
+        m
+        for s in stages_after
+        if s.id == stage_one.id
+        for si_ in s.stage_items
+        for r in si_.rounds
+        for m in r.matches
+        if m.court_id is not None and m.start_time is not None
+    ]
+    placeholder_matches = [
+        m
+        for s in stages_after
+        if s.id == stage_two.id
+        for si_ in s.stage_items
+        for r in si_.rounds
+        for m in r.matches
+    ]
+
+    # First-stage (concrete) matches still get referees.
+    assert len(first_stage_matches) > 0
+    assert all(m.referee_id is not None for m in first_stage_matches)
+
+    # Placeholder matches are left without a referee.
+    assert len(placeholder_matches) > 0
+    assert all(m.referee_id is None for m in placeholder_matches)
 
 
 @pytest.mark.asyncio(loop_scope="session")


### PR DESCRIPTION
The referee auto-optimizer treated only concrete (StageItemInputFinal)
opponents as "playing" when picking an eligible referee. For matches in
later stages whose opponents are still placeholders (StageItemInputTentative,
i.e. "winner of a previous stage item"), it saw no players and was free to
assign any team in the level as referee — including a team that will later
win the prior stage and play that very match.

Defer referee assignment for any match that still has a non-final opponent.
Such matches are left referee-less until their stage is activated (which
resolves the placeholders to real teams) and the optimizer or the
"assign missing referees" action is run again.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UuNjvEoo1FodPY7bfbETTV