### PR TITLE
Refactor matches list into shared component, reuse in admin results

### DIFF
--- a/frontend/src/components/matches/matches_list.tsx
+++ b/frontend/src/components/matches/matches_list.tsx
@@ -1,0 +1,74 @@
+import { Center, Group, Text } from '@mantine/core';
+import { AiOutlineHourglass } from '@react-icons/all-files/ai/AiOutlineHourglass';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { NoContent } from '@components/no_content/empty_table_info';
+import { compareDateTime, formatTime } from '@components/utils/datetime';
+import { LevelResponse, MatchWithDetails } from '@openapi';
+import { ScheduleRow } from './schedule_row';
+
+export function MatchesList({
+  matchesLookup,
+  stageItemsLookup,
+  levels,
+  refereesEnabled,
+  onMatchClick,
+}: {
+  matchesLookup: any;
+  stageItemsLookup: any;
+  levels: LevelResponse[];
+  refereesEnabled: boolean;
+  onMatchClick?: (match: MatchWithDetails) => void;
+}) {
+  const { t } = useTranslation();
+
+  const sortedMatches: any[] = (Object.values(matchesLookup) as any[])
+    .filter((item: any) => item.match.start_time != null)
+    .sort(
+      (m1: any, m2: any) =>
+        compareDateTime(m1.match.start_time, m2.match.start_time) ||
+        (m1.match.court?.name || '').localeCompare(m2.match.court?.name || '') ||
+        m1.match.id - m2.match.id
+    );
+
+  const rows: React.JSX.Element[] = [];
+  for (let c = 0; c < sortedMatches.length; c += 1) {
+    const data = sortedMatches[c];
+    const startTime = formatTime(data.match.start_time);
+
+    if (c < 1 || startTime !== formatTime(sortedMatches[c - 1].match.start_time as string)) {
+      rows.push(
+        <Center mt="md" key={`time-${c}`}>
+          <Text size="xl" fw={800}>
+            {startTime}
+          </Text>
+        </Center>
+      );
+    }
+
+    rows.push(
+      <ScheduleRow
+        key={data.match.id}
+        data={data}
+        stageItemsLookup={stageItemsLookup}
+        matchesLookup={matchesLookup}
+        levels={levels}
+        refereesEnabled={refereesEnabled}
+        onClick={onMatchClick != null ? () => onMatchClick(data.match) : undefined}
+      />
+    );
+  }
+
+  return (
+    <Group wrap="nowrap" align="top" style={{ width: '100%' }}>
+      <div style={{ width: '100%' }}>
+        {rows.length > 0 ? (
+          rows
+        ) : (
+          <NoContent title={t('no_matches_title')} description="" icon={<AiOutlineHourglass />} />
+        )}
+      </div>
+    </Group>
+  );
+}

