### PR TITLE
Display referee conflict icon in match card layout

### DIFF
--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -401,6 +401,7 @@ function MatchCard({
             {placementWarningIcon}
             {shortBreakIcon}
             {violationIcon}
+            {!showReferee && refereeConflictIcon}
           </Flex>
         )}
         <Flex gap={6} align="center" wrap="nowrap">
@@ -428,6 +429,7 @@ function MatchCard({
                 )
               : pinnedScores(scoreChip(match.stage_item_input1_score, score1Colour)))}
           {!metaLine && violationIcon}
+          {!metaLine && refereeConflictIcon}
         </Flex>
         {lines >= 2 && !combineTeams && (
           <Flex gap={4} align="center" wrap="nowrap">


### PR DESCRIPTION
## Summary
Added display of the referee conflict icon in the match card component to make scheduling conflicts more visible to users.

## Changes
- Display `refereeConflictIcon` in the top icon row when the referee view is not shown
- Display `refereeConflictIcon` in the secondary flex row when the meta line is not displayed

## Implementation Details
The referee conflict icon is now conditionally rendered in two locations within the MatchCard component:
1. In the primary icon section (alongside placement warnings, short break, and violation icons) when `!showReferee`
2. In the secondary information row (alongside violation icon) when `!metaLine`

This ensures the referee conflict indicator is visible regardless of the current layout configuration of the match card.

https://claude.ai/code/session_017STMq4rAAib7gVPUpswMJe