### PR TITLE
Swiss rework 1/8: creation generates placeholder skeleton (#150)

### DIFF
--- a/backend/alembic/versions/c3d5a8f2e1b9_swiss_placeholder_columns.py
+++ b/backend/alembic/versions/c3d5a8f2e1b9_swiss_placeholder_columns.py
@@ -1,0 +1,47 @@
+"""Swiss placeholder skeleton: games_per_player, round lifecycle state, match slot columns
+
+Revision ID: c3d5a8f2e1b9
+Revises: b8f2a1c4d6e7
+Create Date: 2026-06-21 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str | None = "c3d5a8f2e1b9"
+down_revision: str | None = "b8f2a1c4d6e7"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column("stage_items", sa.Column("games_per_player", sa.Integer(), nullable=True))
+
+    op.execute("CREATE TYPE round_lifecycle_state AS ENUM ('PLACEHOLDER', 'RESOLVED', 'LOCKED')")
+    op.add_column(
+        "rounds",
+        sa.Column(
+            "lifecycle_state",
+            sa.Enum("PLACEHOLDER", "RESOLVED", "LOCKED", name="round_lifecycle_state"),
+            nullable=True,
+        ),
+    )
+    op.add_column("rounds", sa.Column("is_pinned", sa.Boolean(), nullable=True))
+
+    op.add_column("matches", sa.Column("input1_slot", sa.Integer(), nullable=True))
+    op.add_column("matches", sa.Column("input2_slot", sa.Integer(), nullable=True))
+    op.add_column("matches", sa.Column("referee_slot", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("matches", "referee_slot")
+    op.drop_column("matches", "input2_slot")
+    op.drop_column("matches", "input1_slot")
+
+    op.drop_column("rounds", "is_pinned")
+    op.drop_column("rounds", "lifecycle_state")
+    op.execute("DROP TYPE round_lifecycle_state")
+
+    op.drop_column("stage_items", "games_per_player")

--- a/backend/bracket/logic/scheduling/builder.py
+++ b/backend/bracket/logic/scheduling/builder.py
@@ -1,4 +1,5 @@
 from fastapi import HTTPException
+from heliclockter import datetime_utc
 
 from bracket.logic.ranking.calculation import recalculate_ranking_for_stage_item
 from bracket.logic.scheduling.elimination import (
@@ -9,7 +10,9 @@ from bracket.logic.scheduling.round_robin import (
     build_round_robin_stage_item,
     get_number_of_rounds_to_create_round_robin,
 )
-from bracket.models.db.round import RoundInsertable
+from bracket.logic.scheduling.swiss_skeleton import build_swiss_skeleton
+from bracket.models.db.match import MatchCreateBody
+from bracket.models.db.round import RoundInsertable, RoundLifecycleState
 from bracket.models.db.stage_item import StageItem, StageType
 from bracket.models.db.stage_item_inputs import (
     StageItemInputFinal,
@@ -19,8 +22,10 @@ from bracket.models.db.stage_item_inputs import (
 )
 from bracket.models.db.team import FullTeamWithPlayers
 from bracket.models.db.util import StageWithStageItems
+from bracket.sql.matches import sql_create_match
 from bracket.sql.rounds import get_next_round_name, sql_create_round
 from bracket.sql.stage_items import get_stage_item
+from bracket.sql.tournaments import sql_get_tournament
 from bracket.utils.id_types import StageId, StageItemId, TournamentId
 from tests.integration_tests.mocks import MOCK_NOW
 
@@ -50,6 +55,41 @@ async def create_rounds_for_new_stage_item(
         )
 
 
+async def build_swiss_placeholder_skeleton(
+    tournament_id: TournamentId, stage_item: StageItem
+) -> None:
+    """Generate placeholder rounds and slot-matches for a Swiss stage item on creation."""
+    if stage_item.games_per_player is None:
+        return
+    tournament = await sql_get_tournament(tournament_id)
+    skeleton = build_swiss_skeleton(stage_item.team_count, stage_item.games_per_player)
+    for round_skeleton in skeleton.rounds:
+        round_id = await sql_create_round(
+            RoundInsertable(
+                created=datetime_utc.now(),
+                is_draft=False,
+                stage_item_id=stage_item.id,
+                name=await get_next_round_name(tournament_id, stage_item.id),
+                lifecycle_state=RoundLifecycleState.PLACEHOLDER,
+            )
+        )
+        for slot1, slot2 in round_skeleton.matches:
+            await sql_create_match(
+                MatchCreateBody(
+                    round_id=round_id,
+                    court_id=None,
+                    stage_item_input1_id=None,
+                    stage_item_input2_id=None,
+                    stage_item_input1_winner_from_match_id=None,
+                    stage_item_input2_winner_from_match_id=None,
+                    duration_minutes=tournament.duration_minutes,
+                    custom_duration_minutes=None,
+                    input1_slot=slot1,
+                    input2_slot=slot2,
+                )
+            )
+
+
 async def build_matches_for_stage_item(stage_item: StageItem, tournament_id: TournamentId) -> None:
     await create_rounds_for_new_stage_item(tournament_id, stage_item)
     stage_item_with_rounds = await get_stage_item(tournament_id, stage_item.id)
@@ -60,6 +100,7 @@ async def build_matches_for_stage_item(stage_item: StageItem, tournament_id: Tou
         case StageType.SINGLE_ELIMINATION:
             await build_single_elimination_stage_item(tournament_id, stage_item_with_rounds)
         case StageType.SWISS:
+            await build_swiss_placeholder_skeleton(tournament_id, stage_item)
             return None
 
         case _:

--- a/backend/bracket/logic/scheduling/swiss_skeleton.py
+++ b/backend/bracket/logic/scheduling/swiss_skeleton.py
@@ -1,0 +1,60 @@
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RoundSkeleton:
+    matches: tuple[tuple[int, int], ...]
+    bye_slot: int | None
+
+
+@dataclass(frozen=True)
+class SwissSkeleton:
+    rounds: tuple[RoundSkeleton, ...]
+
+    @property
+    def round_count(self) -> int:
+        return len(self.rounds)
+
+
+def _circle_method(n: int) -> list[list[tuple[int, int]]]:
+    """Round-robin schedule for n teams (n even) via circle method. Returns n-1 rounds."""
+    teams = list(range(n))
+    rounds = []
+    for _ in range(n - 1):
+        rounds.append([(teams[i], teams[n - 1 - i]) for i in range(n // 2)])
+        teams = [teams[0]] + [teams[-1]] + teams[1:-1]
+    return rounds
+
+
+def build_swiss_skeleton(team_count: int, games_per_player: int) -> SwissSkeleton:
+    """
+    Pure function: compute the round/match/bye structure for a Swiss stage item.
+
+    Slots are 0-indexed integers.  For odd team_count a rotating bye is included;
+    for even team_count every round is a perfect matching with no bye.
+    The number of rounds is the minimum needed so every slot reaches at least
+    games_per_player games.
+    """
+    has_bye = team_count % 2 == 1
+    effective_n = team_count + 1 if has_bye else team_count
+
+    if has_bye:
+        rounds_needed = math.ceil(games_per_player * team_count / (team_count - 1))
+    else:
+        rounds_needed = games_per_player
+
+    base = _circle_method(effective_n)
+
+    result: list[RoundSkeleton] = []
+    for i in range(rounds_needed):
+        matches: list[tuple[int, int]] = []
+        bye_slot: int | None = None
+        for a, b in base[i % len(base)]:
+            if a == team_count or b == team_count:
+                bye_slot = b if a == team_count else a
+            else:
+                matches.append((a, b))
+        result.append(RoundSkeleton(matches=tuple(matches), bye_slot=bye_slot))
+
+    return SwissSkeleton(rounds=tuple(result))

--- a/backend/bracket/models/db/match.py
+++ b/backend/bracket/models/db/match.py
@@ -58,6 +58,9 @@ class MatchInsertable(MatchBaseInsertable):
     stage_item_input2_id: StageItemInputId | None = None
     stage_item_input1_winner_from_match_id: MatchId | None = None
     stage_item_input2_winner_from_match_id: MatchId | None = None
+    input1_slot: int | None = None
+    input2_slot: int | None = None
+    referee_slot: int | None = None
 
 
 class Match(MatchInsertable):
@@ -152,6 +155,9 @@ class MatchCreateBodyFrontend(BaseModelORM):
 class MatchCreateBody(MatchCreateBodyFrontend):
     duration_minutes: int
     custom_duration_minutes: int | None = None
+    input1_slot: int | None = None
+    input2_slot: int | None = None
+    referee_slot: int | None = None
 
 
 class MatchRescheduleBody(BaseModelORM):

--- a/backend/bracket/models/db/round.py
+++ b/backend/bracket/models/db/round.py
@@ -1,7 +1,16 @@
+from enum import auto
+
 from heliclockter import datetime_utc
 
 from bracket.models.db.shared import BaseModelORM
 from bracket.utils.id_types import RoundId, StageItemId
+from bracket.utils.types import EnumAutoStr
+
+
+class RoundLifecycleState(EnumAutoStr):
+    PLACEHOLDER = auto()
+    RESOLVED = auto()
+    LOCKED = auto()
 
 
 class RoundInsertable(BaseModelORM):
@@ -9,6 +18,8 @@ class RoundInsertable(BaseModelORM):
     stage_item_id: StageItemId
     is_draft: bool
     name: str
+    lifecycle_state: RoundLifecycleState | None = None
+    is_pinned: bool | None = None
 
 
 class Round(RoundInsertable):

--- a/backend/bracket/models/db/stage_item.py
+++ b/backend/bracket/models/db/stage_item.py
@@ -27,6 +27,7 @@ class StageItemInsertable(BaseModelORM):
     type: StageType
     team_count: int = Field(ge=2, le=64)
     ranking_id: RankingId | None = None
+    games_per_player: int | None = None
 
 
 class StageItem(StageItemInsertable):
@@ -49,6 +50,7 @@ class StageItemCreateBody(BaseModelORM):
     type: StageType
     team_count: int = Field(ge=2, le=64)
     ranking_id: RankingId | None = None
+    games_per_player: int | None = None
 
     def get_name_or_default_name(self) -> str:
         return (

--- a/backend/bracket/schema.py
+++ b/backend/bracket/schema.py
@@ -114,6 +114,7 @@ stage_items = Table(
         ),
         nullable=False,
     ),
+    Column("games_per_player", Integer, nullable=True),
 )
 
 stage_item_inputs = Table(
@@ -148,6 +149,12 @@ rounds = Table(
     Column("created", DateTimeTZ, nullable=False, server_default=func.now()),
     Column("is_draft", Boolean, nullable=False),
     Column("stage_item_id", BigInteger, ForeignKey("stage_items.id"), nullable=False),
+    Column(
+        "lifecycle_state",
+        Enum("PLACEHOLDER", "RESOLVED", "LOCKED", name="round_lifecycle_state"),
+        nullable=True,
+    ),
+    Column("is_pinned", Boolean, nullable=True),
 )
 
 
@@ -206,6 +213,9 @@ matches = Table(
         index=True,
     ),
     Column("completed_at", DateTimeTZ, nullable=True),
+    Column("input1_slot", Integer, nullable=True),
+    Column("input2_slot", Integer, nullable=True),
+    Column("referee_slot", Integer, nullable=True),
     CheckConstraint(
         "referee_stage_item_input_id IS NULL OR referee_name IS NULL",
         name="matches_at_most_one_referee",

--- a/backend/bracket/sql/matches.py
+++ b/backend/bracket/sql/matches.py
@@ -57,7 +57,10 @@ async def sql_create_match(match: MatchCreateBody) -> Match:
             stage_item_input1_conflict,
             stage_item_input2_conflict,
             created,
-            state
+            state,
+            input1_slot,
+            input2_slot,
+            referee_slot
         )
         VALUES (
             :round_id,
@@ -73,7 +76,10 @@ async def sql_create_match(match: MatchCreateBody) -> Match:
             false,
             false,
             NOW(),
-            'NOT_STARTED'
+            'NOT_STARTED',
+            :input1_slot,
+            :input2_slot,
+            :referee_slot
         )
         RETURNING *
     """

--- a/backend/bracket/sql/rounds.py
+++ b/backend/bracket/sql/rounds.py
@@ -8,8 +8,8 @@ from bracket.utils.id_types import RoundId, StageItemId, TournamentId
 
 async def sql_create_round(round_: RoundInsertable) -> RoundId:
     query = """
-        INSERT INTO rounds (created, is_draft, name, stage_item_id)
-        VALUES (NOW(), :is_draft, :name, :stage_item_id)
+        INSERT INTO rounds (created, is_draft, name, stage_item_id, lifecycle_state, is_pinned)
+        VALUES (NOW(), :is_draft, :name, :stage_item_id, :lifecycle_state, :is_pinned)
         RETURNING id
         """
     result: RoundId = await database.fetch_val(
@@ -18,6 +18,10 @@ async def sql_create_round(round_: RoundInsertable) -> RoundId:
             "name": round_.name,
             "is_draft": round_.is_draft,
             "stage_item_id": round_.stage_item_id,
+            "lifecycle_state": round_.lifecycle_state.value
+            if round_.lifecycle_state is not None
+            else None,
+            "is_pinned": round_.is_pinned,
         },
     )
     return result

