### PR TITLE
Reshuffle referee assignments for unpinned matches in full-optimize path

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -604,16 +604,17 @@ def _add_referee_assignment(
     pinned_by_referee_team: dict[TeamId, list[_PinnedMatch]],
     team_level_ids: dict[TeamId, LevelId | None],
     horizon: int,
+    reoptimize: bool = False,
 ) -> tuple[dict[MatchId, dict[TeamId, Any]], list[Any]]:
     """Add referee decision variables, hard constraints, and fairness objective.
 
     For each movable match without a referee, optionally assigns one team (same level,
-    not currently playing). Hard constraints prevent a team from refereeing when it is
-    playing or already refereeing another overlapping match. This covers preserved
-    referees on movable matches too: a match that already has a referee keeps it, but its
-    start time is still re-flowed, so the fixed referee team is constrained from playing or
-    refereeing elsewhere at the chosen time. The fairness term minimises the spread of
-    per-team referee counts across all eligible teams.
+    not currently playing). When reoptimize=True, existing referee assignments on movable
+    matches are also freed up and reshuffled by the solver. When reoptimize=False, a match
+    that already has a referee keeps it, but the no-overlap constraint still applies because
+    its start time is re-flowed. Hard constraints prevent a team from refereeing when it is
+    playing or already refereeing another overlapping match. The fairness term minimises the
+    spread of per-team referee counts across all eligible teams.
 
     Returns (ref_choices, [spread_var]) where ref_choices[match_id][team_id] is the
     BoolVar indicating whether that team referees that match, and spread_var (if any
@@ -641,21 +642,21 @@ def _add_referee_assignment(
                 playing.add(input_.team_id)
         match_playing_teams[context.match.id] = playing
 
-    # Create referee decision variables for each movable match lacking a referee
+    # Create referee decision variables for each movable match.
+    # In default (non-reoptimize) mode, a match that already has a referee keeps it: the
+    # existing assignment is recorded in preserved_ref_team so the no-overlap constraint still
+    # applies while the match is re-flowed. In full-optimize (reoptimize=True) mode, existing
+    # assignments are cleared and the solver picks a fresh referee for every movable match.
     ref_choices: dict[MatchId, dict[TeamId, Any]] = {}
     match_durations: dict[MatchId, int] = {}
-    # Movable matches whose referee is already assigned: we keep the referee, but the match
-    # start time is still re-flowed by the solver, so the fixed referee team must not be
-    # playing (or refereeing) at the chosen time. Record team_id per match so the no-overlap
-    # and pinned-playing constraints below cover these preserved assignments too.
     preserved_ref_team: dict[MatchId, TeamId] = {}
     for context in movable_contexts:
         match = context.match
         if not _opponents_are_known(match):
             # Defer: a placeholder match's players aren't known yet, so don't pick a referee.
             continue
-        if match.referee_id is not None:
-            # Already assigned — preserve it, but still constrain it against playing overlaps.
+        if match.referee_id is not None and not reoptimize:
+            # Non-reoptimize: preserve the existing assignment; still constrain overlaps.
             referee = match.referee
             if referee is not None and referee.team_id is not None:
                 preserved_ref_team[match.id] = referee.team_id
@@ -996,6 +997,7 @@ def build_schedule_plan(
             pinned_by_referee_team,
             team_level_ids,
             horizon,
+            reoptimize,
         )
         if ref_spreads and weights.referee_fairness > 0:
             objective += weights.referee_fairness * sum(ref_spreads)

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -1112,37 +1112,6 @@ def test_existing_referee_assignment_not_overwritten() -> None:
     assert ops[0].referee_team_id is None
 
 
-def test_preserved_referee_not_overlapped_with_its_own_playing_match() -> None:
-    """A re-flowed match keeps its referee, and that team must not play an overlapping match.
-
-    Both matches are movable (reoptimize), so the solver chooses their start times. m1 keeps
-    its preserved referee team 3, but team 3 also plays m2. The solver must not place m1 and
-    m2 at overlapping times, or team 3 would referee m1 while playing m2.
-    """
-    level = LevelId(1)
-    # m1: teams 1 vs 2, refereed by team 3. m2: teams 3 vs 4 (team 3 plays here).
-    m1 = _match_with_referee(_match_with_teams(1, 1, 2, level), team_id=3)
-    m2 = _match_with_teams(2, 3, 4, level)
-    inputs = [
-        _final_input(11, 1, level),
-        _final_input(12, 2, level),
-        _final_input(13, 3, level),
-        _final_input(14, 4, level),
-    ]
-    stages = [_stage_with_inputs(1, [m1, m2], inputs, level_id=level)]
-    tournament = _tournament_with_referees()
-
-    # Two courts let the solver place both matches in parallel unless a constraint forbids it.
-    ops = build_schedule_plan(stages, [_court(1), _court(2)], tournament, reoptimize=True)
-
-    assert len(ops) == 2
-    op_by_id = {op.match.id: op for op in ops}
-    op1, op2 = op_by_id[MatchId(1)], op_by_id[MatchId(2)]
-    end1 = op1.start_time + timedelta(minutes=DURATION)
-    end2 = op2.start_time + timedelta(minutes=DURATION)
-    overlap = op1.start_time < end2 and op2.start_time < end1
-    assert not overlap, "Team 3 referees m1 and plays m2; the two must not overlap"
-
 
 def test_preserved_referee_not_overlapped_with_pinned_playing_match() -> None:
     """A re-flowed match's preserved referee must not overlap a pinned match the team plays.
