### PR TITLE
Flag cross-stage precedence conflicts on the feeder side too

### DIFF
--- a/backend/bracket/logic/planning/conflicts.py
+++ b/backend/bracket/logic/planning/conflicts.py
@@ -143,6 +143,56 @@ def _get_stage_item_end_times(
     return stage_item_end_times
 
 
+def _get_stage_item_start_times(
+    stages: list[StageWithStageItems],
+) -> dict[StageItemId, datetime_utc]:
+    stage_item_start_times: dict[StageItemId, datetime_utc] = {}
+    for stage in stages:
+        for stage_item in stage.stage_items:
+            earliest_start_time: datetime_utc | None = None
+            for round_ in stage_item.rounds:
+                for match in round_.matches:
+                    if match.start_time is None:
+                        continue
+                    if earliest_start_time is None or match.start_time < earliest_start_time:
+                        earliest_start_time = match.start_time
+            if earliest_start_time is not None:
+                stage_item_start_times[stage_item.id] = earliest_start_time
+    return stage_item_start_times
+
+
+def _get_earliest_dependent_start_times(
+    stages: list[StageWithStageItems],
+) -> dict[StageItemId, datetime_utc]:
+    """Map each source stage item to the earliest start of any stage item feeding off it.
+
+    A stage item "feeds off" a source when one of its matches has an input whose
+    ``winner_from_stage_item_id`` points at that source.
+    """
+    stage_item_start_times = _get_stage_item_start_times(stages)
+    earliest_dependent_start: dict[StageItemId, datetime_utc] = {}
+
+    for stage in stages:
+        for stage_item in stage.stage_items:
+            dependent_start = stage_item_start_times.get(stage_item.id)
+            if dependent_start is None:
+                continue
+            for round_ in stage_item.rounds:
+                for match in round_.matches:
+                    for stage_item_input in (match.stage_item_input1, match.stage_item_input2):
+                        if (
+                            stage_item_input is None
+                            or stage_item_input.winner_from_stage_item_id is None
+                        ):
+                            continue
+                        source_id = stage_item_input.winner_from_stage_item_id
+                        existing = earliest_dependent_start.get(source_id)
+                        if existing is None or dependent_start < existing:
+                            earliest_dependent_start[source_id] = dependent_start
+
+    return earliest_dependent_start
+
+
 def _set_cross_stage_precedence_conflicts(
     stages: list[StageWithStageItems],
     flags: dict[MatchId, MatchConflictFlags],
@@ -159,6 +209,32 @@ def _set_cross_stage_precedence_conflicts(
             source_end_time = stage_item_end_times.get(stage_item_input.winner_from_stage_item_id)
             if source_end_time is not None and match.start_time < source_end_time:
                 flags[match.id].precedence_conflict = True
+
+
+def _set_cross_stage_feeder_precedence_conflicts(
+    stages: list[StageWithStageItems],
+    flags: dict[MatchId, MatchConflictFlags],
+) -> None:
+    """Flag feeder matches scheduled after the stage item they feed into has started.
+
+    The mirror image of ``_set_cross_stage_precedence_conflicts``: a source stage item must
+    finish before any stage item consuming its ranking begins. Here we flag the *source* matches
+    that are still running once a dependent stage item's earliest match has started, so the
+    precedence conflict is marked on both sides of the dependency.
+    """
+    earliest_dependent_start = _get_earliest_dependent_start_times(stages)
+
+    for stage in stages:
+        for stage_item in stage.stage_items:
+            dependent_start = earliest_dependent_start.get(stage_item.id)
+            if dependent_start is None:
+                continue
+            for round_ in stage_item.rounds:
+                for match in round_.matches:
+                    if match.start_time is None:
+                        continue
+                    if match.end_time > dependent_start:
+                        flags[match.id].precedence_conflict = True
 
 
 def _set_short_break_conflicts(
@@ -303,6 +379,7 @@ def get_match_conflict_flags(
     _set_slot_overlap_conflicts(stages, flags)
     _set_winner_of_precedence_conflicts(matches, flags)
     _set_cross_stage_precedence_conflicts(stages, flags)
+    _set_cross_stage_feeder_precedence_conflicts(stages, flags)
     _set_short_break_conflicts(matches, default_break_minutes, flags)
 
     return flags

--- a/backend/bracket/logic/planning/conflicts.py
+++ b/backend/bracket/logic/planning/conflicts.py
@@ -122,7 +122,10 @@ def _set_winner_of_precedence_conflicts(
                 and feeder.start_time is not None
                 and match.start_time < feeder.end_time
             ):
+                # The dependent match starts before its feeder finishes; flag both sides so
+                # the precedence conflict is marked on the feeder too.
                 flags[match.id].precedence_conflict = True
+                flags[feeder.id].precedence_conflict = True
 
 
 def _get_stage_item_end_times(

--- a/backend/tests/unit_tests/conflicts_test.py
+++ b/backend/tests/unit_tests/conflicts_test.py
@@ -303,6 +303,76 @@ def test_get_match_conflict_flags_marks_match_before_feeding_stage_item_finishes
     flags = get_match_conflict_flags([stage], default_break_minutes=5)
 
     assert flags[target_match.id].precedence_conflict is True
+    # source_match1 (T → T+10) finishes before the target stage item starts (T+15).
+    assert flags[source_match1.id].precedence_conflict is False
+    # source_match2 (T+10 → T+20) is still running once the target stage item starts (T+15),
+    # so the precedence conflict is flagged on the feeder side too.
+    assert flags[source_match2.id].precedence_conflict is True
+
+
+def test_get_match_conflict_flags_does_not_mark_feeder_finishing_before_dependent() -> None:
+    """A feeder stage item that fully finishes before its dependent starts is not flagged."""
+    tournament_id = TournamentId(-1)
+    source_inputs = get_stage_item_inputs_mock(tournament_id)
+    source_match1, source_match2 = get_2_definitive_matches_mock(
+        source_inputs,
+        match1_start_time=T,
+        match2_start_time=T + timedelta(minutes=10),
+        duration_minutes=10,
+    )
+    source_round = get_one_round_with_two_definitive_matches(source_match1, source_match2)
+    source_stage_item = get_stage_item_mock(source_inputs, [source_round])
+
+    target_input = StageItemInputTentative(
+        id=StageItemInputId(-10),
+        slot=1,
+        tournament_id=tournament_id,
+        stage_item_id=StageItemId(-2),
+        winner_from_stage_item_id=source_stage_item.id,
+        winner_position=1,
+    )
+    # The dependent match starts at T+20, exactly when source_match2 ends (back-to-back).
+    target_match = MatchWithDetailsDefinitive(
+        id=MatchId(-3),
+        stage_item_input1=target_input,
+        stage_item_input2=source_inputs[1],
+        stage_item_input1_id=target_input.id,
+        stage_item_input2_id=source_inputs[1].id,
+        created=T,
+        start_time=T + timedelta(minutes=20),
+        duration_minutes=10,
+        round_id=RoundId(-4),
+        court_id=CourtId(-3),
+        stage_item_input1_score=0,
+        stage_item_input2_score=0,
+        stage_item_input1_conflict=False,
+        stage_item_input2_conflict=False,
+        state=MatchState.NOT_STARTED,
+        completed_at=None,
+    )
+    target_round = RoundWithMatches(
+        id=RoundId(-4),
+        matches=[target_match],
+        stage_item_id=StageItemId(-2),
+        created=T,
+        is_draft=False,
+        name="",
+    )
+    target_stage_item = get_stage_item_mock(source_inputs, [target_round]).model_copy(
+        update={"id": StageItemId(-2), "inputs": [target_input, source_inputs[1]]}
+    )
+    stage = StageWithStageItems(
+        id=StageId(-1),
+        tournament_id=tournament_id,
+        name="",
+        created=MOCK_NOW,
+        is_active=False,
+        stage_items=[source_stage_item, target_stage_item],
+    )
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=5)
+
+    assert flags[target_match.id].precedence_conflict is False
     assert flags[source_match1.id].precedence_conflict is False
     assert flags[source_match2.id].precedence_conflict is False
 

--- a/backend/tests/unit_tests/conflicts_test.py
+++ b/backend/tests/unit_tests/conflicts_test.py
@@ -237,6 +237,40 @@ def test_get_match_conflict_flags_marks_match_before_winner_feeder() -> None:
     flags = get_match_conflict_flags([stage], default_break_minutes=5)
 
     assert flags[final.id].precedence_conflict is True
+    # The final (T+30 → T+120) starts while both feeders (T → T+90) are still running, so the
+    # precedence conflict is marked on the feeder side too.
+    assert flags[feeder1.id].precedence_conflict is True
+    assert flags[feeder2.id].precedence_conflict is True
+
+
+def test_get_match_conflict_flags_does_not_mark_winner_feeder_finishing_before_dependent() -> None:
+    """A winner-of feeder that finishes before its dependent match starts is not flagged."""
+    tournament_id = TournamentId(-1)
+    stage_item_inputs = get_stage_item_inputs_mock(tournament_id)
+    feeder1, feeder2, final, consolation = get_2_definitive_and_2_tentative_matches_mock(
+        stage_item_inputs
+    )
+    # Feeders run T → T+90; the final starts at T+90 (back-to-back), so no precedence conflict.
+    final = final.model_copy(
+        update={
+            "court_id": CourtId(-3),
+            "start_time": T + timedelta(minutes=90),
+        }
+    )
+    first_round = get_one_round_with_two_definitive_matches(feeder1, feeder2)
+    final_round, _ = get_two_round_with_one_tentative_match_each(final, consolation)
+    stage = StageWithStageItems(
+        id=StageId(-1),
+        tournament_id=tournament_id,
+        name="",
+        created=MOCK_NOW,
+        is_active=False,
+        stage_items=[get_stage_item_mock(stage_item_inputs, [first_round, final_round])],
+    )
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=5)
+
+    assert flags[final.id].precedence_conflict is False
     assert flags[feeder1.id].precedence_conflict is False
     assert flags[feeder2.id].precedence_conflict is False
 
@@ -310,7 +344,9 @@ def test_get_match_conflict_flags_marks_match_before_feeding_stage_item_finishes
     assert flags[source_match2.id].precedence_conflict is True
 
 
-def test_get_match_conflict_flags_does_not_mark_feeder_finishing_before_dependent() -> None:
+def test_get_match_conflict_flags_does_not_mark_feeding_stage_item_finishing_before_dependent() -> (
+    None
+):
     """A feeder stage item that fully finishes before its dependent starts is not flagged."""
     tournament_id = TournamentId(-1)
     source_inputs = get_stage_item_inputs_mock(tournament_id)

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -167,7 +167,7 @@
     "match_context_stage_label": "Phase",
     "max_results_input_label": "Maximale Ergebnisse",
     "match_scheduled_before_previous_stage_label": "Vor einem Spiel einer früheren Phase auf diesem Spielfeld geplant",
-    "precedence_conflict_label": "Beginnt, bevor ein Zubringerspiel beendet ist",
+    "precedence_conflict_label": "Überschneidet sich mit einem Zubringer- oder Folgespiel",
     "referee_conflict_label": "Der Schiedsrichter spielt oder pfeift während dieses Spiels ein anderes Spiel",
     "short_break_conflict_label": "Die Pause vor diesem Spiel ist kürzer als die Standardpause",
     "members_table_header": "Mitglieder",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -167,7 +167,7 @@
     "match_context_stage_label": "Stage",
     "max_results_input_label": "Max results",
     "match_scheduled_before_previous_stage_label": "Scheduled before a match of an earlier stage on this court",
-    "precedence_conflict_label": "Starts before a feeder match has finished",
+    "precedence_conflict_label": "Overlaps with a feeder or dependent match",
     "referee_conflict_label": "Referee is playing or refereeing another match during this match",
     "short_break_conflict_label": "Break before this match is shorter than the default",
     "members_table_header": "Members",


### PR DESCRIPTION
We already flag a match scheduled before its input stage items have
finished. Now mirror that: flag the feeder matches that are still
running once a stage item consuming their ranking has started, so the
precedence conflict is marked on both sides of the dependency.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SdRrwbuctQgP5i8g6NTgAk