--- a/backend/bracket/sql/stage_items.py
+++ b/backend/bracket/sql/stage_items.py
@@ -15,8 +15,8 @@ async def sql_create_stage_item(
     tournament_id: TournamentId, stage_item: StageItemCreateBody
 ) -> StageItem:
     query = """
-            INSERT INTO stage_items (type, stage_id, name, team_count, ranking_id)
-            VALUES (:stage_item_type, :stage_id, :name, :team_count, :ranking_id)
+            INSERT INTO stage_items (type, stage_id, name, team_count, ranking_id, games_per_player)
+            VALUES (:stage_item_type, :stage_id, :name, :team_count, :ranking_id, :games_per_player)
             RETURNING *
             """
     result = await database.fetch_one(
@@ -29,6 +29,7 @@ async def sql_create_stage_item(
             "ranking_id": stage_item.ranking_id
             if stage_item.ranking_id
             else (await get_default_ranking_for_stage(tournament_id, stage_item.stage_id)).id,
+            "games_per_player": stage_item.games_per_player,
         },
     )
     if result is None:

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -463,6 +463,28 @@
             "title": "Id",
             "type": "integer"
           },
+          "input1_slot": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input1 Slot"
+          },
+          "input2_slot": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input2 Slot"
+          },
           "precedence_conflict": {
             "default": false,
             "title": "Precedence Conflict",
@@ -483,6 +505,17 @@
               }
             ],
             "title": "Referee Name"
