### PR TITLE
Consolidate manual referee validation onto the same-stage rule

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -158,6 +158,44 @@ def _referee_slots_by_stage(
     return {stage_id: sorted(slot_ids) for stage_id, slot_ids in by_stage.items()}
 
 
+def _stage_referee_candidates(
+    referee_slots_by_stage: dict[StageId, list[StageItemInputId]],
+    stage_id: StageId,
+    playing_slot_ids: tuple[StageItemInputId, ...],
+) -> list[StageItemInputId]:
+    """Base referee candidates for a match: every slot in the match's own stage except the two
+    slots already playing it. The single source of truth for "which slot may referee this match"
+    — shared by the CP-SAT auto-scheduler, the assign-missing-referees pass and the manual
+    single-match validation, so all three honour the same-stage rule identically. Returned in the
+    (already sorted) order of ``referee_slots_by_stage`` for deterministic candidate ordering.
+    """
+    return [
+        slot_id
+        for slot_id in referee_slots_by_stage.get(stage_id, [])
+        if slot_id not in playing_slot_ids
+    ]
+
+
+def eligible_referee_slot_ids(
+    stages: list[StageWithStageItems], match_id: MatchId
+) -> frozenset[StageItemInputId]:
+    """Stage-item input slots that may referee the given match (empty if the match is unknown).
+
+    Public wrapper over ``_stage_referee_candidates`` for callers outside the solver — notably
+    the manual referee-assignment route — so a hand-picked referee is validated against exactly
+    the same eligibility the auto-scheduler uses.
+    """
+    referee_slots_by_stage = _referee_slots_by_stage(stages)
+    for context in _get_match_contexts(stages):
+        if context.match.id == match_id:
+            return frozenset(
+                _stage_referee_candidates(
+                    referee_slots_by_stage, context.stage_id, context.input_ids
+                )
+            )
+    return frozenset()
+
+
 def _get_match_contexts(stages: list[StageWithStageItems]) -> list[_MatchContext]:
     return [
         _MatchContext(
@@ -714,13 +752,9 @@ def _add_referee_assignment(
             match_durations[match.id] = match.duration_minutes
             continue
 
-        # Candidate referee slots: every input in the match's own stage except the two slots
-        # already playing this match.
-        candidates = [
-            slot_id
-            for slot_id in referee_slots_by_stage.get(context.stage_id, [])
-            if slot_id not in context.input_ids
-        ]
+        candidates = _stage_referee_candidates(
+            referee_slots_by_stage, context.stage_id, context.input_ids
+        )
         if not candidates:
             continue
 
@@ -1110,15 +1144,12 @@ def build_referee_assignment_plan(
         end_min = start_min + match.duration_minutes
         match_windows[match.id] = (start_min, end_min)
 
-        # Eligible: a slot in the match's own stage, not one of this match's two playing slots,
-        # and not busy playing or refereeing at an overlapping time. A later stage's slot is
-        # excluded because it names a participant not yet known while this stage is played.
-        # Unresolved (tentative/empty) slots within the stage are allowed exactly as they are
-        # for playing slots.
+        # Start from the same-stage candidates (slots in the match's own stage minus its two
+        # playing slots), then drop any busy playing or refereeing at an overlapping time.
         eligible: list[StageItemInputId] = []
-        for slot_id in referee_slots_by_stage.get(context.stage_id, []):
-            if slot_id in context.input_ids:
-                continue
+        for slot_id in _stage_referee_candidates(
+            referee_slots_by_stage, context.stage_id, context.input_ids
+        ):
             if any(
                 start_min < p_end and p_start < end_min
                 for p_start, p_end in slot_playing_intervals.get(slot_id, [])

--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -7,6 +7,7 @@ from bracket.database import database
 from bracket.logic.planning.conflicts import reconcile_conflicts
 from bracket.logic.planning.matches import (
     assign_missing_referees_only,
+    eligible_referee_slot_ids,
     get_scheduled_matches,
     handle_match_reschedule,
     handle_match_resize_break,
@@ -71,29 +72,20 @@ from bracket.utils.id_types import MatchId, StageItemId, StageItemInputId, Tourn
 router = APIRouter(prefix=config.api_prefix)
 
 
-async def validate_referee_slot_at_match_level(
+async def validate_referee_slot_for_match(
     tournament_id: TournamentId, match: Match, referee_stage_item_input_id: StageItemInputId
 ) -> None:
-    """A referee slot must belong to a stage item at the refereed match's level."""
+    """A referee slot must be eligible for the refereed match: a stage-item input in the match's
+    own stage that is not one of the two slots playing the match. This reuses the same
+    eligibility the CP-SAT auto-scheduler applies (see eligible_referee_slot_ids), so a
+    hand-picked referee can never name a participant from a later stage who is still unknown
+    while this match is played.
+    """
     stages = await get_full_tournament_details(tournament_id)
-    match_level_id = None
-    input_level_id = None
-    input_found = False
-    for stage in stages:
-        for stage_item in stage.stage_items:
-            for stage_item_input in stage_item.inputs:
-                if stage_item_input.id == referee_stage_item_input_id:
-                    input_found = True
-                    input_level_id = stage.level_id
-            for round_ in stage_item.rounds:
-                for round_match in round_.matches:
-                    if round_match.id == match.id:
-                        match_level_id = stage.level_id
-
-    if not input_found or input_level_id != match_level_id:
+    if referee_stage_item_input_id not in eligible_referee_slot_ids(stages, match.id):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Referee slot must belong to a stage item at the match's level",
+            detail="Referee slot must be a stage-item input in the match's own stage",
         )
 
 
@@ -395,9 +387,7 @@ async def update_match_by_id(
         )
 
     if referee_stage_item_input_id is not None:
-        await validate_referee_slot_at_match_level(
-            tournament_id, match, referee_stage_item_input_id
-        )
+        await validate_referee_slot_for_match(tournament_id, match, referee_stage_item_input_id)
 
     match_body = get_match_body_with_state_updates(match, match_body)
 

--- a/backend/tests/integration_tests/api/referees_test.py
+++ b/backend/tests/integration_tests/api/referees_test.py
@@ -195,6 +195,71 @@ async def test_deleting_referee_input_nulls_match(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_patch_match_referee_slot_later_stage_rejected(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """A referee slot from a later stage is rejected even when both stages share a level.
+
+    The slot names a participant who is still unknown while the earlier match is played, so the
+    manual path honours the same same-stage rule as the auto-scheduler.
+    """
+    tournament_id = auth_context.tournament.id
+    async with (
+        inserted_level(DUMMY_LEVEL1.model_copy(update={"tournament_id": tournament_id})) as level1,
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id, "level_id": level1.id})
+        ) as stage_a,
+        inserted_stage(
+            DUMMY_STAGE2.model_copy(update={"tournament_id": tournament_id, "level_id": level1.id})
+        ) as stage_b,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage_a.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item_a,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM2.model_copy(
+                update={"stage_id": stage_b.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item_b,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item_a.id})
+        ) as round_a,
+        inserted_team(DUMMY_TEAM3.model_copy(update={"tournament_id": tournament_id})) as team3,
+        _final_input(tournament_id, stage_item_b.id, 0, team3.id) as later_stage_input,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_a.id,
+                    "stage_item_input1_id": None,
+                    "stage_item_input2_id": None,
+                    "court_id": None,
+                }
+            )
+        ) as match_inserted,
+    ):
+        response = await send_tournament_request(
+            HTTPMethod.PUT,
+            f"matches/{match_inserted.id}",
+            auth_context,
+            None,
+            {
+                "round_id": round_a.id,
+                "referee_stage_item_input_id": later_stage_input.id,
+            },
+        )
+        assert "detail" in response
+        assert "success" not in response
+
+        match_after = await fetch_one_parsed_certain(
+            database, Match, query=matches.select().where(matches.c.id == match_inserted.id)
+        )
+        assert match_after.referee_stage_item_input_id is None
+
+        await assert_row_count_and_clear(matches, 1)
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_patch_match_referee_name_round_trips(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:

--- a/frontend/src/components/modals/match_modal.tsx
+++ b/frontend/src/components/modals/match_modal.tsx
@@ -261,14 +261,18 @@ function MatchModalForm({
   const matchLevelId = matchEntry?.stage.level_id ?? match.level_id;
   const level = levels?.find((candidate) => candidate.id === matchLevelId) ?? null;
 
-  // Referee slots are the stage-item inputs at the match's level (concrete teams, "Winner of
+  // Referee slots are the stage-item inputs in the match's own stage (concrete teams, "Winner of
   // Group A" placeholders, and still-empty positions), mirroring how playing slots are picked.
+  // Slots are restricted to the match's stage — not just its level — because a later stage's slot
+  // names a participant who is still unknown while this match is played; the backend enforces the
+  // same rule (see eligible_referee_slot_ids).
+  const matchStageId = matchEntry?.stage.id;
   const ownInputIds = new Set(
     [match.stage_item_input1_id, match.stage_item_input2_id].filter((id) => id != null)
   );
   const refereeSlotOptions = refereesEnabled
     ? (swrStagesResponse.data?.data ?? [])
-        .filter((stage) => stage.level_id === matchLevelId)
+        .filter((stage) => stage.id === matchStageId)
         .flatMap((stage) => stage.stage_items)
         .flatMap((stageItem) => stageItem.inputs)
         .filter((input) => !ownInputIds.has(input.id))


### PR DESCRIPTION
The manual single-match referee assignment validated a hand-picked slot
against the match's level, while the CP-SAT auto-scheduler had been
tightened to the match's own stage. That left the manual path able to
assign a slot from a later stage of the same level — a participant who is
still unknown while the match is played.

Extract the eligibility into a single source of truth in the planning
module: _stage_referee_candidates (slots in the match's own stage minus
its two playing slots), used by the full scheduler, the
assign-missing-referees pass, and a new public eligible_referee_slot_ids
wrapper. The route validator now defers to that wrapper.

Align the frontend match modal to offer referee slots from the match's
own stage instead of its level, so it never presents an option the
backend rejects.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VUNpstBSsVhkw9nUzGMbsk