### PR TITLE
Move referee conflict icon into RefereeDisplay component

### DIFF
--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -400,7 +400,6 @@ function MatchCard({
             {badgeLabel != null ? fullBadge(badgeLabel) : null}
             {placementWarningIcon}
             {shortBreakIcon}
-            {refereeConflictIcon}
             {violationIcon}
           </Flex>
         )}
@@ -413,7 +412,6 @@ function MatchCard({
           )}
           {!metaLine && placementWarningIcon}
           {!metaLine && shortBreakIcon}
-          {!metaLine && refereeConflictIcon}
           {(combineTeams ||
             (lines === 1 && !(mergeConflictIcons && match.stage_item_input1_conflict))) &&
             match.stage_item_input2_conflict && (
@@ -447,6 +445,7 @@ function MatchCard({
             match={match}
             refereesEnabled={refereesEnabled}
             stageItemsLookup={stageItemsLookup}
+            conflictIcon={refereeConflictIcon}
           />
         )}
       </Box>

--- a/frontend/src/components/utils/referee.tsx
+++ b/frontend/src/components/utils/referee.tsx
@@ -1,5 +1,6 @@
 import { Flex, Text } from '@mantine/core';
 import { GiWhistle } from '@react-icons/all-files/gi/GiWhistle';
+import { ReactNode } from 'react';
 
 import { MatchWithDetails } from '@openapi';
 import { formatStageItemInput } from './stage_item_input';
@@ -20,16 +21,19 @@ export function RefereeDisplay({
   match,
   refereesEnabled,
   stageItemsLookup = {},
+  conflictIcon = null,
 }: {
   match: RefereeFields;
   refereesEnabled: boolean;
   stageItemsLookup?: any;
+  conflictIcon?: ReactNode;
 }) {
   const name = getRefereeName(match, stageItemsLookup);
   if (!refereesEnabled || name == null) return null;
 
   return (
     <Flex gap={4} align="center" wrap="nowrap">
+      {conflictIcon}
       <GiWhistle size={13} style={{ flexShrink: 0, color: 'var(--mantine-color-dimmed)' }} />
       <Text size="xs" c="dimmed" truncate>
         {name}


### PR DESCRIPTION
## Summary
Refactored the referee conflict icon display by moving it from the MatchCard layout into the RefereeDisplay component itself, for consistency with the other team related conflict icons.

## Changes
- Added `conflictIcon` prop to `RefereeDisplay` component to accept an optional ReactNode
- Removed `refereeConflictIcon` from the main flex layout in MatchCard (both in the badge section and meta line section)
- Passed `refereeConflictIcon` to `RefereeDisplay` via the new `conflictIcon` prop
- Updated `RefereeDisplay` to render the conflict icon alongside the whistle icon

## Implementation Details
- The conflict icon is now rendered within the RefereeDisplay component's flex container, appearing before the whistle icon
- The prop defaults to `null` to maintain backward compatibility
- This change consolidates all referee-related display logic into a single component, making the code more maintainable

https://claude.ai/code/session_01BdiVccP4QDs7SH3To25TyY