+          },
+          "referee_slot": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Referee Slot"
           },
           "referee_stage_item_input_id": {
             "anyOf": [
@@ -638,6 +671,9 @@
           "stage_item_input2_id",
           "stage_item_input1_winner_from_match_id",
           "stage_item_input2_winner_from_match_id",
+          "input1_slot",
+          "input2_slot",
+          "referee_slot",
           "id",
           "stage_item_input1",
           "stage_item_input2"
@@ -982,6 +1018,28 @@
             "title": "Id",
             "type": "integer"
           },
+          "input1_slot": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input1 Slot"
+          },
+          "input2_slot": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input2 Slot"
+          },
           "level_id": {
             "anyOf": [
               {
@@ -1030,6 +1088,17 @@
               }
             ],
             "title": "Referee Name"
+          },
+          "referee_slot": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Referee Slot"
           },
           "referee_stage_item_input_id": {
             "anyOf": [
@@ -1185,6 +1254,9 @@
           "stage_item_input2_id",
           "stage_item_input1_winner_from_match_id",
           "stage_item_input2_winner_from_match_id",
+          "input1_slot",
+          "input2_slot",
+          "referee_slot",
           "id",
           "stage_item_input1",
           "stage_item_input2",
@@ -1259,6 +1331,28 @@
             "title": "Id",
             "type": "integer"
           },
+          "input1_slot": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input1 Slot"
+          },
+          "input2_slot": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input2 Slot"
+          },
           "level_id": {
             "anyOf": [
               {
@@ -1307,6 +1401,17 @@
               }
             ],
             "title": "Referee Name"
+          },
+          "referee_slot": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Referee Slot"
           },
           "referee_stage_item_input_id": {
             "anyOf": [
@@ -1456,6 +1561,9 @@
           "stage_item_input2_id",
           "stage_item_input1_winner_from_match_id",
           "stage_item_input2_winner_from_match_id",
+          "input1_slot",
+          "input2_slot",
+          "referee_slot",
           "id",
           "stage_item_input1",
           "stage_item_input2",
@@ -1988,6 +2096,15 @@
         "title": "RoundCreateBody",
         "type": "object"
       },
+      "RoundLifecycleState": {
+        "enum": [
+          "PLACEHOLDER",
+          "RESOLVED",
+          "LOCKED"
+        ],
+        "title": "RoundLifecycleState",
+        "type": "string"
+      },
       "RoundUpdateBody": {
         "properties": {
           "is_draft": {
@@ -2021,6 +2138,27 @@
             "title": "Is Draft",
             "type": "boolean"
           },
+          "is_pinned": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Pinned"
+          },
+          "lifecycle_state": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RoundLifecycleState"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "matches": {
             "items": {
               "anyOf": [
@@ -2049,6 +2187,8 @@
           "stage_item_id",
           "is_draft",
           "name",
+          "lifecycle_state",
+          "is_pinned",
           "id",
           "matches"
         ],
@@ -2501,6 +2641,17 @@
       },
       "StageItemCreateBody": {
         "properties": {
+          "games_per_player": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Games Per Player"
+          },
           "name": {
             "anyOf": [
               {
@@ -2542,7 +2693,8 @@
           "name",
           "type",
           "team_count",
-          "ranking_id"
+          "ranking_id",
+          "games_per_player"
         ],
         "title": "StageItemCreateBody",
         "type": "object"
@@ -2961,6 +3113,17 @@
             "title": "Created",
             "type": "string"
           },
+          "games_per_player": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Games Per Player"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
@@ -3029,6 +3192,7 @@
           "type",
           "team_count",
           "ranking_id",
+          "games_per_player",
           "id",
           "rounds",
           "inputs",

--- a/backend/tests/integration_tests/api/stages_test.py
+++ b/backend/tests/integration_tests/api/stages_test.py
@@ -87,12 +87,15 @@ async def test_stages_endpoint(
                                     "stage_item_id": stage_item_inserted.id,
                                     "created": DUMMY_MOCK_TIME.isoformat().replace("+00:00", "Z"),
                                     "is_draft": False,
+                                    "lifecycle_state": None,
+                                    "is_pinned": None,
                                     "name": "Round 1",
                                     "matches": [],
                                 }
                             ],
                             "inputs": [],
                             "type_name": "Round robin",
+                            "games_per_player": None,
                         }
                     ],
                 }

