### PR TITLE
Account for referees in pre-placement conflict preview

### DIFF
--- a/frontend/src/logic/planning/conflict_preview.test.ts
+++ b/frontend/src/logic/planning/conflict_preview.test.ts
@@ -21,6 +21,7 @@ function match({
   startMinutes,
   input1,
   input2,
+  referee = null,
   durationMinutes = 90,
 }: {
   id: number;
@@ -28,6 +29,7 @@ function match({
   startMinutes: number | null;
   input1: number;
   input2: number;
+  referee?: number | null;
   durationMinutes?: number;
 }): ConflictPreviewMatch {
   return {
@@ -37,6 +39,7 @@ function match({
     duration_minutes: durationMinutes,
     stage_item_input1_id: input1,
     stage_item_input2_id: input2,
+    referee_stage_item_input_id: referee,
   };
 }
 
@@ -98,6 +101,88 @@ describe('actionCreatesSelectedConflict', () => {
         },
       })
     ).toBe(true);
+  });
+
+  it('detects a conflict when the selected match referees a team that is playing an overlapping match', () => {
+    // Match 1 referees team 60; match 3 plays team 60 at the same time. They share
+    // no playing input, so only the referee slot makes them conflict.
+    const stages = stagesWith([
+      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20, referee: 60 }),
+      match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 50 }),
+      match({ id: 3, courtId: 3, startMinutes: 0, input1: 60, input2: 30 }),
+    ]);
+
+    expect(
+      actionCreatesSelectedConflict({
+        stages,
+        selectedMatchId: 1,
+        tournamentStartTime: START,
+        action: {
+          type: 'reschedule',
+          matchId: 1,
+          body: {
+            old_court_id: 1,
+            old_position: 0,
+            new_court_id: 2,
+            new_position: 0,
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('detects a conflict when the selected match referees a team that referees an overlapping match', () => {
+    // Both match 1 and match 3 have team 60 as referee, at the same time.
+    const stages = stagesWith([
+      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20, referee: 60 }),
+      match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 50 }),
+      match({ id: 3, courtId: 3, startMinutes: 0, input1: 70, input2: 30, referee: 60 }),
+    ]);
+
+    expect(
+      actionCreatesSelectedConflict({
+        stages,
+        selectedMatchId: 1,
+        tournamentStartTime: START,
+        action: {
+          type: 'reschedule',
+          matchId: 1,
+          body: {
+            old_court_id: 1,
+            old_position: 0,
+            new_court_id: 2,
+            new_position: 0,
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('ignores the referee slot when referees are disabled', () => {
+    const stages = stagesWith([
+      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20, referee: 60 }),
+      match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 50 }),
+      match({ id: 3, courtId: 3, startMinutes: 0, input1: 60, input2: 30 }),
+    ]);
+
+    expect(
+      actionCreatesSelectedConflict({
+        stages,
+        selectedMatchId: 1,
+        tournamentStartTime: START,
+        refereesEnabled: false,
+        action: {
+          type: 'reschedule',
+          matchId: 1,
+          body: {
+            old_court_id: 1,
+            old_position: 0,
+            new_court_id: 2,
+            new_position: 0,
+          },
+        },
+      })
+    ).toBe(false);
   });
 });
 
@@ -282,5 +367,34 @@ describe('computeConflictPreview', () => {
 
     expect([...preview.swapTargets]).toContain(4);
     expect([...preview.swapTargets]).not.toContain(2);
+  });
+
+  it('flags a swap target whose slot would double-book the selected match referee', () => {
+    // Tray match 1 referees team 60. Swapping it into match 2's slot (court 1, start
+    // 0) puts it in the same window as match 3, which plays team 60 on court 2 — a
+    // referee conflict the preview must surface even though no playing input is shared.
+    const matches = [
+      match({ id: 1, courtId: null, startMinutes: null, input1: 10, input2: 20, referee: 60 }),
+      match({ id: 2, courtId: 1, startMinutes: 0, input1: 40, input2: 50 }),
+      match({ id: 3, courtId: 2, startMinutes: 0, input1: 60, input2: 30 }),
+    ];
+    const layout = computeScheduleLayout({
+      courts: [
+        { id: 1, name: 'Court 1' },
+        { id: 2, name: 'Court 2' },
+      ],
+      matchesByCourtId: { 1: [matches[1]], 2: [matches[2]] },
+      tournamentStartTime: START,
+    });
+
+    const preview = computeConflictPreview({
+      stages: stagesWith(matches),
+      layout,
+      selection: { kind: 'tray-match-selected', matchId: 1 },
+      refereesEnabled: true,
+    });
+
+    expect([...preview.swapTargets]).toContain(2);
+    expect([...preview.swapTargets]).not.toContain(3);
   });
 });