--- a/frontend/src/components/matches/schedule_row.tsx
+++ b/frontend/src/components/matches/schedule_row.tsx
@@ -1,0 +1,115 @@
+import { Badge, Card, Center, Flex, Grid, Stack, Text, UnstyledButton } from '@mantine/core';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { LevelBadge } from '@components/levels/levels';
+import { Time } from '@components/utils/datetime';
+import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
+import { RefereeDisplay } from '@components/utils/referee';
+import { getScoreColors } from '@logic/colors';
+import { LevelResponse, MatchWithDetails } from '@openapi';
+import { stringToColour } from '@services/lookups';
+
+export function ScheduleRow({
+  data,
+  stageItemsLookup,
+  matchesLookup,
+  levels,
+  refereesEnabled,
+  onClick,
+}: {
+  data: any;
+  stageItemsLookup: any;
+  matchesLookup: any;
+  levels: LevelResponse[];
+  refereesEnabled: boolean;
+  onClick?: () => void;
+}) {
+  const { t } = useTranslation();
+  const colors = getScoreColors(data.match);
+
+  const card = (
+    <Card
+      shadow="sm"
+      radius="md"
+      withBorder
+      mt="md"
+      pt="0rem"
+      onClick={onClick}
+      style={onClick != null ? { cursor: 'pointer' } : undefined}
+    >
+      <Card.Section withBorder>
+        <Grid pt="0.75rem" pb="0.5rem">
+          <Grid.Col mb="0rem" span={4}>
+            <Text pl="sm" mt="sm" fw={800}>
+              {data.match.court.name}
+            </Text>
+          </Grid.Col>
+          <Grid.Col mb="0rem" span={3}>
+            <Center>
+              <Text mt="sm" fw={800}>
+                {data.match.start_time != null ? <Time datetime={data.match.start_time} /> : null}
+              </Text>
+            </Center>
+          </Grid.Col>
+          <Grid.Col mb="0rem" span={5}>
+            <Flex justify="right" align="center" gap="xs" mr="xs" mt="0.8rem">
+              <LevelBadge levels={levels} levelId={data.stage.level_id} />
+              <Badge color={stringToColour(`${data.stageItem.id}`)} variant="outline" size="md">
+                {data.stageItem.name}
+              </Badge>
+            </Flex>
+          </Grid.Col>
+        </Grid>
+      </Card.Section>
+      <Stack pt="sm">
+        <Grid>
+          <Grid.Col span="auto" pb="0rem">
+            <Text fw={500}>
+              {formatMatchInput1(t, stageItemsLookup, matchesLookup, data.match)}
+            </Text>
+          </Grid.Col>
+          <Grid.Col span="content" pb="0rem">
+            <div
+              style={{
+                backgroundColor: colors.stage_item_input1_score,
+                borderRadius: '0.5rem',
+                width: '2.5rem',
+                color: colors.textColor,
+                fontWeight: 800,
+              }}
+            >
+              <Center>{data.match.stage_item_input1_score}</Center>
+            </div>
+          </Grid.Col>
+        </Grid>
+        <Grid mb="0rem">
+          <Grid.Col span="auto" pb="0rem">
+            <Text fw={500}>
+              {formatMatchInput2(t, stageItemsLookup, matchesLookup, data.match)}
+            </Text>
+          </Grid.Col>
+          <Grid.Col span="content" pb="0rem">
+            <div
+              style={{
+                backgroundColor: colors.stage_item_input2_score,
+                borderRadius: '0.5rem',
+                width: '2.5rem',
+                color: colors.textColor,
+                fontWeight: 800,
+              }}
+            >
+              <Center>{data.match.stage_item_input2_score}</Center>
+            </div>
+          </Grid.Col>
+        </Grid>
+        <RefereeDisplay match={data.match} refereesEnabled={refereesEnabled} />
+      </Stack>
+    </Card>
+  );
+
+  if (onClick != null) {
+    return <UnstyledButton style={{ width: '100%' }}>{card}</UnstyledButton>;
+  }
+  return card;
+}

--- a/frontend/src/pages/tournaments/[id]/dashboard/index.tsx
+++ b/frontend/src/pages/tournaments/[id]/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import { Badge, Card, Center, Flex, Grid, Group, Stack, Text } from '@mantine/core';
+import { Center, Group } from '@mantine/core';
 import { AiOutlineHourglass } from '@react-icons/all-files/ai/AiOutlineHourglass';
 import { parseAsInteger, useQueryState } from 'nuqs';
 import React from 'react';
@@ -6,112 +6,17 @@ import { useTranslation } from 'react-i18next';
 
 import { DashboardFooter } from '@components/dashboard/footer';
 import { DoubleHeader, getTournamentHeadTitle } from '@components/dashboard/layout';
-import { LevelBadge } from '@components/levels/levels';
+import { ScheduleRow } from '@components/matches/schedule_row';
 import { NoContent } from '@components/no_content/empty_table_info';
-import { Time } from '@components/utils/datetime';
-import {
-  formatMatchInput1,
-  formatMatchInput2,
-  isMatchCompletedRecently,
-  matchHasTeam,
-} from '@components/utils/match';
-import { RefereeDisplay } from '@components/utils/referee';
+import { isMatchCompletedRecently, matchHasTeam } from '@components/utils/match';
 import { Translator } from '@components/utils/types';
 import { responseIsValid, setTitle } from '@components/utils/util';
