### PR TITLE
Detect referee double-booking in conflict detection

### DIFF
--- a/backend/bracket/logic/planning/conflicts.py
+++ b/backend/bracket/logic/planning/conflicts.py
@@ -7,7 +7,7 @@ from bracket.database import database
 from bracket.logic.planning.team_windows import PlayingWindow, get_team_playing_windows
 from bracket.models.db.match import Match, MatchWithDetails, MatchWithDetailsDefinitive
 from bracket.models.db.util import StageWithStageItems
-from bracket.utils.id_types import CourtId, MatchId, StageItemId, TournamentId
+from bracket.utils.id_types import CourtId, MatchId, StageItemId, TeamId, TournamentId
 
 
 def matches_overlap(match1: Match, match2: Match) -> bool:
@@ -181,6 +181,9 @@ def _set_referee_overlap_conflicts(
     flags: dict[MatchId, MatchConflictFlags],
 ) -> None:
     team_playing_windows = get_team_playing_windows(stages)
+    refereeing_matches_by_team: defaultdict[
+        TeamId, list[MatchWithDetailsDefinitive | MatchWithDetails]
+    ] = defaultdict(list)
 
     for match in _get_all_matches(stages):
         if match.start_time is None:
@@ -188,6 +191,8 @@ def _set_referee_overlap_conflicts(
         referee = match.referee
         if referee is None or referee.team_id is None:
             continue
+
+        refereeing_matches_by_team[referee.team_id].append(match)
 
         for playing_match, playing_window in team_playing_windows.get(referee.team_id, []):
             if not _time_ranges_overlap(
@@ -200,6 +205,14 @@ def _set_referee_overlap_conflicts(
             flags[match.id].referee_conflict = True
             if isinstance(playing_match, MatchWithDetailsDefinitive):
                 _set_stage_item_input_conflict(playing_match, playing_window, flags)
+
+    # A team cannot referee two matches that overlap in time; flag both of them.
+    for refereeing_matches in refereeing_matches_by_team.values():
+        for i, match1 in enumerate(refereeing_matches):
+            for match2 in refereeing_matches[i + 1 :]:
+                if matches_overlap(match1, match2):
+                    flags[match1.id].referee_conflict = True
+                    flags[match2.id].referee_conflict = True
 
 
 def get_match_conflict_flags(

--- a/backend/tests/unit_tests/conflicts_test.py
+++ b/backend/tests/unit_tests/conflicts_test.py
@@ -576,6 +576,68 @@ def test_referee_conflict_no_playing_match_no_conflict() -> None:
     assert flags[refereeing_match.id].referee_conflict is False
 
 
+def test_referee_conflict_team_referees_two_overlapping_matches() -> None:
+    """A team assigned as referee to two overlapping matches flags both matches."""
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    # inp[0] (team -20) referees both matches, which overlap in time.
+    refereeing_match1 = _make_definitive_match(
+        MatchId(-20),
+        inp[1],
+        inp[2],
+        RoundId(-10),
+        CourtId(-1),
+        T,
+        referee=inp[0],
+    )
+    refereeing_match2 = _make_definitive_match(
+        MatchId(-21),
+        inp[1],
+        inp[3],
+        RoundId(-11),
+        CourtId(-2),
+        T + timedelta(minutes=30),
+        referee=inp[0],
+    )
+    stage = _make_stage_with_two_matches(refereeing_match1, refereeing_match2)
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[refereeing_match1.id].referee_conflict is True
+    assert flags[refereeing_match2.id].referee_conflict is True
+
+
+def test_referee_conflict_team_referees_two_non_overlapping_matches() -> None:
+    """A team refereeing two matches that do not overlap is not flagged."""
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    # inp[0] (team -20) referees both matches, two hours apart — no overlap.
+    refereeing_match1 = _make_definitive_match(
+        MatchId(-20),
+        inp[1],
+        inp[2],
+        RoundId(-10),
+        CourtId(-1),
+        T,
+        referee=inp[0],
+    )
+    refereeing_match2 = _make_definitive_match(
+        MatchId(-21),
+        inp[1],
+        inp[3],
+        RoundId(-11),
+        CourtId(-2),
+        T + timedelta(hours=2),
+        referee=inp[0],
+    )
+    stage = _make_stage_with_two_matches(refereeing_match1, refereeing_match2)
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[refereeing_match1.id].referee_conflict is False
+    assert flags[refereeing_match2.id].referee_conflict is False
+
+
 def test_referee_conflict_team_plays_and_referees_same_match() -> None:
     """A team that is both a player and referee in the same match is flagged."""
     tid = TournamentId(-1)

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -168,7 +168,7 @@
     "max_results_input_label": "Maximale Ergebnisse",
     "match_scheduled_before_previous_stage_label": "Vor einem Spiel einer früheren Phase auf diesem Spielfeld geplant",
     "precedence_conflict_label": "Beginnt, bevor ein Zubringerspiel beendet ist",
-    "referee_conflict_label": "Der Schiedsrichter spielt ebenfalls während dieses Spiels",
+    "referee_conflict_label": "Der Schiedsrichter spielt oder pfeift während dieses Spiels ein anderes Spiel",
     "short_break_conflict_label": "Die Pause vor diesem Spiel ist kürzer als die Standardpause",
     "members_table_header": "Mitglieder",
     "minutes": "Minuten",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -168,7 +168,7 @@
     "max_results_input_label": "Max results",
     "match_scheduled_before_previous_stage_label": "Scheduled before a match of an earlier stage on this court",
     "precedence_conflict_label": "Starts before a feeder match has finished",
-    "referee_conflict_label": "Referee is also playing during this match",
+    "referee_conflict_label": "Referee is playing or refereeing another match during this match",
     "short_break_conflict_label": "Break before this match is shorter than the default",
     "members_table_header": "Members",
     "minutes": "minutes",

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -259,7 +259,12 @@ function MatchCard({
   ) : null;
   const refereeConflictIcon =
     refereesEnabled && match.referee_conflict ? (
-      <Tooltip label={t('referee_conflict_label', 'Referee is also playing during this match')}>
+      <Tooltip
+        label={t(
+          'referee_conflict_label',
+          'Referee is playing or refereeing another match during this match'
+        )}
+      >
         <Box
           component="span"
           style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}


### PR DESCRIPTION
Referee conflicts were only flagged when a team that referees a match was
also *playing* in an overlapping match. The case where the same team is
assigned as referee to two matches that overlap in time went undetected,
so the schedule grid showed no warning.

Extend `_set_referee_overlap_conflicts` to also group refereeing matches by
team and flag both matches whenever two of them overlap. Generalize the UI
tooltip and translations accordingly, and add unit tests covering the
overlapping and non-overlapping double-referee cases.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BnEGEZzRfrCxU74SFMmHBS