### PR TITLE
feat(swiss): resolve round 1 to concrete teams on stage activation (#152)

### DIFF
--- a/backend/bracket/logic/scheduling/handle_stage_activation.py
+++ b/backend/bracket/logic/scheduling/handle_stage_activation.py
@@ -8,16 +8,25 @@ from bracket.logic.ranking.calculation import (
     determine_team_ranking_for_stage_item,
 )
 from bracket.logic.ranking.statistics import TeamStatistics
+from bracket.logic.scheduling.swiss_round_pairing import select_round_pairing
+from bracket.logic.scheduling.swiss_slot_assigner import (
+    assign_pairs_to_slots,
+    skeleton_from_slot_pairs,
+)
 from bracket.models.db.match import MatchState
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.stage_item import StageType
 from bracket.models.db.stage_item_inputs import (
     StageItemInputEmpty,
     StageItemInputFinal,
     StageItemInputTentative,
 )
 from bracket.models.db.team import Team
-from bracket.models.db.util import StageWithStageItems
-from bracket.sql.matches import clear_scores_for_matches_in_stage_item
+from bracket.models.db.util import StageItemWithRounds, StageWithStageItems
+from bracket.sql.matches import clear_scores_for_matches_in_stage_item, sql_set_input_ids_for_match
 from bracket.sql.rankings import get_ranking_for_stage_item
+from bracket.sql.referees import sql_set_match_referee_slot
+from bracket.sql.rounds import set_round_lifecycle_state
 from bracket.sql.stage_item_inputs import (
     get_stage_item_input_by_id,
     sql_set_team_id_for_stage_item_input,
@@ -147,9 +156,59 @@ async def get_updates_to_inputs_in_activated_stage(
     return dict(result)
 
 
+async def _resolve_round_1_for_swiss_stage_item(
+    tournament_id: TournamentId,
+    stage_item: StageItemWithRounds,
+) -> None:
+    """Fill in concrete team assignments for round 1 of a Swiss stage item."""
+    placeholder_round = next(
+        (r for r in stage_item.rounds if r.lifecycle_state == RoundLifecycleState.PLACEHOLDER),
+        None,
+    )
+    if placeholder_round is None:
+        return
+
+    inputs = [i for i in stage_item.inputs if isinstance(i, StageItemInputFinal) and i.team.active]
+    if not inputs:
+        return
+
+    slot_pairs = [
+        (m.input1_slot, m.input2_slot)
+        for m in placeholder_round.matches
+        if m.input1_slot is not None and m.input2_slot is not None
+    ]
+    bye_slot = next(
+        (m.referee_slot for m in placeholder_round.matches if m.referee_slot is not None),
+        None,
+    )
+
+    pairs, bye = select_round_pairing(inputs, [])
+    skeleton = skeleton_from_slot_pairs(slot_pairs, bye_slot)
+    slot_mapping = assign_pairs_to_slots(pairs, bye, skeleton)
+
+    for match in placeholder_round.matches:
+        if match.input1_slot is None or match.input2_slot is None:
+            continue
+        input1_id = slot_mapping.get(match.input1_slot)
+        input2_id = slot_mapping.get(match.input2_slot)
+        if input1_id is None or input2_id is None:
+            continue
+        await sql_set_input_ids_for_match(placeholder_round.id, match.id, [input1_id, input2_id])
+
+        if match.referee_slot is not None:
+            ref_id = slot_mapping.get(match.referee_slot)
+            if ref_id is not None:
+                await sql_set_match_referee_slot(match.id, ref_id)
+
+    await set_round_lifecycle_state(
+        placeholder_round.id, tournament_id, RoundLifecycleState.RESOLVED
+    )
+
+
 async def update_matches_in_activated_stage(tournament_id: TournamentId, stage_id: StageId) -> None:
     """
     Sets the team_id for stage item inputs of the newly activated stage.
+    For Swiss stage items also resolves round 1 placeholder matches.
     """
     updates_per_stage_item = await get_updates_to_inputs_in_activated_stage(tournament_id, stage_id)
     for stage_item_updates in updates_per_stage_item.values():
@@ -157,6 +216,16 @@ async def update_matches_in_activated_stage(tournament_id: TournamentId, stage_i
             await sql_set_team_id_for_stage_item_input(
                 tournament_id, update.stage_item_input.id, update.team.id
             )
+
+    # Re-fetch after tentative inputs are resolved so inputs are Final
+    stages = await get_full_tournament_details(tournament_id, stage_id=stage_id)
+    activated_stage = next((s for s in stages if s.id == stage_id), None)
+    if activated_stage is None:
+        return
+
+    for stage_item in activated_stage.stage_items:
+        if stage_item.type == StageType.SWISS:
+            await _resolve_round_1_for_swiss_stage_item(tournament_id, stage_item)
 
 
 async def update_matches_in_deactivated_stage(

--- a/backend/bracket/logic/scheduling/swiss_round_pairing.py
+++ b/backend/bracket/logic/scheduling/swiss_round_pairing.py
@@ -1,0 +1,65 @@
+"""Pure Swiss round pairing selector (issue #152)."""
+
+from collections.abc import Sequence
+
+from bracket.logic.scheduling.ladder_teams import get_possible_upcoming_matches_for_swiss
+from bracket.models.db.match import MatchFilter
+from bracket.models.db.stage_item_inputs import StageItemInput, StageItemInputFinal
+from bracket.models.db.util import RoundWithMatches
+from bracket.utils.id_types import StageItemInputId
+
+SWISS_MATCH_FILTER = MatchFilter(
+    elo_diff_threshold=200,
+    iterations=2000,
+    only_recommended=True,
+    limit=50,
+)
+
+
+def select_round_pairing(
+    inputs: Sequence[StageItemInput],
+    previous_rounds: list[RoundWithMatches],
+) -> tuple[list[tuple[StageItemInput, StageItemInput]], StageItemInput | None]:
+    """Select a complete perfect matching + optional bye for one Swiss round.
+
+    Uses hardcoded optimizer defaults (elo-diff 200, iterations 2000,
+    only-recommended, limit 50) and greedy completion to guarantee a full
+    matching even when the optimizer's suggestion list is short.
+    """
+    active = [i for i in inputs if not isinstance(i, StageItemInputFinal) or i.team.active]
+
+    bye: StageItemInput | None = None
+    if len(active) % 2 == 1:
+        bye = _pick_bye(active, previous_rounds)
+        pool = [i for i in active if i.id != bye.id]
+    else:
+        pool = list(active)
+
+    suggestions = get_possible_upcoming_matches_for_swiss(SWISS_MATCH_FILTER, previous_rounds, pool)
+
+    used: set[StageItemInputId] = set()
+    pairs: list[tuple[StageItemInput, StageItemInput]] = []
+
+    for sug in suggestions:
+        id1 = sug.stage_item_input1.id
+        id2 = sug.stage_item_input2.id
+        if id1 not in used and id2 not in used:
+            pairs.append((sug.stage_item_input1, sug.stage_item_input2))
+            used.add(id1)
+            used.add(id2)
+
+    # Fallback: pair remaining inputs when the optimizer falls short (rematch may be unavoidable)
+    remaining = [i for i in pool if i.id not in used]
+    while len(remaining) >= 2:
+        pairs.append((remaining[0], remaining[1]))
+        remaining = remaining[2:]
+
+    return pairs, bye
+
+
+def _pick_bye(
+    inputs: Sequence[StageItemInput],
+    previous_rounds: list[RoundWithMatches],
+) -> StageItemInput:
+    """Rotate bye through inputs by round count, falling back to index 0."""
+    return inputs[len(previous_rounds) % len(inputs)]

--- a/backend/bracket/logic/scheduling/swiss_slot_assigner.py
+++ b/backend/bracket/logic/scheduling/swiss_slot_assigner.py
@@ -1,0 +1,64 @@
+"""Pure pair→slot assigner for Swiss round resolution (issue #152)."""
+
+import itertools
+
+from bracket.logic.scheduling.swiss_skeleton import RoundSkeleton
+from bracket.models.db.stage_item_inputs import StageItemInput
+from bracket.utils.id_types import StageItemInputId
+
+
+def assign_pairs_to_slots(
+    pairs: list[tuple[StageItemInput, StageItemInput]],
+    bye: StageItemInput | None,
+    round_skeleton: RoundSkeleton,
+    previous_slot_assignments: list[dict[int, StageItemInputId]] | None = None,
+) -> dict[int, StageItemInputId]:
+    """Map pairs onto skeleton slot indices, keeping each pair in the same match slot.
+
+    Returns {slot_index: stage_item_input_id}. The bye team is placed in the
+    bye_slot (referee position) and does not occupy any playing slot.
+
+    When previous_slot_assignments is provided, the function picks the permutation
+    of pairs that minimises total slot reuse from prior rounds (fairness objective).
+    """
+    match_slots = list(round_skeleton.matches)
+    best: dict[int, StageItemInputId] | None = None
+    best_score = len(pairs) * 2 + 1  # worse than worst possible
+
+    for pair_order in itertools.permutations(range(len(pairs))):
+        candidate: dict[int, StageItemInputId] = {}
+        for match_idx, pair_idx in enumerate(pair_order):
+            slot1, slot2 = match_slots[match_idx]
+            inp1, inp2 = pairs[pair_idx]
+            candidate[slot1] = inp1.id
+            candidate[slot2] = inp2.id
+
+        score = _slot_reuse_count(candidate, previous_slot_assignments)
+        if best is None or score < best_score:
+            best = candidate
+            best_score = score
+
+    assert best is not None
+    if bye is not None and round_skeleton.bye_slot is not None:
+        best[round_skeleton.bye_slot] = bye.id
+
+    return best
+
+
+def skeleton_from_slot_pairs(
+    slot_pairs: list[tuple[int, int]],
+    bye_slot: int | None,
+) -> RoundSkeleton:
+    """Reconstruct a RoundSkeleton from a round's match slot pairs and bye slot."""
+    return RoundSkeleton(matches=tuple(slot_pairs), bye_slot=bye_slot)
+
+
+def _slot_reuse_count(
+    candidate: dict[int, StageItemInputId],
+    history: list[dict[int, StageItemInputId]] | None,
+) -> int:
+    """Count how many teams are in the same slot they occupied in the most recent round."""
+    if not history:
+        return 0
+    prev = history[-1]
+    return sum(1 for slot, inp_id in candidate.items() if prev.get(slot) == inp_id)

--- a/backend/tests/unit_tests/test_swiss_round_pairing.py
+++ b/backend/tests/unit_tests/test_swiss_round_pairing.py
@@ -1,0 +1,139 @@
+"""Unit tests for the Swiss round pairing selector (issue #152)."""
+
+from decimal import Decimal
+
+from bracket.models.db.match import Match, MatchWithDetailsDefinitive
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.stage_item_inputs import StageItemInputFinal
+from bracket.models.db.team import Team
+from bracket.models.db.util import RoundWithMatches
+from bracket.utils.dummy_records import DUMMY_MATCH1, DUMMY_MOCK_TIME, DUMMY_TEAM1
+from bracket.utils.id_types import (
+    MatchId,
+    RoundId,
+    StageItemId,
+    StageItemInputId,
+    TeamId,
+    TournamentId,
+)
+
+
+def _input(n: int, elo: int = 1000) -> StageItemInputFinal:
+    """Build a StageItemInputFinal with a unique id and optional ELO."""
+    return StageItemInputFinal(
+        id=StageItemInputId(n),
+        slot=n,
+        tournament_id=TournamentId(-1),
+        team_id=TeamId(n),
+        points=Decimal(str(elo)),
+        wins=0,
+        draws=0,
+        losses=0,
+        team=Team(
+            **{**DUMMY_TEAM1.model_dump(), "id": TeamId(n), "active": True},
+        ),
+    )
+
+
+def _round_with_match(
+    round_id: int,
+    inp1: StageItemInputFinal,
+    inp2: StageItemInputFinal,
+) -> RoundWithMatches:
+    """Build a completed round with a single match between inp1 and inp2."""
+    base = Match.model_validate(
+        DUMMY_MATCH1.model_dump()
+        | {
+            "id": MatchId(round_id),
+            "stage_item_input1_id": inp1.id,
+            "stage_item_input2_id": inp2.id,
+        }
+    )
+    match = MatchWithDetailsDefinitive(
+        **base.model_dump(),
+        stage_item_input1=inp1,
+        stage_item_input2=inp2,
+        court=None,
+    )
+    return RoundWithMatches(
+        id=RoundId(round_id),
+        matches=[match],
+        lifecycle_state=RoundLifecycleState.LOCKED,
+        stage_item_id=StageItemId(-1),
+        name=f"R{round_id}",
+        created=DUMMY_MOCK_TIME,
+    )
+
+
+# ── Test 1: Complete matching for even number of teams ────────────────────────
+
+
+def test_complete_matching_even_teams() -> None:
+    """For 4 teams with no history, selector produces 2 pairs covering all teams."""
+    from bracket.logic.scheduling.swiss_round_pairing import select_round_pairing
+
+    inputs = [_input(i) for i in range(4)]
+    pairs, bye = select_round_pairing(inputs, [])
+
+    assert bye is None
+    assert len(pairs) == 2
+    all_ids = {inp.id for pair in pairs for inp in pair}
+    assert all_ids == {inp.id for inp in inputs}
+
+
+# ── Test 2: Bye for odd number of teams ───────────────────────────────────────
+
+
+def test_bye_for_odd_teams() -> None:
+    """For 3 teams with no history, selector produces 1 pair and 1 bye."""
+    from bracket.logic.scheduling.swiss_round_pairing import select_round_pairing
+
+    inputs = [_input(i) for i in range(3)]
+    pairs, bye = select_round_pairing(inputs, [])
+
+    assert bye is not None
+    assert len(pairs) == 1
+    pair_ids = {inp.id for inp in pairs[0]}
+    assert bye.id not in pair_ids
+    assert pair_ids | {bye.id} == {inp.id for inp in inputs}
+
+
+# ── Test 3: Rematch avoidance ──────────────────────────────────────────────────
+
+
+def test_rematch_avoidance() -> None:
+    """Teams that already played each other are not paired again when alternatives exist."""
+    from bracket.logic.scheduling.swiss_round_pairing import select_round_pairing
+
+    a, b, c, d = _input(1), _input(2), _input(3), _input(4)
+    # Round 1 history: a played b, c played d
+    history = [_round_with_match(1, a, b), _round_with_match(2, c, d)]
+    pairs, bye = select_round_pairing([a, b, c, d], history)
+
+    assert bye is None
+    assert len(pairs) == 2
+    pair_sets = {frozenset(inp.id for inp in pair) for pair in pairs}
+    assert frozenset({a.id, b.id}) not in pair_sets
+    assert frozenset({c.id, d.id}) not in pair_sets
+
+
+# ── Test 4: Games balance ──────────────────────────────────────────────────────
+
+
+def test_games_balance_teams_behind_schedule_are_paired() -> None:
+    """Teams with zero games played are prioritized over teams that already played.
+
+    Setup: teams a and b have already played each other (1 game each); teams c and d
+    are fresh (0 games each). The selector must pair c with d (behind schedule) over
+    forcing a rematch of a vs b.
+    """
+    from bracket.logic.scheduling.swiss_round_pairing import select_round_pairing
+
+    a, b, c, d = _input(1), _input(2), _input(3), _input(4)
+    history = [_round_with_match(1, a, b)]
+    pairs, bye = select_round_pairing([a, b, c, d], history)
+
+    assert bye is None
+    assert len(pairs) == 2
+    pair_sets = {frozenset(inp.id for inp in pair) for pair in pairs}
+    assert frozenset({c.id, d.id}) in pair_sets

--- a/backend/tests/unit_tests/test_swiss_slot_assigner.py
+++ b/backend/tests/unit_tests/test_swiss_slot_assigner.py
@@ -1,0 +1,127 @@
+"""Unit tests for the Swiss pair→slot assigner (issue #152)."""
+
+from decimal import Decimal
+
+from bracket.logic.scheduling.swiss_skeleton import RoundSkeleton
+from bracket.models.db.stage_item_inputs import StageItemInputFinal
+from bracket.models.db.team import Team
+from bracket.utils.dummy_records import DUMMY_TEAM1
+from bracket.utils.id_types import StageItemInputId, TeamId, TournamentId
+
+
+def _input(n: int, elo: int = 1000) -> StageItemInputFinal:
+    return StageItemInputFinal(
+        id=StageItemInputId(n),
+        slot=n,
+        tournament_id=TournamentId(-1),
+        team_id=TeamId(n),
+        points=Decimal(str(elo)),
+        wins=0,
+        draws=0,
+        losses=0,
+        team=Team(**{**DUMMY_TEAM1.model_dump(), "id": TeamId(n), "active": True}),
+    )
+
+
+# ── Test 5: All skeleton slots are covered ────────────────────────────────────
+
+
+def test_all_skeleton_slots_covered() -> None:
+    """The returned mapping covers every slot index declared in the skeleton."""
+    from bracket.logic.scheduling.swiss_slot_assigner import assign_pairs_to_slots
+
+    a, b, c, d = _input(1), _input(2), _input(3), _input(4)
+    pairs = [(a, b), (c, d)]
+    bye = None
+    skeleton = RoundSkeleton(matches=((0, 1), (2, 3)), bye_slot=None)
+
+    result = assign_pairs_to_slots(pairs, bye, skeleton)
+
+    assert set(result.keys()) == {0, 1, 2, 3}
+
+
+# ── Test 6: Each pair occupies the same match slot ────────────────────────────
+
+
+def test_each_pair_in_same_match_slot() -> None:
+    """Both members of a pair land in the same skeleton match (same slot pair)."""
+    from bracket.logic.scheduling.swiss_slot_assigner import assign_pairs_to_slots
+
+    a, b, c, d = _input(1), _input(2), _input(3), _input(4)
+    pairs = [(a, b), (c, d)]
+    skeleton = RoundSkeleton(matches=((0, 1), (2, 3)), bye_slot=None)
+
+    result = assign_pairs_to_slots(pairs, None, skeleton)
+
+    # a and b should be in the same match slot pair
+    for slot1, slot2 in skeleton.matches:
+        slot_set = {result[slot1], result[slot2]}
+        assert slot_set in ({a.id, b.id}, {c.id, d.id}), (
+            f"Match slots ({slot1},{slot2}) contain mixed-pair teams: {slot_set}"
+        )
+
+
+# ── Test 7: Bye team is referee and never a player ────────────────────────────
+
+
+def test_bye_team_is_referee_not_player() -> None:
+    """Bye team appears only in the bye_slot (referee position), not in any match slot."""
+    from bracket.logic.scheduling.swiss_slot_assigner import assign_pairs_to_slots
+
+    a, b, c, d, e = _input(1), _input(2), _input(3), _input(4), _input(5)
+    pairs = [(a, b), (c, d)]
+    skeleton = RoundSkeleton(matches=((0, 1), (2, 3)), bye_slot=4)
+
+    result = assign_pairs_to_slots(pairs, e, skeleton)
+
+    assert result[4] == e.id
+    playing_ids = {result[s] for s in (0, 1, 2, 3)}
+    assert e.id not in playing_ids
+
+
+# ── Test 8: Fairness — minimise slot reuse from previous round ────────────────
+
+
+def test_fairness_minimizes_slot_reuse() -> None:
+    """When pairs are the same as last round, assigner picks a different slot arrangement.
+
+    Round 1 had A@0, B@1, C@2, D@3. Same pairs (A,B) and (C,D) must be assigned again
+    (forced-rematch scenario for the slot-assigner unit test). The optimal assignment has
+    zero slot reuses; the naive ordering has four. The assigner must choose the former.
+    """
+    from bracket.logic.scheduling.swiss_slot_assigner import assign_pairs_to_slots
+
+    a, b, c, d = _input(1), _input(2), _input(3), _input(4)
+    prev_slots = [{0: a.id, 1: b.id, 2: c.id, 3: d.id}]
+    pairs = [(a, b), (c, d)]
+    skeleton = RoundSkeleton(matches=((0, 1), (2, 3)), bye_slot=None)
+
+    result = assign_pairs_to_slots(pairs, None, skeleton, previous_slot_assignments=prev_slots)
+
+    reuses = sum(1 for slot, inp_id in result.items() if prev_slots[0].get(slot) == inp_id)
+    assert reuses == 0
+
+
+# ── Test 9: skeleton_from_matches reconstructs the round skeleton correctly ───
+
+
+def test_skeleton_from_matches_even_teams() -> None:
+    """Slot pairs and bye_slot are correctly extracted from placeholder match data."""
+    from bracket.logic.scheduling.swiss_slot_assigner import skeleton_from_slot_pairs
+
+    slot_pairs = [(0, 1), (2, 3)]
+    skeleton = skeleton_from_slot_pairs(slot_pairs, bye_slot=None)
+
+    assert skeleton.matches == ((0, 1), (2, 3))
+    assert skeleton.bye_slot is None
+
+
+def test_skeleton_from_matches_odd_teams() -> None:
+    """Bye slot is preserved when reconstructing skeleton from placeholder matches."""
+    from bracket.logic.scheduling.swiss_slot_assigner import skeleton_from_slot_pairs
+
+    slot_pairs = [(0, 1), (2, 3)]
+    skeleton = skeleton_from_slot_pairs(slot_pairs, bye_slot=4)
+
+    assert skeleton.matches == ((0, 1), (2, 3))
+    assert skeleton.bye_slot == 4


### PR DESCRIPTION
Add pure pairing selector (wrapping optimizer with hardcoded Swiss defaults,
greedy completion fallback) and pure pair→slot assigner (minimises slot reuse
via permutation search). Hook into stage activation so Swiss round 1 placeholder
matches are resolved to real teams and referees immediately.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JMVUrKGMVd7Knh9UgLuLYc