-import { getScoreColors } from '@logic/colors';
 import { LevelResponse } from '@openapi';
 import { getStagesLive } from '@services/adapter';
 import { getTournamentResponseByEndpointName } from '@services/dashboard';
-import { getMatchLookup, getStageItemLookup, stringToColour } from '@services/lookups';
+import { getMatchLookup, getStageItemLookup } from '@services/lookups';
 
-export function ScheduleRow({
-  data,
-  stageItemsLookup,
-  matchesLookup,
-  levels,
-  refereesEnabled,
-}: {
-  data: any;
-  stageItemsLookup: any;
-  matchesLookup: any;
-  levels: LevelResponse[];
-  refereesEnabled: boolean;
-}) {
-  const { t } = useTranslation();
-  const colors = getScoreColors(data.match);
-
-  return (
-    <Card shadow="sm" radius="md" withBorder mt="md" pt="0rem">
-      <Card.Section withBorder>
-        <Grid pt="0.75rem" pb="0.5rem">
-          <Grid.Col mb="0rem" span={4}>
-            <Text pl="sm" mt="sm" fw={800}>
-              {data.match.court.name}
-            </Text>
-          </Grid.Col>
-          <Grid.Col mb="0rem" span={3}>
-            <Center>
-              <Text mt="sm" fw={800}>
-                {data.match.start_time != null ? <Time datetime={data.match.start_time} /> : null}
-              </Text>
-            </Center>
-          </Grid.Col>
-          <Grid.Col mb="0rem" span={5}>
-            <Flex justify="right" align="center" gap="xs" mr="xs" mt="0.8rem">
-              <LevelBadge levels={levels} levelId={data.stage.level_id} />
-              <Badge color={stringToColour(`${data.stageItem.id}`)} variant="outline" size="md">
-                {data.stageItem.name}
-              </Badge>
-            </Flex>
-          </Grid.Col>
-        </Grid>
-      </Card.Section>
-      <Stack pt="sm">
-        <Grid>
-          <Grid.Col span="auto" pb="0rem">
-            <Text fw={500}>
-              {formatMatchInput1(t, stageItemsLookup, matchesLookup, data.match)}
-            </Text>
-          </Grid.Col>
-          <Grid.Col span="content" pb="0rem">
-            <div
-              style={{
-                backgroundColor: colors.stage_item_input1_score,
-                borderRadius: '0.5rem',
-                width: '2.5rem',
-                color: colors.textColor,
-                fontWeight: 800,
-              }}
-            >
-              <Center>{data.match.stage_item_input1_score}</Center>
-            </div>
-          </Grid.Col>
-        </Grid>
-        <Grid mb="0rem">
-          <Grid.Col span="auto" pb="0rem">
-            <Text fw={500}>
-              {formatMatchInput2(t, stageItemsLookup, matchesLookup, data.match)}
-            </Text>
-          </Grid.Col>
-          <Grid.Col span="content" pb="0rem">
-            <div
-              style={{
-                backgroundColor: colors.stage_item_input2_score,
-                borderRadius: '0.5rem',
-                width: '2.5rem',
-                color: colors.textColor,
-                fontWeight: 800,
-              }}
-            >
-              <Center>{data.match.stage_item_input2_score}</Center>
-            </div>
-          </Grid.Col>
-        </Grid>
-        <RefereeDisplay match={data.match} refereesEnabled={refereesEnabled} />
-      </Stack>
-    </Card>
-  );
-}
+export { ScheduleRow };
 
 export function Schedule({
   t,

--- a/frontend/src/pages/tournaments/[id]/dashboard/matches.tsx
+++ b/frontend/src/pages/tournaments/[id]/dashboard/matches.tsx
@@ -1,19 +1,16 @@
-import { Center, Group, Text } from '@mantine/core';
-import { AiOutlineHourglass } from '@react-icons/all-files/ai/AiOutlineHourglass';
+import { Center, Group } from '@mantine/core';
 import { parseAsInteger, useQueryState } from 'nuqs';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DashboardFooter } from '@components/dashboard/footer';
 import { DoubleHeader, getTournamentHeadTitle } from '@components/dashboard/layout';
-import { NoContent } from '@components/no_content/empty_table_info';
-import { compareDateTime, formatTime } from '@components/utils/datetime';
+import { MatchesList } from '@components/matches/matches_list';
 import { matchHasTeam } from '@components/utils/match';
 import { responseIsValid, setTitle } from '@components/utils/util';
 import { getStagesLive } from '@services/adapter';
 import { getTournamentResponseByEndpointName } from '@services/dashboard';
 import { getMatchLookup, getStageItemLookup } from '@services/lookups';
-import { ScheduleRow } from './index';
 
 export default function DashboardMatchesPage() {
   const { t } = useTranslation();
@@ -34,70 +31,29 @@ export default function DashboardMatchesPage() {
 
   const stageItemsLookup = getStageItemLookup(swrStagesResponse);
   const matchesLookup = getMatchLookup(swrStagesResponse);
-  const sortedMatches = Object.values(matchesLookup)
-    .filter((item: any) => item.match.start_time != null)
-    .filter((item: any) => levelId == null || item.stage.level_id === levelId)
-    .filter(
-      (item: any) =>
-        teamId == null || matchHasTeam(item.match, teamId, tournamentDataFull.referees_enabled)
-    )
-    .sort(
-      (m1: any, m2: any) =>
-        compareDateTime(m1.match.start_time, m2.match.start_time) ||
-        (m1.match.court?.name || '').localeCompare(m2.match.court?.name || '') ||
-        m1.match.id - m2.match.id
-    );
-
-  const rows: React.JSX.Element[] = [];
-  for (let c = 0; c < sortedMatches.length; c += 1) {
-    const data: any = sortedMatches[c];
-    const startTime = formatTime(data.match.start_time);
-
-    if (
-      c < 1 ||
-      startTime !==
-        formatTime(
-          // sortedMatches only includes matches with a start time (see filter above)
-          sortedMatches[c - 1].match.start_time as string
+  const filteredMatchesLookup =
+    levelId != null || teamId != null
+      ? Object.fromEntries(
+          Object.entries(matchesLookup).filter(
+            ([, entry]: any) =>
+              (levelId == null || entry.stage.level_id === levelId) &&
+              (teamId == null ||
+                matchHasTeam(entry.match, teamId, tournamentDataFull.referees_enabled))
+          )
         )
-    ) {
-      rows.push(
-        <Center mt="md" key={`time-${c}`}>
-          <Text size="xl" fw={800}>
-            {startTime}
-          </Text>
-        </Center>
-      );
-    }
-
-    rows.push(
-      <ScheduleRow
-        key={data.match.id}
-        data={data}
-        stageItemsLookup={stageItemsLookup}
-        matchesLookup={matchesLookup}
-        levels={tournamentDataFull.levels}
-        refereesEnabled={tournamentDataFull.referees_enabled}
-      />
-    );
-  }
+      : matchesLookup;
 
   return (
     <>
       <DoubleHeader tournamentData={tournamentDataFull} />
       <Center>
         <Group style={{ maxWidth: '48rem', width: '100%' }} px="1rem">
-          <div style={{ width: '100%' }}>
-            {rows.length > 0 ? (
-              rows
-            ) : (
-              <NoContent
-                title={t('no_matches_title')}
-                description=""
-                icon={<AiOutlineHourglass />}
-              />
-            )}
-          </div>
+          <MatchesList
+            matchesLookup={filteredMatchesLookup}
+            stageItemsLookup={stageItemsLookup}
+            levels={tournamentDataFull.levels}
+            refereesEnabled={tournamentDataFull.referees_enabled}
+          />
         </Group>
       </Center>
       <DashboardFooter />

--- a/frontend/src/pages/tournaments/[id]/results.tsx
+++ b/frontend/src/pages/tournaments/[id]/results.tsx
@@ -1,225 +1,18 @@
-import {
-  Alert,
-  Badge,
-  Card,
-  Center,
-  Flex,
-  Grid,
-  Group,
-  Select,
-  Stack,
-  Text,
-  Title,
-  UnstyledButton,
-} from '@mantine/core';
-import { AiOutlineHourglass } from '@react-icons/all-files/ai/AiOutlineHourglass';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { Center, Group, Select, Title } from '@mantine/core';
 import { parseAsInteger, useQueryState } from 'nuqs';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { TeamFilterCombobox } from '@components/dashboard/team_filter';
 import { levelSelectData } from '@components/levels/levels';
+import { MatchesList } from '@components/matches/matches_list';
 import MatchModal from '@components/modals/match_modal';
-import { NoContent } from '@components/no_content/empty_table_info';
-import { Time, formatTime } from '@components/utils/datetime';
-import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
-import { Translator } from '@components/utils/types';
+import { matchHasTeam } from '@components/utils/match';
 import { getTournamentIdFromRouter, responseIsValid } from '@components/utils/util';
-import { scoreColour } from '@logic/colors';
 import { MatchWithDetails } from '@openapi';
 import TournamentLayout from '@pages/tournaments/_tournament_layout';
-import { getCourts, getStages, getTournamentById } from '@services/adapter';
-import { getMatchLookup, getStageItemLookup, stringToColour } from '@services/lookups';
-
-function ScheduleRow({
-  data,
-  openMatchModal,
-  stageItemsLookup,
-  matchesLookup,
-}: {
-  data: any;
-  openMatchModal: any;
-  stageItemsLookup: any;
-  matchesLookup: any;
-}) {
-  const { t } = useTranslation();
-  const team1_color = scoreColour(
-    data.match.stage_item_input1_score,
-    data.match.stage_item_input2_score
-  );
-  const team2_color = scoreColour(
-    data.match.stage_item_input2_score,
-    data.match.stage_item_input1_score
-  );
-
-  return (
-    <UnstyledButton style={{ width: '48rem' }}>
-      <Card
-        shadow="sm"
-        radius="md"
-        withBorder
-        mt="md"
-        pt="0rem"
-        onClick={() => {
-          openMatchModal(data.match);
-        }}
-      >
-        <Card.Section withBorder>
-          <Grid pt="0.75rem" pb="0.5rem">
-            <Grid.Col mb="0rem" span={4}>
-              <Text pl="sm" mt="sm" fw={800}>
-                {data.match.court.name}
-              </Text>
-            </Grid.Col>
-            <Grid.Col mb="0rem" span={4}>
-              <Center>
-                <Text mt="sm" fw={800}>
-                  {data.match.start_time != null ? <Time datetime={data.match.start_time} /> : null}
-                </Text>
-              </Center>
-            </Grid.Col>
-            <Grid.Col mb="0rem" span={4}>
-              <Flex justify="right">
-                <Badge
-                  color={stringToColour(`${data.stageItem.id}`)}
-                  variant="outline"
-                  mr="md"
-                  mt="0.8rem"
-                  size="md"
-                >
-                  {data.stageItem.name}
-                </Badge>
-              </Flex>
-            </Grid.Col>
-          </Grid>
-        </Card.Section>
-        <Stack pt="sm">
-          <Grid>
-            <Grid.Col span="auto" pb="0rem">
-              <Text fw={500}>
-                {formatMatchInput1(t, stageItemsLookup, matchesLookup, data.match)}
-              </Text>
-            </Grid.Col>
-            <Grid.Col span="content" pb="0rem">
-              <div
-                style={{
-                  backgroundColor: team1_color,
-                  borderRadius: '0.5rem',
-                  paddingLeft: '1rem',
-                  paddingRight: '1rem',
-                  color: 'white',
-                  fontWeight: 800,
-                }}
-              >
-                {data.match.stage_item_input1_score}
-              </div>
-            </Grid.Col>
-          </Grid>
-          <Grid mb="0rem">
-            <Grid.Col span="auto" pb="0rem">
-              <Text fw={500}>
-                {formatMatchInput2(t, stageItemsLookup, matchesLookup, data.match)}
-              </Text>
-            </Grid.Col>
-            <Grid.Col span="content" pb="0rem">
-              <div
-                style={{
-                  backgroundColor: team2_color,
-                  borderRadius: '0.5rem',
-                  paddingLeft: '1rem',
-                  paddingRight: '1rem',
-                  color: 'white',
-                  fontWeight: 800,
-                }}
-              >
-                {data.match.stage_item_input2_score}
-              </div>
-            </Grid.Col>
-          </Grid>
-        </Stack>
-      </Card>
-    </UnstyledButton>
-  );
-}
-
-function Schedule({
-  t,
-  stageItemsLookup,
-  openMatchModal,
-  matchesLookup,
-}: {
-  t: Translator;
-  stageItemsLookup: any;
-  openMatchModal: CallableFunction;
-  matchesLookup: any;
-}) {
-  const matches: any[] = Object.values(matchesLookup);
-  const sortedMatches = matches
-    .filter((m1: any) => m1.match.start_time != null)
-    .sort((m1: any, m2: any) => (m1.match.court?.name > m2.match.court?.name ? 1 : -1))
-    .sort((m1: any, m2: any) => (m1.match.start_time > m2.match.start_time ? 1 : -1));
-
-  const rows: React.JSX.Element[] = [];
-
-  for (let c = 0; c < sortedMatches.length; c += 1) {
-    const data = sortedMatches[c];
-
-    if (c < 1 || sortedMatches[c - 1].match.start_time) {
-      const startTime = formatTime(data.match.start_time);
-
-      if (c < 1 || startTime !== formatTime(sortedMatches[c - 1].match.start_time)) {
-        rows.push(
-          <Center mt="md" key={`time-${c}`}>
-            <Text size="xl" fw={800}>
-              {startTime}
-            </Text>
-          </Center>
-        );
-      }
-    }
-
-    rows.push(
-      <ScheduleRow
-        key={data.match.id}
-        data={data}
-        openMatchModal={openMatchModal}
-        stageItemsLookup={stageItemsLookup}
-        matchesLookup={matchesLookup}
-      />
-    );
-  }
-
-  if (rows.length < 1) {
-    return (
-      <NoContent
-        title={t('no_matches_title')}
-        description={t('no_matches_description')}
-        icon={<AiOutlineHourglass />}
-      />
-    );
-  }
-
-  const noItemsAlert =
-    matchesLookup.length < 1 ? (
-      <Alert
-        icon={<IconAlertCircle size={16} />}
-        title={t('no_matches_title')}
-        color="gray"
-        radius="md"
-      >
-        {t('drop_match_alert_title')}
-      </Alert>
-    ) : null;
-
-  return (
-    <Group wrap="nowrap" align="top">
-      <div style={{ width: '48rem' }}>
-        {rows}
-        {noItemsAlert}
-      </div>
-    </Group>
-  );
-}
+import { getCourts, getStages, getTeamsForDashboard, getTournamentById } from '@services/adapter';
+import { getMatchLookup, getStageItemLookup } from '@services/lookups';
 
 export default function ResultsPage() {
   const [modalOpened, modalSetOpened] = useState(false);
@@ -231,7 +24,12 @@ export default function ResultsPage() {
   const swrCourtsResponse = getCourts(tournamentData.id);
   const swrTournamentResponse = getTournamentById(tournamentData.id);
   const levels = swrTournamentResponse.data?.data.levels ?? [];
+  const refereesEnabled = swrTournamentResponse.data?.data.referees_enabled ?? false;
   const [levelId, setLevelId] = useQueryState('level', parseAsInteger);
+  const [teamId, setTeamId] = useQueryState('team', parseAsInteger);
+
+  const { teams } = getTeamsForDashboard(tournamentData.id, levelId);
+  const teamOptions = teams.map((team) => ({ value: `${team.id}`, label: team.name }));
 
   const stageItemsLookup = responseIsValid(swrStagesResponse)
     ? getStageItemLookup(swrStagesResponse)
@@ -239,9 +37,13 @@ export default function ResultsPage() {
   const matchesLookup = responseIsValid(swrStagesResponse) ? getMatchLookup(swrStagesResponse) : [];
 
   const filteredMatchesLookup =
-    levelId != null
+    levelId != null || teamId != null
       ? Object.fromEntries(
-          Object.entries(matchesLookup).filter(([, entry]: any) => entry.stage.level_id === levelId)
+          Object.entries(matchesLookup).filter(
+            ([, entry]: any) =>
+              (levelId == null || entry.stage.level_id === levelId) &&
+              (teamId == null || matchHasTeam(entry.match, teamId, refereesEnabled))
+          )
         )
       : matchesLookup;
 
@@ -260,6 +62,24 @@ export default function ResultsPage() {
     modalSetOpened(opened);
   }
 
+  const onLevelChange = (val: string | null) => {
+    const nextLevelId = val === 'all' || val === null ? null : parseInt(val, 10);
+    setLevelId(nextLevelId);
+    if (nextLevelId != null && teamId != null) {
+      setTeamId(null);
+    }
+  };
+
+  const onTeamChange = (nextTeamId: number | null) => {
+    setTeamId(nextTeamId);
+    if (nextTeamId != null && levelId == null) {
+      const team = teams.find((candidate) => candidate.id === nextTeamId);
+      if (team?.level_id != null) {
+        setLevelId(team.level_id);
+      }
+    }
+  };
+
   return (
     <TournamentLayout tournament_id={tournamentData.id}>
       <MatchModal
@@ -274,23 +94,29 @@ export default function ResultsPage() {
       />
       <Group justify="space-between" align="center">
         <Title>{t('results_title')}</Title>
-        {levels.length > 0 && (
-          <Select
-            size="sm"
-            w={160}
-            data={levelSelectData(levels, t('all_levels_label'))}
-            value={levelId != null ? `${levelId}` : 'all'}
-            onChange={(val) => setLevelId(val === 'all' || val === null ? null : parseInt(val, 10))}
-          />
-        )}
+        <Group gap="xs">
+          {levels.length > 0 && (
+            <Select
+              size="sm"
+              w={160}
+              data={levelSelectData(levels, t('all_levels_label'))}
+              value={levelId != null ? `${levelId}` : 'all'}
+              onChange={onLevelChange}
+            />
+          )}
+          <TeamFilterCombobox value={teamId} onChange={onTeamChange} teamOptions={teamOptions} width={160} />
+        </Group>
       </Group>
       <Center mt="1rem">
-        <Schedule
-          t={t}
-          matchesLookup={filteredMatchesLookup}
-          stageItemsLookup={stageItemsLookup}
-          openMatchModal={openMatchModal}
-        />
+        <Group style={{ maxWidth: '48rem', width: '100%' }}>
+          <MatchesList
+            matchesLookup={filteredMatchesLookup}
+            stageItemsLookup={stageItemsLookup}
+            levels={levels}
+            refereesEnabled={refereesEnabled}
+            onMatchClick={openMatchModal}
+          />
+        </Group>
       </Center>
     </TournamentLayout>
   );


### PR DESCRIPTION
## Summary

- Extract `ScheduleRow` and `MatchesList` into `components/matches/` so both the admin Results page and the public dashboard Matches tab share the same card style (level badge, stage badge, state-aware score colours, referee display).
- Admin Results page gains a **team filter** dropdown (alongside the existing level filter) to match the dashboard's filtering capabilities. Clicking a card in admin opens the match modal; clicking in the dashboard still does nothing.
- `dashboard/index.tsx` (Live tab) imports `ScheduleRow` from the shared location and re-exports it.

## Screenshots

### Admin Results (after)
Identical cards to the public dashboard: level + stage badges, state-aware score colours, referee row, and team filter in the header.

![Admin Results](https://github.com/user-attachments/assets/5a4acace-1c13-4d00-9a77-ac0fc23dc31a)

### Public Dashboard — Matches tab (visually unchanged)

![Public Dashboard Matches](https://github.com/user-attachments/assets/b3a5e174-4e2f-4826-b7c3-97b03e4e23ad)

## Test plan

- [ ] Admin Results page shows match cards with court, time, level badge (if applicable), stage badge, team names, colour-coded scores, referee (if enabled).
- [ ] Level filter and team filter both work; selecting a team auto-selects its level when no level is chosen.
- [ ] Clicking a match card in admin opens the match details modal.
- [ ] Public dashboard Matches tab is visually identical and cards are **not** clickable.
- [ ] Public dashboard Live tab (index) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HnaezTupSCASvb7aMcLSu

---
_Generated by [Claude Code](https://claude.ai/code/session_019HnaezTupSCASvb7aMcLSu)_