@@ -1205,6 +1174,65 @@ def test_free_text_referee_match_not_overwritten() -> None:
 
     assert len(ops) == 1
     assert ops[0].referee_team_id is None
+
+
+# ── Referee assignment: full-optimize reshuffles referees ─────────────────────
+
+
+def test_full_optimize_reshuffles_referee_for_unpinned_match() -> None:
+    """reoptimize=True frees up referee assignments on movable matches for reshuffling.
+
+    A match that already has a referee (team 3) should have its assignment cleared in the
+    full-optimize path so the solver picks the best available team. The resulting operation
+    carries a freshly assigned referee_team_id.
+    """
+    level = LevelId(1)
+    m = _match_with_referee(_match_with_teams(1, 1, 2, level), team_id=3)
+    inputs = [
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
+        _final_input(14, 4, level),
+    ]
+    stages = [_stage_with_inputs(1, [m], inputs, level_id=level)]
+    tournament = _tournament_with_referees()
+
+    ops = build_schedule_plan(stages, [_court(1)], tournament, reoptimize=True)
+
+    assert len(ops) == 1
+    assert ops[0].referee_team_id is not None
+
+
+def test_reshuffled_referee_not_overlapped_with_its_own_playing_match() -> None:
+    """The no-overlap constraint applies to freshly assigned referees too.
+
+    Stage inputs only include teams 1–3, so team 4 is not eligible as referee. The solver is
+    forced to pick team 3 as referee for m1 (teams 1 vs 2). Since team 3 also plays m2
+    (teams 3 vs 4), m1 and m2 must not overlap in time.
+    """
+    level = LevelId(1)
+    m1 = _match_with_referee(_match_with_teams(1, 1, 2, level), team_id=3)
+    m2 = _match_with_teams(2, 3, 4, level)
+    inputs = [
+        _final_input(11, 1, level),
+        _final_input(12, 2, level),
+        _final_input(13, 3, level),
+        # Team 4 intentionally omitted — not eligible as referee
+    ]
+    stages = [_stage_with_inputs(1, [m1, m2], inputs, level_id=level)]
+    tournament = _tournament_with_referees()
+
+    ops = build_schedule_plan(stages, [_court(1), _court(2)], tournament, reoptimize=True)
+
+    assert len(ops) == 2
+    op_by_id = {op.match.id: op for op in ops}
+    op1 = op_by_id[MatchId(1)]
+    op2 = op_by_id[MatchId(2)]
+    assert op1.referee_team_id == TeamId(3), "Team 3 is the only eligible referee for m1"
+    end1 = op1.start_time + timedelta(minutes=DURATION)
+    end2 = op2.start_time + timedelta(minutes=DURATION)
+    overlap = op1.start_time < end2 and op2.start_time < end1
+    assert not overlap, "Team 3 both referees m1 and plays m2; they must not overlap"
 
 
 # ── Referee assignment: no rest penalty ───────────────────────────────────────


### PR DESCRIPTION
Previously, movable matches that already had a referee preserved that
assignment in `reoptimize=True` mode — only matches with no referee got
one assigned. Now the full-optimize path clears existing referee
assignments on unpinned matches and lets the solver pick the best team
for each, subject to the same level, playing, and no-overlap constraints.
The default (non-reoptimize) path is unchanged.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UVmUkLwQLSKXWnMKmUZPe5