--- a/frontend/src/logic/planning/conflict_preview.ts
+++ b/frontend/src/logic/planning/conflict_preview.ts
@@ -5,6 +5,7 @@ import { PlanningAction, SelectionState, selectionReducer } from './selection';
 export interface ConflictPreviewMatch extends OptimisticMatch {
   stage_item_input1_id: number | null;
   stage_item_input2_id: number | null;
+  referee_stage_item_input_id: number | null;
 }
 
 export interface ConflictPreviewStage extends OptimisticStage {
@@ -27,6 +28,7 @@ interface PreparedPreview {
   blocksByCourtId: Map<number, PreviewBlock[]>;
   blockByMatchId: Map<number, PreviewBlock>;
   defaultBreakMinutes: number;
+  refereesEnabled: boolean;
 }
 
 export function insertionLineKey(courtId: number, index: number): string {
@@ -54,20 +56,26 @@ function getMatches(stages: ConflictPreviewStage[]): ConflictPreviewMatch[] {
   );
 }
 
-function matchInputIds(match: ConflictPreviewMatch): Set<number> {
-  return new Set(
-    [match.stage_item_input1_id, match.stage_item_input2_id].filter(
-      (id): id is number => id != null
-    )
-  );
+/**
+ * The stage-item-input slots a match occupies for conflict purposes: its two
+ * playing slots and — when referees are enabled — the referee slot, mirroring the
+ * backend's "referee is a third match slot" model. This is the single place that
+ * decides which slots a match ties up; both the simulated-action check and the
+ * block-based preview share it, so referee double-booking is handled identically.
+ */
+function occupiedSlotIds(match: ConflictPreviewMatch, refereesEnabled: boolean): Set<number> {
+  const slotIds = [match.stage_item_input1_id, match.stage_item_input2_id];
+  if (refereesEnabled) slotIds.push(match.referee_stage_item_input_id);
+  return new Set(slotIds.filter((id): id is number => id != null));
 }
 
-function sharesInput(match1: ConflictPreviewMatch, match2: ConflictPreviewMatch): boolean {
-  const inputIds = matchInputIds(match1);
-  return (
-    (match2.stage_item_input1_id != null && inputIds.has(match2.stage_item_input1_id)) ||
-    (match2.stage_item_input2_id != null && inputIds.has(match2.stage_item_input2_id))
-  );
+function sharesSlot(
+  match1: ConflictPreviewMatch,
+  match2: ConflictPreviewMatch,
+  refereesEnabled: boolean
+): boolean {
+  const slots1 = occupiedSlotIds(match1, refereesEnabled);
+  return [...occupiedSlotIds(match2, refereesEnabled)].some((id) => slots1.has(id));
 }
 
 function playingIntervalMillis(match: ConflictPreviewMatch): [number, number] | null {
@@ -107,12 +115,14 @@ export function actionCreatesSelectedConflict({
   selectedMatchId,
   tournamentStartTime,
   defaultBreakMinutes = 0,
+  refereesEnabled = true,
   action,
 }: {
   stages: ConflictPreviewStage[];
   selectedMatchId: number;
   tournamentStartTime: string | Date;
   defaultBreakMinutes?: number;
+  refereesEnabled?: boolean;
   action: PlanningAction;
 }): boolean {
   const simulated = applyPlanningActions(
@@ -123,12 +133,12 @@ export function actionCreatesSelectedConflict({
   );
   const matches = getMatches(simulated);
   const selected = matches.find((match) => match.id === selectedMatchId);
-  if (selected == null || matchInputIds(selected).size === 0) return false;
+  if (selected == null || occupiedSlotIds(selected, refereesEnabled).size === 0) return false;
 
   return matches.some(
     (match) =>
       match.id !== selected.id &&
-      sharesInput(selected, match) &&
+      sharesSlot(selected, match, refereesEnabled) &&
       playingTimesOverlap(selected, match)
   );
 }
@@ -136,7 +146,8 @@ export function actionCreatesSelectedConflict({
 function preparePreview(
   stages: ConflictPreviewStage[],
   layout: ScheduleGridLayout<LayoutCourt, ConflictPreviewMatch>,
-  selection: SelectionState
+  selection: SelectionState,
+  refereesEnabled: boolean
 ): PreparedPreview | null {
   const selectedMatchId = getSelectedMatchId(selection);
   if (selectedMatchId == null) return null;
@@ -164,6 +175,7 @@ function preparePreview(
     blocksByCourtId,
     blockByMatchId,
     defaultBreakMinutes: layout.defaultBreakMinutes,
+    refereesEnabled,
   };
 }
 
@@ -206,9 +218,13 @@ function courtEntries(
     .map((block) => ({ match: block.match, baseStartMinutes: block.startMinutes }));
 }
 
-function blocksConflict(block1: PreviewBlock, block2: PreviewBlock): boolean {
+function blocksConflict(
+  block1: PreviewBlock,
+  block2: PreviewBlock,
+  refereesEnabled: boolean
+): boolean {
   return (
-    sharesInput(block1.match, block2.match) &&
+    sharesSlot(block1.match, block2.match, refereesEnabled) &&
     playingMinutesOverlap(
       block1.startMinutes,
       slotLengthMinutes(block1.match),
@@ -248,7 +264,10 @@ function affectedScheduleCreatesConflict(
 
   for (const changedBlock of changedBlocks) {
     for (const block of postBlocks) {
-      if (changedBlock.match.id !== block.match.id && blocksConflict(changedBlock, block)) {
+      if (
+        changedBlock.match.id !== block.match.id &&
+        blocksConflict(changedBlock, block, prepared.refereesEnabled)
+      ) {
         return true;
       }
     }
@@ -372,13 +391,15 @@ export function computeConflictPreview({
   stages,
   layout,
   selection,
+  refereesEnabled = true,
 }: {
   stages: ConflictPreviewStage[];
   layout: ScheduleGridLayout<LayoutCourt, ConflictPreviewMatch>;
   selection: SelectionState;
+  refereesEnabled?: boolean;
 }): ConflictPreview {
   if (selection.kind === 'idle') return emptyPreview();
-  const prepared = preparePreview(stages, layout, selection);
+  const prepared = preparePreview(stages, layout, selection, refereesEnabled);
   if (prepared == null) return emptyPreview();
   const preparedPreview = prepared;
 

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -424,6 +424,7 @@ export default function SchedulePage() {
         stages: rawStages,
         layout,
         selection: planner.selection,
+        refereesEnabled: tournament.referees_enabled,
       });
 
   // Pieces of the selection pill, extracted so the mobile (stacked) and desktop


### PR DESCRIPTION
The schedule planner's placement preview (which highlights where a selected
match can be dropped or swapped without creating a conflict) only considered
the two playing slots. It ignored the referee slot entirely, so a slot where
the match's referee team was already playing — or refereeing an overlapping
match — was shown as conflict-free.

Treat the referee as a third occupied slot, mirroring the backend's
"referee is a third match slot" model. The slot-sharing decision lives in a
single helper (occupiedSlotIds/sharesSlot) used by both the simulated-action
check and the block-based preview, so both paths handle referee
double-booking identically. Referee slots are only counted when the
tournament has referees enabled.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FM2AFCba5udSPjviHUnQac