### PR TITLE
Add tooltips to team double-booked conflict warnings

### DIFF
--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -409,14 +409,28 @@ function MatchCard({
           {lines === 1 && coreShort != null && inlineBadge(coreShort)}
           {lines < 3 && statusIndicator}
           {match.stage_item_input1_conflict && (
-            <AiFillWarning color={CONFLICT_COLOURS.teamDoubleBooked} />
+            <Tooltip label={t('team_double_booked_conflict_label', { team: input1 })}>
+              <Box
+                component="span"
+                style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}
+              >
+                <AiFillWarning color={CONFLICT_COLOURS.teamDoubleBooked} />
+              </Box>
+            </Tooltip>
           )}
           {!metaLine && placementWarningIcon}
           {!metaLine && shortBreakIcon}
           {(combineTeams ||
             (lines === 1 && !(mergeConflictIcons && match.stage_item_input1_conflict))) &&
             match.stage_item_input2_conflict && (
-              <AiFillWarning color={CONFLICT_COLOURS.teamDoubleBooked} />
+              <Tooltip label={t('team_double_booked_conflict_label', { team: input2 })}>
+                <Box
+                  component="span"
+                  style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}
+                >
+                  <AiFillWarning color={CONFLICT_COLOURS.teamDoubleBooked} />
+                </Box>
+              </Tooltip>
             )}
           <Text size="xs" fz={fontSize} fw={600} lh={1.3} truncate style={{ flex: 1 }}>
             {lines === 1 || combineTeams ? `${input1} – ${input2}` : input1}
@@ -434,7 +448,14 @@ function MatchCard({
         {lines >= 2 && !combineTeams && (
           <Flex gap={4} align="center" wrap="nowrap">
             {match.stage_item_input2_conflict && (
-              <AiFillWarning color={CONFLICT_COLOURS.teamDoubleBooked} />
+              <Tooltip label={t('team_double_booked_conflict_label', { team: input2 })}>
+                <Box
+                  component="span"
+                  style={{ flexShrink: 0, display: 'flex', alignItems: 'center', height: '1rem' }}
+                >
+                  <AiFillWarning color={CONFLICT_COLOURS.teamDoubleBooked} />
+                </Box>
+              </Tooltip>
             )}
             <Text size="xs" fz={fontSize} fw={600} lh={1.3} truncate>
               {input2}


### PR DESCRIPTION
## Summary
Enhanced the user experience by adding informative tooltips to team double-booked conflict warning icons in the scheduling grid. The tooltips display which team is double-booked, providing immediate context without requiring additional interaction.

## Key Changes
- Wrapped all three instances of the team double-booked warning icon (`AiFillWarning`) with `Tooltip` components that display the affected team name
- Added consistent styling wrapper (`Box` component) around warning icons to ensure proper layout and alignment:
  - `flexShrink: 0` prevents icon compression
  - `display: 'flex'` with `alignItems: 'center'` ensures vertical centering
  - `height: '1rem'` maintains consistent icon sizing
- Updated tooltip labels to use i18n key `'team_double_booked_conflict_label'` with the team name as a parameter

## Implementation Details
The changes maintain the existing visual appearance while improving accessibility and clarity. The tooltip implementation is consistent across all three conflict warning locations in the component (input1 conflict in first section, input2 conflict in conditional sections).

https://claude.ai/code/session_015bnFpnC41cyZhQCCqRNWZ4