### PR TITLE
Restrict referee auto-assignment to the current stage

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -135,23 +135,27 @@ def _has_open_slot(stage_item: StageItemWithRounds) -> bool:
     return any(isinstance(input_, StageItemInputEmpty) for input_ in stage_item.inputs)
 
 
-def _referee_slots_by_level(
+def _referee_slots_by_stage(
     stages: list[StageWithStageItems],
-) -> dict[LevelId | None, list[StageItemInputId]]:
-    """Map each level to the stage-item input slots that can referee a match at that level.
+) -> dict[StageId, list[StageItemInputId]]:
+    """Map each stage to the stage-item input slots that can referee a match in that stage.
 
     A referee is just a third match slot, treated like the two playing slots: any stage-item
-    input at the match's level is a candidate, regardless of whether it is Final (a team),
-    Tentative (winner-of a prior stage item) or Empty. Unresolved slots are allowed exactly as
-    they are for playing slots; they simply resolve to a team later. Slots are returned sorted
-    for deterministic candidate ordering.
+    input in the match's *own stage* is a candidate, regardless of whether it is Final (a team),
+    Tentative (winner-of a prior stage item) or Empty. Candidates are restricted to the same
+    stage because a slot only describes a participant who is actually present for that stage: a
+    later stage's slot (e.g. "1st of the group stage") names a team that is still unknown while
+    an earlier stage is being played, so it must never be picked to referee an earlier match.
+    Within a stage, unresolved slots are allowed exactly as they are for playing slots; they
+    simply resolve to a team later. Slots are returned sorted for deterministic candidate
+    ordering.
     """
-    by_level: dict[LevelId | None, list[StageItemInputId]] = defaultdict(list)
+    by_stage: dict[StageId, list[StageItemInputId]] = defaultdict(list)
     for stage in stages:
         for stage_item in stage.stage_items:
             for input_ in stage_item.inputs:
-                by_level[stage.level_id].append(input_.id)
-    return {level_id: sorted(slot_ids) for level_id, slot_ids in by_level.items()}
+                by_stage[stage.id].append(input_.id)
+    return {stage_id: sorted(slot_ids) for stage_id, slot_ids in by_stage.items()}
 
 
 def _get_match_contexts(stages: list[StageWithStageItems]) -> list[_MatchContext]:
@@ -673,14 +677,14 @@ def _add_referee_assignment(
     input_intervals: dict[StageItemInputId, list[Any]],
     pinned_by_input: dict[StageItemInputId, list[_PinnedMatch]],
     pinned_referee_slots: list[StageItemInputId],
-    referee_slots_by_level: dict[LevelId | None, list[StageItemInputId]],
+    referee_slots_by_stage: dict[StageId, list[StageItemInputId]],
     horizon: int,
     reoptimize: bool = False,
 ) -> tuple[dict[MatchId, dict[StageItemInputId, Any]], list[Any]]:
     """Assign the referee as a third match slot, treated like the two playing slots.
 
     For each movable match without a referee, the solver picks one referee *slot* from the
-    stage-item inputs at the match's level (any of Final/Tentative/Empty), excluding the
+    stage-item inputs in the match's own stage (any of Final/Tentative/Empty), excluding the
     match's own two playing slots. The chosen slot contributes an interval to the very same
     ``input_intervals`` no-overlap machinery used for playing slots, so a slot can never both
     play and referee — or referee two matches — at the same time, exactly as a playing slot
@@ -710,11 +714,11 @@ def _add_referee_assignment(
             match_durations[match.id] = match.duration_minutes
             continue
 
-        # Candidate referee slots: every input at the match's level except the two slots
+        # Candidate referee slots: every input in the match's own stage except the two slots
         # already playing this match.
         candidates = [
             slot_id
-            for slot_id in referee_slots_by_level.get(context.level_id, [])
+            for slot_id in referee_slots_by_stage.get(context.stage_id, [])
             if slot_id not in context.input_ids
         ]
         if not candidates:
@@ -924,7 +928,7 @@ def build_schedule_plan(
             input_intervals,
             pinned_by_input,
             pinned_referee_slots,
-            _referee_slots_by_level(stages),
+            _referee_slots_by_stage(stages),
             horizon,
             reoptimize,
         )
@@ -1056,7 +1060,7 @@ def build_referee_assignment_plan(
         return {}
 
     contexts = _get_match_contexts(stages)
-    referee_slots_by_level = _referee_slots_by_level(stages)
+    referee_slots_by_stage = _referee_slots_by_stage(stages)
 
     # Only scheduled matches (fixed court + start_time) participate.
     scheduled_contexts = [c for c in contexts if _is_scheduled(c)]
@@ -1106,11 +1110,13 @@ def build_referee_assignment_plan(
         end_min = start_min + match.duration_minutes
         match_windows[match.id] = (start_min, end_min)
 
-        # Eligible: a slot at the match's level, not one of this match's two playing slots, and
-        # not busy playing or refereeing at an overlapping time. Unresolved (tentative/empty)
-        # slots are allowed exactly as they are for playing slots.
+        # Eligible: a slot in the match's own stage, not one of this match's two playing slots,
+        # and not busy playing or refereeing at an overlapping time. A later stage's slot is
+        # excluded because it names a participant not yet known while this stage is played.
+        # Unresolved (tentative/empty) slots within the stage are allowed exactly as they are
+        # for playing slots.
         eligible: list[StageItemInputId] = []
-        for slot_id in referee_slots_by_level.get(context.level_id, []):
+        for slot_id in referee_slots_by_stage.get(context.stage_id, []):
             if slot_id in context.input_ids:
                 continue
             if any(

--- a/backend/tests/integration_tests/api/auto_assign_referees_test.py
+++ b/backend/tests/integration_tests/api/auto_assign_referees_test.py
@@ -187,6 +187,10 @@ async def test_auto_assign_referees_assigns_placeholder_matches(
     A later stage's matches reference the previous stage's results via tentative inputs. The
     referee is now a slot, so the optimizer assigns one regardless of whether the opponents
     are known yet — both the concrete first-stage matches and the placeholder matches get one.
+
+    Crucially, each referee slot comes from the match's *own stage*: a later stage's slot (e.g.
+    "1st of the group stage") must never referee an earlier match, since that participant is
+    unknown until the earlier stage is played.
     """
     tid = auth_context.tournament.id
 
@@ -203,13 +207,15 @@ async def test_auto_assign_referees_assigns_placeholder_matches(
             inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t3,
         ):
             si_first = await _setup_round_robin_3teams(tid, stage_one.id, t1.id, t2.id, t3.id)
-            # Second-stage item whose two opponents are placeholders from the first stage.
+            # Second-stage item whose opponents are all placeholders from the first stage. It has
+            # three slots so that, in each of its matches, a slot from its own stage is free to
+            # referee (the only eligible candidates after the same-stage restriction).
             si_placeholder = await sql_create_stage_item_with_inputs(
                 tid,
                 StageItemWithInputsCreate(
                     stage_id=stage_two.id,
                     name="Finals",
-                    team_count=2,
+                    team_count=3,
                     type=DUMMY_STAGE_ITEM1.type,
                     inputs=[
                         StageItemInputCreateBodyTentative(
@@ -217,6 +223,9 @@ async def test_auto_assign_referees_assigns_placeholder_matches(
                         ),
                         StageItemInputCreateBodyTentative(
                             slot=2, winner_from_stage_item_id=si_first.id, winner_position=2
+                        ),
+                        StageItemInputCreateBodyTentative(
+                            slot=3, winner_from_stage_item_id=si_first.id, winner_position=3
                         ),
                     ],
                 ),
@@ -254,13 +263,25 @@ async def test_auto_assign_referees_assigns_placeholder_matches(
         for m in r.matches
     ]
 
-    # First-stage (concrete) matches get referees.
+    # The stage-item input slots that belong to each stage.
+    slots_by_stage = {
+        s.id: {inp.id for si_ in s.stage_items for inp in si_.inputs} for s in stages_after
+    }
+
+    # First-stage (concrete) matches get referees, all from the first stage's own slots.
     assert len(first_stage_matches) > 0
     assert all(m.referee_stage_item_input_id is not None for m in first_stage_matches)
+    assert all(
+        m.referee_stage_item_input_id in slots_by_stage[stage_one.id] for m in first_stage_matches
+    )
 
-    # Placeholder matches now also get a referee slot (no more deferral).
+    # Placeholder matches now also get a referee slot (no more deferral), and that slot comes
+    # from the placeholder stage itself — never a slot from a different stage.
     assert len(placeholder_matches) > 0
     assert all(m.referee_stage_item_input_id is not None for m in placeholder_matches)
+    assert all(
+        m.referee_stage_item_input_id in slots_by_stage[stage_two.id] for m in placeholder_matches
+    )
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -983,6 +983,34 @@ def test_referee_only_assigned_to_teams_of_own_level() -> None:
     assert ops[0].referee_stage_item_input_id is None
 
 
+def test_referee_not_assigned_from_a_later_stage() -> None:
+    """A slot that only exists in a later stage is never picked to referee an earlier match.
+
+    Both stages share a level, so before the fix the later stage's slot (e.g. "1st of the
+    group stage") was a candidate referee for an earlier-stage match — but that participant is
+    still unknown while the earlier stage is being played. The earlier match has no spare slot
+    in its own stage, so the only correct outcome is no referee.
+    """
+    level = LevelId(1)
+    m = _match_with_teams(1, 1, 2, level)
+    stages = [
+        _stage_with_inputs(
+            1,
+            [m],
+            [_final_input(1, level), _final_input(2, level)],
+            level_id=level,
+        ),
+        # Same level but a *later* stage: its slot must not referee the earlier match.
+        _stage_with_inputs(2, [], [_final_input(3, level)], level_id=level),
+    ]
+    tournament = _tournament_with_referees()
+
+    ops = build_schedule_plan(stages, [_court(1)], tournament)
+
+    assert len(ops) == 1
+    assert ops[0].referee_stage_item_input_id is None
+
+
 def test_referee_not_assigned_to_playing_team() -> None:
     """A team playing in a match is never chosen as its referee."""
     level = LevelId(1)
@@ -1324,7 +1352,9 @@ def test_referee_assigned_to_placeholder_match() -> None:
     Such matches used to be deferred because assigning a concrete team risked picking an
     eventual player (#121). Now the referee is a slot: the optimizer assigns one regardless of
     whether the opponents are known, and the unresolved playing slots impose no constraint
-    until they resolve.
+    until they resolve. The referee must come from the placeholder match's *own stage*, so the
+    stage needs a spare slot beyond the two that play — a slot from the earlier stage (e.g. a
+    concrete group team) is no longer eligible, since the rule is strictly same-stage.
     """
     level = LevelId(1)
     # Stage item 1 (level L): a concrete match between teams 1 and 2; slots for teams 1..3 exist.
@@ -1335,6 +1365,7 @@ def test_referee_assigned_to_placeholder_match() -> None:
         _final_input(3, level),
     ]
     # Stage item 2 (level L): a match whose two opponents are tentative winners of stage item 1.
+    # A third tentative slot exists so the placeholder match has an eligible same-stage referee.
     source_stage_item_id = StageItemId(100)  # stage 1's single stage item (stage_id * 100)
     tentative_a = StageItemInputTentative(
         id=StageItemInputId(201),
@@ -1352,6 +1383,14 @@ def test_referee_assigned_to_placeholder_match() -> None:
         winner_from_stage_item_id=source_stage_item_id,
         winner_position=2,
     )
+    tentative_c = StageItemInputTentative(
+        id=StageItemInputId(203),
+        slot=3,
+        tournament_id=TournamentId(-1),
+        stage_item_id=StageItemId(200),
+        winner_from_stage_item_id=source_stage_item_id,
+        winner_position=3,
+    )
     placeholder = MatchWithDetails(
         id=MatchId(2),
         created=T0,
@@ -1368,19 +1407,18 @@ def test_referee_assigned_to_placeholder_match() -> None:
     )
     stages = [
         _stage_with_inputs(1, [concrete], concrete_inputs, level_id=level),
-        _stage_with_inputs(2, [placeholder], [tentative_a, tentative_b], level_id=level),
+        _stage_with_inputs(
+            2, [placeholder], [tentative_a, tentative_b, tentative_c], level_id=level
+        ),
     ]
     tournament = _tournament_with_referees()
 
     ops = build_schedule_plan(stages, [_court(1)], tournament)
 
     op_by_id = {op.match.id: op for op in ops}
-    # The placeholder match is assigned a referee resolving to one of the level's teams.
-    assert _slot_team(stages, op_by_id[MatchId(2)].referee_stage_item_input_id) in (
-        TeamId(1),
-        TeamId(2),
-        TeamId(3),
-    )
+    # The placeholder match gets the only spare slot of its own stage as referee, never an
+    # earlier stage's slot (teams 1..3 belong to stage 1).
+    assert op_by_id[MatchId(2)].referee_stage_item_input_id == tentative_c.id
 
 
 def test_no_eligible_referee_leaves_match_unassigned() -> None:
@@ -1478,6 +1516,30 @@ def test_assign_referees_level_restriction() -> None:
             level_id=level_a,
         ),
         _stage_with_inputs(2, [], [_final_input(3, level_b)], level_id=level_b),
+    ]
+
+    result = build_referee_assignment_plan(stages, _tournament_with_referees())
+
+    assert result == {}
+
+
+def test_assign_referees_excludes_later_stage_slots() -> None:
+    """A slot from a later stage (same level) is not assigned to referee an earlier match.
+
+    The earlier-stage match has no spare slot in its own stage, so no referee can be picked:
+    reaching into the next stage would name a participant who is unknown until that stage.
+    """
+    level = LevelId(1)
+    m = _scheduled_match_with_teams(1, 1, 2, level, start_offset_minutes=0)
+    stages = [
+        _stage_with_inputs(
+            1,
+            [m],
+            [_final_input(1, level), _final_input(2, level)],
+            level_id=level,
+        ),
+        # Same level but a later stage; its slot is ineligible for the earlier match.
+        _stage_with_inputs(2, [], [_final_input(3, level)], level_id=level),
     ]
 
     result = build_referee_assignment_plan(stages, _tournament_with_referees())


### PR DESCRIPTION
The slot-based referee scheduler offered any stage-item input at the
match's level as a referee candidate. Because several stages share a
level, a slot that only materializes in a later stage (e.g. "1st of the
group stage", a tentative input wired into the knockout stage) could be
picked to referee an earlier group-stage match — but that participant is
unknown while the group stage is still being played.

Key the candidate slots by stage instead of by level, in both the full
scheduler (build_schedule_plan) and the assign-missing-referees pass
(build_referee_assignment_plan), so a match can only be refereed by a
slot from its own stage.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VUNpstBSsVhkw9nUzGMbsk