--- a/backend/tests/integration_tests/api/swiss_placeholder_test.py
+++ b/backend/tests/integration_tests/api/swiss_placeholder_test.py
@@ -1,0 +1,70 @@
+import pytest
+
+from bracket.models.db.stage_item import StageType
+from bracket.schema import matches, rounds, stage_item_inputs, stage_items, stages
+from bracket.sql.stages import get_full_tournament_details
+from bracket.utils.dummy_records import DUMMY_STAGE1
+from bracket.utils.http import HTTPMethod
+from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
+from tests.integration_tests.models import AuthContext
+from tests.integration_tests.sql import (
+    assert_row_count_and_clear,
+    inserted_stage,
+)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_swiss_placeholder_skeleton_created_on_create(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Creating a Swiss stage item with games_per_player generates placeholder rounds and
+    slot-matches.  4 teams, N=2 → 2 rounds × 2 matches each; matches have slot ids set but
+    no concrete team assignments yet."""
+    async with inserted_stage(
+        DUMMY_STAGE1.model_copy(update={"tournament_id": auth_context.tournament.id})
+    ) as stage_inserted:
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                "stage_items",
+                auth_context,
+                json={
+                    "type": StageType.SWISS.value,
+                    "team_count": 4,
+                    "stage_id": stage_inserted.id,
+                    "games_per_player": 2,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        stages_in_tournament = await get_full_tournament_details(auth_context.tournament.id)
+        stage_item = next(
+            si
+            for stage in stages_in_tournament
+            if stage.id == stage_inserted.id
+            for si in stage.stage_items
+        )
+
+        try:
+            # 4 teams (even), N=2 → exactly 2 rounds
+            assert len(stage_item.rounds) == 2
+            for round_ in stage_item.rounds:
+                # 4 teams ÷ 2 = 2 matches per round
+                assert len(round_.matches) == 2
+                for match in round_.matches:
+                    # Placeholder: no concrete teams assigned yet
+                    assert match.stage_item_input1_id is None
+                    assert match.stage_item_input2_id is None
+                    # Abstract slot ids must be set and distinct
+                    assert match.input1_slot is not None
+                    assert match.input2_slot is not None
+                    assert match.input1_slot != match.input2_slot
+        finally:
+            # Clean up in dependency order so the stage FK is satisfied when
+            # the inserted_stage context manager runs its DELETE.
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)

--- a/backend/tests/unit_tests/test_swiss_skeleton.py
+++ b/backend/tests/unit_tests/test_swiss_skeleton.py
@@ -1,0 +1,84 @@
+import pytest
+
+from bracket.logic.scheduling.swiss_skeleton import build_swiss_skeleton
+
+
+def test_even_teams_round_count() -> None:
+    skeleton = build_swiss_skeleton(team_count=4, games_per_player=3)
+    assert skeleton.round_count == 3
+
+
+def test_odd_teams_round_count() -> None:
+    # ceil(3 * 5 / 4) = ceil(3.75) = 4
+    skeleton = build_swiss_skeleton(team_count=5, games_per_player=3)
+    assert skeleton.round_count == 4
+
+
+def test_odd_teams_n_not_exact_divisor() -> None:
+    # 5 teams, N=2 → ceil(2 * 5 / 4) = ceil(2.5) = 3 rounds
+    skeleton = build_swiss_skeleton(team_count=5, games_per_player=2)
+    assert skeleton.round_count == 3
+
+
+@pytest.mark.parametrize(
+    "team_count, games_per_player",
+    [
+        (4, 3),
+        (5, 3),
+        (5, 4),
+        (6, 5),
+        (3, 3),
+        (7, 4),
+    ],
+)
+def test_all_slots_reach_games_per_player(team_count: int, games_per_player: int) -> None:
+    skeleton = build_swiss_skeleton(team_count=team_count, games_per_player=games_per_player)
+    games: list[int] = [0] * team_count
+    for round_ in skeleton.rounds:
+        for s1, s2 in round_.matches:
+            games[s1] += 1
+            games[s2] += 1
+    assert all(g >= games_per_player for g in games)
+
+
+@pytest.mark.parametrize(
+    "team_count, games_per_player",
+    [(4, 3), (5, 3), (6, 4), (7, 5)],
+)
+def test_no_double_booking_per_round(team_count: int, games_per_player: int) -> None:
+    skeleton = build_swiss_skeleton(team_count=team_count, games_per_player=games_per_player)
+    for round_ in skeleton.rounds:
+        used: set[int] = set()
+        for s1, s2 in round_.matches:
+            assert s1 not in used
+            assert s2 not in used
+            used.add(s1)
+            used.add(s2)
+        if round_.bye_slot is not None:
+            assert round_.bye_slot not in used
+
+
+def test_rotating_bye_all_slots_covered_in_one_cycle() -> None:
+    # With 5 teams, 5 rounds = one full cycle; every slot gets exactly 1 bye
+    skeleton = build_swiss_skeleton(team_count=5, games_per_player=4)
+    assert skeleton.round_count == 5
+    bye_slots = [r.bye_slot for r in skeleton.rounds if r.bye_slot is not None]
+    assert sorted(bye_slots) == [0, 1, 2, 3, 4]
+
+
+def test_even_teams_have_no_bye() -> None:
+    skeleton = build_swiss_skeleton(team_count=6, games_per_player=4)
+    for round_ in skeleton.rounds:
+        assert round_.bye_slot is None
+
+
+@pytest.mark.parametrize("team_count, games_per_player", [(3, 2), (5, 3), (6, 4), (8, 5)])
+def test_slot_indices_are_valid(team_count: int, games_per_player: int) -> None:
+    skeleton = build_swiss_skeleton(team_count=team_count, games_per_player=games_per_player)
+    valid = set(range(team_count))
+    for round_ in skeleton.rounds:
+        for s1, s2 in round_.matches:
+            assert s1 in valid, f"slot {s1} out of range for team_count={team_count}"
+            assert s2 in valid, f"slot {s2} out of range for team_count={team_count}"
+        if round_.bye_slot is not None:
+            assert round_.bye_slot in valid


### PR DESCRIPTION
- Pure `build_swiss_skeleton` (circle-method, no DB) computes round count,
  slot-pair matches, and rotating bye for any team count and games-per-player N
- 19 unit tests covering even/odd teams, rotating bye, no-double-booking,
  all-slots-reach-N, and valid slot indices
- Alembic migration adds `stage_items.games_per_player` (nullable int),
  `rounds.lifecycle_state` enum + `is_pinned`, and
  `matches.input1_slot / input2_slot / referee_slot` (nullable ints)
- `build_swiss_placeholder_skeleton` generates placeholder rounds and
  slot-matches on Swiss stage-item creation; matches carry slot ids but null
  team assignments
- Integration test: POST /stage_items with type=SWISS + games_per_player=2
  and team_count=4 produces exactly 2 rounds × 2 slot-matches each

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Mm5zjyemwnSA47QKFvXuR