### PR TITLE
Flag placeholder (tentative/empty) slots in conflict detector (#132)

### DIFF
--- a/backend/bracket/logic/planning/conflicts.py
+++ b/backend/bracket/logic/planning/conflicts.py
@@ -7,7 +7,14 @@ from bracket.database import database
 from bracket.logic.planning.team_windows import PlayingWindow, get_team_playing_windows
 from bracket.models.db.match import Match, MatchWithDetails, MatchWithDetailsDefinitive
 from bracket.models.db.util import StageWithStageItems
-from bracket.utils.id_types import CourtId, MatchId, StageItemId, TeamId, TournamentId
+from bracket.utils.id_types import (
+    CourtId,
+    MatchId,
+    StageItemId,
+    StageItemInputId,
+    TeamId,
+    TournamentId,
+)
 
 
 def matches_overlap(match1: Match, match2: Match) -> bool:
@@ -215,6 +222,76 @@ def _set_referee_overlap_conflicts(
                     flags[match2.id].referee_conflict = True
 
 
+@dataclass(frozen=True)
+class _SlotOccupancy:
+    """A match's use of a single stage_item_input slot, as either a player or the referee.
+
+    ``playing_side`` is 1 or 2 for the two playing slots, or None when the match occupies the
+    slot as its referee. This mirrors the auto-scheduler and the frontend placement preview,
+    which treat the referee as a third match slot alongside the two playing slots.
+    """
+
+    match: MatchWithDetailsDefinitive | MatchWithDetails
+    start_time: datetime_utc
+    end_time: datetime_utc
+    playing_side: int | None
+
+
+def _flag_slot_occupancy(
+    occupancy: _SlotOccupancy, flags: dict[MatchId, MatchConflictFlags]
+) -> None:
+    if occupancy.playing_side == 1:
+        flags[occupancy.match.id].stage_item_input1_conflict = True
+    elif occupancy.playing_side == 2:
+        flags[occupancy.match.id].stage_item_input2_conflict = True
+    else:
+        flags[occupancy.match.id].referee_conflict = True
+
+
+def _set_slot_overlap_conflicts(
+    stages: list[StageWithStageItems],
+    flags: dict[MatchId, MatchConflictFlags],
+) -> None:
+    """Flag any two overlapping matches that share a stage_item_input slot id.
+
+    This is slot-id based rather than team-id based, so it flags placeholder (tentative/empty)
+    slots too — a slot that isn't yet resolved to a concrete team is still a real resource that
+    cannot play and/or referee two overlapping matches, exactly as the auto-scheduler and the
+    frontend placement preview already assume. The team-id based checks above remain for cross-
+    stage-item identity (the same team appearing under different slot ids), which a slot-id check
+    cannot see; for resolved slots this check only re-flags conflicts those already cover, so
+    behavior for Final slots is unchanged.
+    """
+    occupancies_by_slot: defaultdict[StageItemInputId, list[_SlotOccupancy]] = defaultdict(list)
+    for match in _get_all_matches(stages):
+        if match.start_time is None:
+            continue
+        slots = (
+            (match.stage_item_input1_id, 1),
+            (match.stage_item_input2_id, 2),
+            (match.referee_stage_item_input_id, None),
+        )
+        for slot_id, playing_side in slots:
+            if slot_id is None:
+                continue
+            occupancies_by_slot[slot_id].append(
+                _SlotOccupancy(match, match.start_time, match.end_time, playing_side)
+            )
+
+    for occupancies in occupancies_by_slot.values():
+        for i, occupancy1 in enumerate(occupancies):
+            for occupancy2 in occupancies[i + 1 :]:
+                if not _time_ranges_overlap(
+                    occupancy1.start_time,
+                    occupancy1.end_time,
+                    occupancy2.start_time,
+                    occupancy2.end_time,
+                ):
+                    continue
+                _flag_slot_occupancy(occupancy1, flags)
+                _flag_slot_occupancy(occupancy2, flags)
+
+
 def get_match_conflict_flags(
     stages: list[StageWithStageItems], default_break_minutes: int
 ) -> dict[MatchId, MatchConflictFlags]:
@@ -223,6 +300,7 @@ def get_match_conflict_flags(
 
     _set_team_overlap_conflicts(stages, flags)
     _set_referee_overlap_conflicts(stages, flags)
+    _set_slot_overlap_conflicts(stages, flags)
     _set_winner_of_precedence_conflicts(matches, flags)
     _set_cross_stage_precedence_conflicts(stages, flags)
     _set_short_break_conflicts(matches, default_break_minutes, flags)

--- a/backend/tests/unit_tests/conflicts_test.py
+++ b/backend/tests/unit_tests/conflicts_test.py
@@ -341,8 +341,8 @@ def test_get_match_conflict_flags_marks_sub_default_break_on_later_match() -> No
 
 def _make_definitive_match(
     match_id: MatchId,
-    input1: StageItemInputFinal,
-    input2: StageItemInputFinal,
+    input1: StageItemInput,
+    input2: StageItemInput,
     round_id: RoundId,
     court_id: CourtId,
     start_time: object,
@@ -686,3 +686,110 @@ def test_referee_conflict_team_plays_and_referees_same_match() -> None:
     assert flags[match.id].referee_conflict is True
     assert flags[match.id].stage_item_input1_conflict is True
     assert flags[match.id].stage_item_input2_conflict is False
+
+
+# ---------------------------------------------------------------------------
+# Placeholder (tentative/empty) slot conflict tests (issue #132)
+# ---------------------------------------------------------------------------
+
+
+def _make_tentative(
+    input_id: int, slot: int, tournament_id: TournamentId
+) -> StageItemInputTentative:
+    """A placeholder ("winner of …") slot: a real stage_item_input with team_id = None."""
+    return StageItemInputTentative(
+        id=StageItemInputId(input_id),
+        slot=slot,
+        tournament_id=tournament_id,
+        stage_item_id=StageItemId(-10),
+        winner_from_stage_item_id=StageItemId(-99),
+        winner_position=slot,
+    )
+
+
+def test_referee_conflict_placeholder_slot_plays_and_referees() -> None:
+    """The issue's example: a tentative slot referees one match and plays in an overlapping one.
+
+    Inputs [A, B, C(tentative), D]: match1 is ``A vs B`` refereed by ``C``; match2 is ``C vs D``
+    overlapping. ``C`` both plays and referees, so the backend must flag it even though ``C`` has
+    no resolved team_id yet — matching the auto-scheduler and the frontend placement preview.
+    """
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    tentative_c = _make_tentative(-30, 3, tid)
+    referee_match = _make_definitive_match(
+        MatchId(-20), inp[0], inp[1], RoundId(-10), CourtId(-1), T, referee=tentative_c
+    )
+    playing_match = _make_definitive_match(
+        MatchId(-21), tentative_c, inp[3], RoundId(-11), CourtId(-2), T
+    )
+    stage = _make_stage_with_two_matches(referee_match, playing_match)
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[referee_match.id].referee_conflict is True
+    assert flags[playing_match.id].stage_item_input1_conflict is True
+    assert flags[playing_match.id].stage_item_input2_conflict is False
+    assert flags[playing_match.id].referee_conflict is False
+
+
+def test_referee_conflict_placeholder_slot_referees_two_overlapping_matches() -> None:
+    """A tentative slot assigned as referee to two overlapping matches flags both."""
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    tentative_c = _make_tentative(-30, 3, tid)
+    referee_match1 = _make_definitive_match(
+        MatchId(-20), inp[0], inp[1], RoundId(-10), CourtId(-1), T, referee=tentative_c
+    )
+    referee_match2 = _make_definitive_match(
+        MatchId(-21),
+        inp[2],
+        inp[3],
+        RoundId(-11),
+        CourtId(-2),
+        T + timedelta(minutes=30),
+        referee=tentative_c,
+    )
+    stage = _make_stage_with_two_matches(referee_match1, referee_match2)
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[referee_match1.id].referee_conflict is True
+    assert flags[referee_match2.id].referee_conflict is True
+
+
+def test_conflict_two_matches_share_placeholder_playing_slot() -> None:
+    """Two overlapping matches that both use the same placeholder playing slot are flagged."""
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    tentative_c = _make_tentative(-30, 3, tid)
+    # tentative_c plays input1 in both matches, which overlap in time.
+    match1 = _make_definitive_match(MatchId(-20), tentative_c, inp[1], RoundId(-10), CourtId(-1), T)
+    match2 = _make_definitive_match(
+        MatchId(-21), tentative_c, inp[3], RoundId(-11), CourtId(-2), T + timedelta(minutes=30)
+    )
+    stage = _make_stage_with_two_matches(match1, match2)
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[match1.id].stage_item_input1_conflict is True
+    assert flags[match2.id].stage_item_input1_conflict is True
+    assert flags[match1.id].stage_item_input2_conflict is False
+    assert flags[match2.id].stage_item_input2_conflict is False
+
+
+def test_conflict_placeholder_playing_slots_non_overlapping_no_conflict() -> None:
+    """The same placeholder playing slot in two non-overlapping matches is not flagged."""
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    tentative_c = _make_tentative(-30, 3, tid)
+    match1 = _make_definitive_match(MatchId(-20), tentative_c, inp[1], RoundId(-10), CourtId(-1), T)
+    match2 = _make_definitive_match(
+        MatchId(-21), tentative_c, inp[3], RoundId(-11), CourtId(-2), T + timedelta(hours=2)
+    )
+    stage = _make_stage_with_two_matches(match1, match2)
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[match1.id].stage_item_input1_conflict is False
+    assert flags[match2.id].stage_item_input1_conflict is False


### PR DESCRIPTION
The backend conflict detector was team-id based and silently ignored any
stage_item_input slot that had not yet resolved to a concrete team. This
made it inconsistent with the auto-scheduler and the frontend placement
preview, which are both slot-id based and treat placeholder slots as real
resources: the preview could warn about a placeholder double-booking that
the backend then refused to persist as a referee_conflict.

Add a slot-id based pass (_set_slot_overlap_conflicts) that treats the
referee as a third match slot alongside the two playing slots, mirroring
the scheduler and preview. Two overlapping matches that share a
stage_item_input id are now flagged whether the slot is Final, Tentative
or Empty. The existing team-id based checks remain for cross-stage-item
identity (the same team under different slot ids); for resolved slots the
new pass only re-flags what those already cover, so Final-slot behavior is
unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0151FAXNsB3vC5rofBKZDHmJ