### PR TITLE
Use a colourblind-safe palette for level colours

### DIFF
--- a/frontend/src/logic/colors.test.ts
+++ b/frontend/src/logic/colors.test.ts
@@ -54,29 +54,131 @@ function hueDistance(a: number, b: number): number {
   return Math.min(delta, 360 - delta);
 }
 
-describe('levelHue', () => {
-  it('spreads levels evenly around the wheel by position', () => {
-    const levels = [level(1, 'A', 0), level(2, 'B', 1), level(3, 'C', 2)];
-    const hues = levels.map((l) => levelHue(l.id, levels));
-    // Three levels → 120° apart, the maximal separation three points allow.
-    expect(hueDistance(hues[0], hues[1])).toBeCloseTo(120);
-    expect(hueDistance(hues[1], hues[2])).toBeCloseTo(120);
-    expect(hueDistance(hues[0], hues[2])).toBeCloseTo(120);
-  });
+/** Pull the lightness out of an `oklch(<l> <c> <h>)` string. */
+function oklchLightness(colour: string): number {
+  const match = colour.match(/oklch\(([\d.]+) /);
+  if (match == null) throw new Error(`not an oklch colour: ${colour}`);
+  return Number(match[1]);
+}
 
-  it('orders by position, not array order, so colour is stable', () => {
+// ── Colour-vision-deficiency (CVD) simulation, so the tests can assert what the
+// header promises: every level stays distinguishable for deuter-/protanopes. The
+// maths is self-contained (no deps): OKLCH → linear sRGB → Machado-2009 dichromat
+// simulation → CIELab, then ΔE76 between the simulated colours. ────────────────
+
+type RGB = [number, number, number];
+const clamp01 = (x: number) => Math.min(1, Math.max(0, x));
+
+/** OKLCH string → linear sRGB (Björn Ottosson's OKLab matrices). */
+function oklchToLinearRGB(colour: string): RGB {
+  const match = colour.match(/oklch\(([\d.]+) ([\d.]+) ([\d.]+)\)/);
+  if (match == null) throw new Error(`not an oklch colour: ${colour}`);
+  const [L, C, h] = [Number(match[1]), Number(match[2]), (Number(match[3]) * Math.PI) / 180];
+  const a = C * Math.cos(h);
+  const b = C * Math.sin(h);
+  const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const s = (L - 0.0894841775 * a - 1.291485548 * b) ** 3;
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+}
+
+/** Machado-2009 severity-1.0 dichromat matrices, applied in linear sRGB. */
+const DEUTERANOPIA = [
+  0.367322, 0.860646, -0.227968, 0.280085, 0.672501, 0.047413, -0.01182, 0.04294, 0.968881,
+];
+const PROTANOPIA = [
+  0.152286, 1.052583, -0.204868, 0.114503, 0.786281, 0.099216, -0.003882, -0.048116, 1.051998,
+];
+const NORMAL_VISION = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
+function applyMatrix(m: number[], [r, g, b]: RGB): RGB {
+  return [
+    m[0] * r + m[1] * g + m[2] * b,
+    m[3] * r + m[4] * g + m[5] * b,
+    m[6] * r + m[7] * g + m[8] * b,
+  ];
+}
+
+/** Simulated colour as CIELab (D65), for a perceptual ΔE comparison. */
+function labUnderVision(colour: string, vision: number[]): [number, number, number] {
+  const [r, g, b] = applyMatrix(vision, oklchToLinearRGB(colour).map(clamp01) as RGB).map(clamp01);
+  const X = 0.4124 * r + 0.3576 * g + 0.1805 * b;
+  const Y = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  const Z = 0.0193 * r + 0.1192 * g + 0.9505 * b;
+  const f = (t: number) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116);
+  const [fx, fy, fz] = [f(X / 0.95047), f(Y), f(Z / 1.08883)];
+  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)];
+}
+
+function deltaE76(a: number[], b: number[]): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+/** Smallest pairwise ΔE76 between N level colours, as seen under `vision`. */
+function minLevelSeparation(count: number, vision: number[]): number {
+  const levels = Array.from({ length: count }, (_, i) => level(i + 1, `L${i}`, i));
+  const labs = levels.map((l) => labUnderVision(levelColour(l.id, levels), vision));
+  let min = Infinity;
+  for (let i = 0; i < labs.length; i += 1) {
+    for (let j = i + 1; j < labs.length; j += 1) {
+      min = Math.min(min, deltaE76(labs[i], labs[j]));
+    }
+  }
+  return min;
+}
+
+describe('levelColour / levelHue (colourblind-safe palette)', () => {
+  it('orders by position, not array order, so a level’s colour is stable', () => {
     const ordered = [level(1, 'A', 0), level(2, 'B', 1)];
     const shuffled = [level(2, 'B', 1), level(1, 'A', 0)];
+    expect(levelColour(1, ordered)).toBe(levelColour(1, shuffled));
+    expect(levelColour(2, ordered)).toBe(levelColour(2, shuffled));
     expect(levelHue(1, ordered)).toBe(levelHue(1, shuffled));
-    expect(levelHue(2, ordered)).toBe(levelHue(2, shuffled));
   });
-});
 
-describe('levelColour', () => {
-  it('returns an oklch colour on the level’s hue', () => {
-    const levels = [level(1, 'A', 0), level(2, 'B', 1)];
-    expect(levelColour(2, levels)).toMatch(/^oklch\(/);
-    expect(oklchHue(levelColour(2, levels))).toBeCloseTo(levelHue(2, levels));
+  it('draws the first level from the palette anchor (blue, 250°)', () => {
+    const levels = [level(1, 'A', 0)];
+    expect(levelHue(1, levels)).toBeCloseTo(250);
+    expect(levelColour(1, levels)).toBe('oklch(0.500 0.130 250.0)');
+  });
+
+  it('keeps levelColour and levelHue on the same hue', () => {
+    const levels = [level(1, 'A', 0), level(2, 'B', 1), level(3, 'C', 2)];
+    for (const l of levels) {
+      expect(levelColour(l.id, levels)).toMatch(/^oklch\(/);
+      expect(oklchHue(levelColour(l.id, levels))).toBeCloseTo(levelHue(l.id, levels));
+    }
+  });
+
+  it('varies lightness between consecutive levels — the cue every CVD type keeps', () => {
+    const levels = Array.from({ length: 5 }, (_, i) => level(i + 1, `L${i}`, i));
+    const lightnesses = levels.map((l) => oklchLightness(levelColour(l.id, levels)));
+    for (let i = 1; i < lightnesses.length; i += 1) {
+      expect(Math.abs(lightnesses[i] - lightnesses[i - 1])).toBeGreaterThan(0.04);
+    }
+  });
+
+  it('falls back to the even hue spread past the palette length', () => {
+    // Nine levels: the first seven come from the palette, the last two land on the
+    // even-spread fallback at the fixed level lightness (0.55).
+    const levels = Array.from({ length: 9 }, (_, i) => level(i + 1, `L${i}`, i));
+    expect(oklchLightness(levelColour(8, levels))).toBeCloseTo(0.55);
+    expect(oklchLightness(levelColour(9, levels))).toBeCloseTo(0.55);
+  });
+
+  it('keeps every level distinguishable under deuteranopia and protanopia', () => {
+    for (const count of [3, 5, 7]) {
+      expect(minLevelSeparation(count, DEUTERANOPIA)).toBeGreaterThan(12);
+      expect(minLevelSeparation(count, PROTANOPIA)).toBeGreaterThan(12);
+    }
+  });
+
+  it('stays clearly distinct for normal colour vision', () => {
+    expect(minLevelSeparation(5, NORMAL_VISION)).toBeGreaterThan(20);
   });
 });
 

--- a/frontend/src/logic/colors.ts
+++ b/frontend/src/logic/colors.ts
@@ -9,23 +9,41 @@
  *      arbitrary key (team, stage item, …). Used where any stable-but-distinct
  *      colour will do.
  *
- *   2. Level colours      — a level's colour is generated in OKLCH and spread by
- *      the level's *position* in the tournament, so the levels actually present
- *      land as far apart on the hue wheel as the count allows. `levelColour`
- *      returns the badge colour shown on every view; the planner derives its
- *      stage/item shades from the same hue (`levelHue`), so a level keeps its
- *      identity from a badge to a schedule card.
+ *   2. Level colours      — a level's colour is drawn, by the level's *position*
+ *      in the tournament, from a curated colourblind-safe qualitative palette
+ *      (`LEVEL_PALETTE`), falling back to an even OKLCH hue spread only past the
+ *      palette length. `levelColour` returns the badge colour shown on every
+ *      view; the planner derives its stage/item shades from the same hue
+ *      (`levelHue`), so a level keeps its identity from a badge to a schedule
+ *      card.
  *
  *   3. Score colours      — win / draw / loss (and live / pending) chip colours,
  *      shared by the results, dashboard, score-tracking and schedule views.
  *
+ * Invariant across all three: colour is never the *only* cue. Level badges always
+ * render the level name, the planner legend pairs every swatch with its name, and
+ * score chips contain the score — so colour only sharpens the at-a-glance read and
+ * is never load-bearing for correctness. That is what lets us optimise the palette
+ * for colour-vision deficiency (CVD) without worrying about ambiguous edge cases.
+ *
  * Why OKLCH for levels: OKLCH is perceptually uniform, so equal hue steps look
- * equally different and a fixed lightness reads as equally light across every
- * hue. That makes "spread the levels evenly around the wheel" actually look even,
- * and keeps the within-level shade steps from blurring into the next level — the
+ * equally different and equal lightness reads as equally light across every hue.
+ * That keeps the within-level shade steps from blurring into the next level — the
  * failure mode of the old HSL scheme, where e.g. blue (217°) and indigo (228°)
  * were numerically distinct but visually identical. OKLCH and `color-mix(in
  * oklch)` are Baseline-supported in every browser this app targets.
+ *
+ * Why a curated palette and not an even hue spread: for the ~8% of men with
+ * red–green CVD (deuter-/protan-), the perceivable hue axis collapses roughly to a
+ * single blue↔yellow line, so spreading hues evenly around the *whole* wheel spends
+ * most of the separation budget on the red↔green direction they can't see — two
+ * levels 130° apart can look identical to them. `LEVEL_PALETTE` instead picks hues
+ * that stay apart on the blue↔yellow axis and, crucially, varies *lightness* level
+ * to level (the one cue every CVD type keeps), so consecutive levels separate by
+ * lightness as well as hue. The colours were verified with a Machado-2009 CVD
+ * simulation: every pair of the first N (N ≤ palette length) stays well clear of
+ * confusion (min ΔE76 ≳ 16) under both deuteranopia and protanopia, versus ≈10 for
+ * the old even spread, while normal-vision separation stays strong (min ΔE76 ≳ 30).
  */
 
 import type { LevelResponse, MatchWithDetails, StageWithStageItems } from '@openapi';
@@ -59,13 +77,40 @@ export function stringToColour(input: string): string {
 
 // ── Level colours (OKLCH) ───────────────────────────────────────────────────
 
-/** Hue the first level (and a tournament without levels) anchors on. */
+/** Hue the first level (and a tournament without levels) anchors on. Matches the
+ * first palette entry so a no-levels family and the first level read alike. */
 const LEVEL_BASE_HUE = 250;
-/** Lightness/chroma of a level's badge + planner accent. Tuned so the colour
- * reads as text on its own light tint (the `variant="light"` badge) and as a
- * border/glyph in the planner, identically across every hue. */
+/** Lightness/chroma for levels beyond the palette length, and for the planner
+ * accent (which keeps a constant brightness across every level hue). Tuned so the
+ * colour reads as text on its own light tint (the `variant="light"` badge) and as
+ * a border/glyph in the planner, identically across every hue. */
 const LEVEL_LIGHTNESS = 0.55;
 const LEVEL_CHROMA = 0.15;
+
+/**
+ * Colourblind-safe qualitative palette for level badges, as OKLCH `[L, C, H]`
+ * triples assigned to levels in position order. Inspired by the Okabe-Ito set but
+ * tuned for this app's `variant="light"` badge (where the colour is the *text*):
+ *
+ *   - Hues stay spread along the blue↔yellow axis that red–green CVD keeps, rather
+ *     than evenly around the whole wheel.
+ *   - Lightness deliberately varies entry to entry — the cue that survives every
+ *     CVD type — so consecutive levels separate by lightness as well as hue.
+ *   - The first five entries (the common 2–5 level case) hold L ≤ 0.68 so the level
+ *     name stays legible as badge text; the rarely-reached tail may run lighter.
+ *
+ * Verified with a Machado-2009 CVD simulation (see the header note): every pair of
+ * the first N stays at min ΔE76 ≳ 16 under deuteranopia and protanopia.
+ */
+const LEVEL_PALETTE: readonly (readonly [number, number, number])[] = [
+  [0.5, 0.13, 250], // blue
+  [0.66, 0.145, 62], // orange
+  [0.56, 0.115, 160], // green
+  [0.62, 0.15, 352], // reddish purple
+  [0.68, 0.105, 232], // sky blue
+  [0.55, 0.175, 33], // vermillion
+  [0.8, 0.135, 100], // yellow
+];
 
 function oklch(lightness: number, chroma: number, hue: number): string {
   const wrapped = ((hue % 360) + 360) % 360;
@@ -80,26 +125,37 @@ function orderedLevels(levels: LevelResponse[]): LevelResponse[] {
 }
 
 /**
- * Base hue (deg) for a level, spread evenly around the wheel by the level's
- * position among all levels — so N levels are as far apart as N points can be.
+ * A level's OKLCH `[L, C, H]`, by its position among all levels: the curated
+ * `LEVEL_PALETTE` entry while one is available, then an even hue spread (at the
+ * fixed level lightness/chroma) for any overflow past the palette length.
  *
- * Trade-off: because the spread divides the wheel by the level *count*, adding
- * or removing a level re-spaces the others. We accept that (levels are set up
- * once and rarely change) in exchange for maximal separation, which is the whole
- * point of the scheme. Unknown levels fall back to the base hue.
+ * The even-spread fallback divides the wheel by the level *count*, so adding or
+ * removing an overflow level re-spaces those — accepted (levels are set up once
+ * and rarely change, and >7 levels is vanishingly rare). Unknown levels fall back
+ * to the base hue.
  */
-export function levelHue(levelId: number, levels: LevelResponse[]): number {
+function levelOklch(levelId: number, levels: LevelResponse[]): readonly [number, number, number] {
   const ordered = orderedLevels(levels);
   const index = ordered.findIndex((level) => level.id === levelId);
-  if (index < 0) return LEVEL_BASE_HUE;
+  if (index < 0) return [LEVEL_LIGHTNESS, LEVEL_CHROMA, LEVEL_BASE_HUE];
+  if (index < LEVEL_PALETTE.length) return LEVEL_PALETTE[index];
   const count = Math.max(ordered.length, 1);
-  return (LEVEL_BASE_HUE + (360 * index) / count) % 360;
+  return [LEVEL_LIGHTNESS, LEVEL_CHROMA, (LEVEL_BASE_HUE + (360 * index) / count) % 360];
 }
 
-/** A level's app-wide colour: the same hue every view paints it with. Pass it
+/**
+ * Base hue (deg) for a level: the hue of its palette colour, so the planner's
+ * stage/item shades land on the same hue the badge uses and a level keeps its
+ * identity from a badge to a schedule card.
+ */
+export function levelHue(levelId: number, levels: LevelResponse[]): number {
+  return levelOklch(levelId, levels)[2];
+}
+
+/** A level's app-wide colour: the same colour every view paints it with. Pass it
  * straight to a Mantine `<Badge color={...} variant="light">`. */
 export function levelColour(levelId: number, levels: LevelResponse[]): string {
-  return oklch(LEVEL_LIGHTNESS, LEVEL_CHROMA, levelHue(levelId, levels));
+  return oklch(...levelOklch(levelId, levels));
 }
 
 /** Legend swatch in the planner: a level's exact app-wide colour, so the key


### PR DESCRIPTION
Level colours were spread evenly around the full OKLCH hue wheel at a
fixed lightness. For red–green colour-vision deficiency (deuter-/protan-,
~8% of men) the perceivable hue axis collapses to roughly a blue↔yellow
line, so an even full-wheel spread put much of the separation on the
red↔green direction those viewers can't see, and the fixed lightness left
no fallback cue — two levels could look identical to a deuteranope.

Draw level colours, in position order, from a curated colourblind-safe
qualitative palette (Okabe-Ito-inspired, tuned for the variant="light"
badge where the colour is the text): hues stay along the blue↔yellow axis
and lightness varies level to level, the cue every CVD type keeps. Fall
back to the previous even hue spread only past the palette length. The
first five entries (the common 2–5 level case) keep L ≤ 0.68 so the level
name stays legible as badge text.

Verified with a Machado-2009 CVD simulation: min ΔE76 ≳ 16 between any
pair of the first N under both deuteranopia and protanopia (versus ≈10 for
the old even spread), while normal-vision separation stays strong
(min ΔE76 ≳ 30). The test encodes this with a self-contained CVD
simulation plus the palette/ordering/fallback invariants.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VJXkhZYTpJknJGByGQ5N9H