### PR TITLE
feat(swiss): edit games-per-player after creation (issue #156)

### DIFF
--- a/backend/alembic/versions/d7e2b4f9a1c8_replace_is_draft_with_lifecycle_state.py
+++ b/backend/alembic/versions/d7e2b4f9a1c8_replace_is_draft_with_lifecycle_state.py
@@ -44,9 +44,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     # Re-add is_draft column (nullable first, then populate, then constrain)
     op.add_column("rounds", sa.Column("is_draft", sa.Boolean(), nullable=True))
-    op.execute(
-        "UPDATE rounds SET is_draft = (lifecycle_state = 'DRAFT')"
-    )
+    op.execute("UPDATE rounds SET is_draft = (lifecycle_state = 'DRAFT')")
     op.alter_column("rounds", "is_draft", nullable=False)
 
     # Make lifecycle_state nullable again

--- a/backend/bracket/models/db/round.py
+++ b/backend/bracket/models/db/round.py
@@ -1,5 +1,4 @@
 from enum import auto
-from typing import Any
 
 from heliclockter import datetime_utc
 from pydantic import computed_field

--- a/backend/bracket/models/db/stage_item.py
+++ b/backend/bracket/models/db/stage_item.py
@@ -38,6 +38,7 @@ class StageItemUpdateBody(BaseModelORM):
     name: str
     ranking_id: RankingId
     team_count: int = Field(ge=2, le=64)
+    games_per_player: int | None = None
 
 
 class StageItemActivateNextBody(BaseModelORM):

--- a/backend/bracket/routes/stage_items.py
+++ b/backend/bracket/routes/stage_items.py
@@ -25,6 +25,7 @@ from bracket.logic.scheduling.round_robin import (
     get_number_of_rounds_to_create_round_robin,
     get_round_robin_combinations,
 )
+from bracket.logic.scheduling.swiss_skeleton import build_swiss_skeleton
 from bracket.logic.scheduling.upcoming_matches import get_upcoming_matches_for_swiss
 from bracket.logic.subscriptions import check_requirement
 from bracket.models.db.match import MatchCreateBody, MatchFilter, MatchState, SuggestedMatch
@@ -55,6 +56,7 @@ from bracket.sql.rounds import (
     get_round_by_id,
     set_round_lifecycle_state,
     sql_create_round,
+    sql_delete_round,
     sql_delete_rounds_for_stage_item_id,
 )
 from bracket.sql.shared import (
@@ -129,7 +131,8 @@ async def update_stage_item_row(
             UPDATE stage_items
             SET name = :name,
                 ranking_id = :ranking_id,
-                team_count = :team_count
+                team_count = :team_count,
+                games_per_player = COALESCE(:games_per_player, games_per_player)
             WHERE stage_items.id = :stage_item_id
         """,
         values={
@@ -137,6 +140,7 @@ async def update_stage_item_row(
             "name": stage_item_body.name,
             "ranking_id": stage_item_body.ranking_id,
             "team_count": stage_item_body.team_count,
+            "games_per_player": stage_item_body.games_per_player,
         },
     )
 
@@ -380,6 +384,67 @@ async def resize_non_elimination_stage_item(
     await clear_removed_winner_positions(stage_item_id, new_team_count)
 
 
+async def adjust_swiss_games_per_player(
+    tournament_id: TournamentId,
+    stage_item_id: StageItemId,
+    stage_item: StageItemWithRounds,
+    new_games_per_player: int,
+) -> None:
+    """Append or remove trailing PLACEHOLDER rounds when games-per-player changes."""
+    old_games_per_player = stage_item.games_per_player
+    if old_games_per_player is None or new_games_per_player == old_games_per_player:
+        return
+
+    old_skeleton = build_swiss_skeleton(stage_item.team_count, old_games_per_player)
+    new_skeleton = build_swiss_skeleton(stage_item.team_count, new_games_per_player)
+    current_rounds = sorted(stage_item.rounds, key=lambda r: r.id)
+
+    if new_skeleton.round_count > old_skeleton.round_count:
+        tournament = await sql_get_tournament(tournament_id)
+        for round_skeleton in new_skeleton.rounds[old_skeleton.round_count :]:
+            round_id = await sql_create_round(
+                RoundInsertable(
+                    created=datetime_utc.now(),
+                    stage_item_id=stage_item_id,
+                    name=await get_next_round_name(tournament_id, stage_item_id),
+                    lifecycle_state=RoundLifecycleState.PLACEHOLDER,
+                )
+            )
+            for slot1, slot2 in round_skeleton.matches:
+                await sql_create_match(
+                    MatchCreateBody(
+                        round_id=round_id,
+                        court_id=None,
+                        stage_item_input1_id=None,
+                        stage_item_input2_id=None,
+                        stage_item_input1_winner_from_match_id=None,
+                        stage_item_input2_winner_from_match_id=None,
+                        duration_minutes=tournament.duration_minutes,
+                        custom_duration_minutes=None,
+                        input1_slot=slot1,
+                        input2_slot=slot2,
+                        referee_slot=round_skeleton.bye_slot,
+                    )
+                )
+    elif new_skeleton.round_count < old_skeleton.round_count:
+        rounds_to_remove = current_rounds[new_skeleton.round_count :]
+        for round_ in rounds_to_remove:
+            for match in round_.matches:
+                if match.state is not MatchState.NOT_STARTED:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=(
+                            "Cannot reduce games-per-player: a trailing round contains "
+                            "matches that have already started or completed"
+                        ),
+                    )
+        for round_ in rounds_to_remove:
+            match_ids = [match.id for match in round_.matches]
+            if match_ids:
+                await sql_delete_matches(match_ids)
+            await sql_delete_round(round_.id)
+
+
 async def resize_stage_item_if_needed(
     tournament_id: TournamentId,
     stage_item_id: StageItemId,
@@ -456,6 +521,10 @@ async def update_stage_item(
     team_count_changed = stage_item_body.team_count != stage_item.team_count
 
     async with database.transaction():
+        if stage_item_body.games_per_player is not None and stage_item.type is StageType.SWISS:
+            await adjust_swiss_games_per_player(
+                tournament_id, stage_item_id, stage_item, stage_item_body.games_per_player
+            )
         await resize_stage_item_if_needed(tournament_id, stage_item_id, stage_item, stage_item_body)
         await update_stage_item_row(stage_item_id, stage_item_body)
 

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -3079,6 +3079,17 @@
       },
       "StageItemUpdateBody": {
         "properties": {
+          "games_per_player": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Games Per Player"
+          },
           "name": {
             "title": "Name",
             "type": "string"
@@ -3097,7 +3108,8 @@
         "required": [
           "name",
           "ranking_id",
-          "team_count"
+          "team_count",
+          "games_per_player"
         ],
         "title": "StageItemUpdateBody",
         "type": "object"

--- a/backend/tests/integration_tests/api/matches_test.py
+++ b/backend/tests/integration_tests/api/matches_test.py
@@ -64,7 +64,10 @@ async def test_create_match(
         ) as stage_item_inserted,
         inserted_round(
             DUMMY_ROUND1.model_copy(
-                update={"stage_item_id": stage_item_inserted.id, "lifecycle_state": RoundLifecycleState.DRAFT}
+                update={
+                    "stage_item_id": stage_item_inserted.id,
+                    "lifecycle_state": RoundLifecycleState.DRAFT,
+                }
             )
         ) as round_inserted,
         inserted_team(
@@ -110,7 +113,10 @@ async def test_delete_match(
         ) as stage_item_inserted,
         inserted_round(
             DUMMY_ROUND1.model_copy(
-                update={"stage_item_id": stage_item_inserted.id, "lifecycle_state": RoundLifecycleState.DRAFT}
+                update={
+                    "stage_item_id": stage_item_inserted.id,
+                    "lifecycle_state": RoundLifecycleState.DRAFT,
+                }
             )
         ) as round_inserted,
         inserted_team(

--- a/backend/tests/integration_tests/api/swiss_placeholder_test.py
+++ b/backend/tests/integration_tests/api/swiss_placeholder_test.py
@@ -1,5 +1,8 @@
 import pytest
 
+from bracket.database import database
+from bracket.models.db.match import MatchState
+from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.stage_item import StageType
 from bracket.schema import matches, rounds, stage_item_inputs, stage_items, stages
 from bracket.sql.stages import get_full_tournament_details
@@ -63,6 +66,218 @@ async def test_swiss_placeholder_skeleton_created_on_create(
         finally:
             # Clean up in dependency order so the stage FK is satisfied when
             # the inserted_stage context manager runs its DELETE.
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_raise_games_per_player_appends_rounds(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Raising games_per_player on an existing Swiss stage item appends new PLACEHOLDER rounds."""
+    async with inserted_stage(
+        DUMMY_STAGE1.model_copy(update={"tournament_id": auth_context.tournament.id})
+    ) as stage_inserted:
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                "stage_items",
+                auth_context,
+                json={
+                    "type": StageType.SWISS.value,
+                    "team_count": 4,
+                    "stage_id": stage_inserted.id,
+                    "games_per_player": 2,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        stages_in_tournament = await get_full_tournament_details(auth_context.tournament.id)
+        stage_item = next(
+            si
+            for stage in stages_in_tournament
+            if stage.id == stage_inserted.id
+            for si in stage.stage_items
+        )
+        assert len(stage_item.rounds) == 2
+
+        assert (
+            await send_tournament_request(
+                HTTPMethod.PUT,
+                f"stage_items/{stage_item.id}",
+                auth_context,
+                json={
+                    "name": stage_item.name,
+                    "ranking_id": stage_item.ranking_id,
+                    "team_count": stage_item.team_count,
+                    "games_per_player": 3,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        stages_in_tournament = await get_full_tournament_details(auth_context.tournament.id)
+        stage_item = next(
+            si
+            for stage in stages_in_tournament
+            if stage.id == stage_inserted.id
+            for si in stage.stage_items
+        )
+
+        try:
+            assert stage_item.games_per_player == 3
+            assert len(stage_item.rounds) == 3
+            for round_ in stage_item.rounds:
+                assert round_.lifecycle_state == RoundLifecycleState.PLACEHOLDER
+        finally:
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_lower_games_per_player_removes_trailing_rounds(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Lowering games_per_player removes only the trailing NOT_STARTED placeholder rounds."""
+    async with inserted_stage(
+        DUMMY_STAGE1.model_copy(update={"tournament_id": auth_context.tournament.id})
+    ) as stage_inserted:
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                "stage_items",
+                auth_context,
+                json={
+                    "type": StageType.SWISS.value,
+                    "team_count": 4,
+                    "stage_id": stage_inserted.id,
+                    "games_per_player": 3,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        stages_in_tournament = await get_full_tournament_details(auth_context.tournament.id)
+        stage_item = next(
+            si
+            for stage in stages_in_tournament
+            if stage.id == stage_inserted.id
+            for si in stage.stage_items
+        )
+        assert len(stage_item.rounds) == 3
+
+        assert (
+            await send_tournament_request(
+                HTTPMethod.PUT,
+                f"stage_items/{stage_item.id}",
+                auth_context,
+                json={
+                    "name": stage_item.name,
+                    "ranking_id": stage_item.ranking_id,
+                    "team_count": stage_item.team_count,
+                    "games_per_player": 2,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        stages_in_tournament = await get_full_tournament_details(auth_context.tournament.id)
+        stage_item = next(
+            si
+            for stage in stages_in_tournament
+            if stage.id == stage_inserted.id
+            for si in stage.stage_items
+        )
+
+        try:
+            assert stage_item.games_per_player == 2
+            assert len(stage_item.rounds) == 2
+        finally:
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_lower_games_per_player_blocked_when_round_started(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Lowering games_per_player is rejected with 400 when a trailing round has started matches."""
+    async with inserted_stage(
+        DUMMY_STAGE1.model_copy(update={"tournament_id": auth_context.tournament.id})
+    ) as stage_inserted:
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                "stage_items",
+                auth_context,
+                json={
+                    "type": StageType.SWISS.value,
+                    "team_count": 4,
+                    "stage_id": stage_inserted.id,
+                    "games_per_player": 2,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        stages_in_tournament = await get_full_tournament_details(auth_context.tournament.id)
+        stage_item = next(
+            si
+            for stage in stages_in_tournament
+            if stage.id == stage_inserted.id
+            for si in stage.stage_items
+        )
+        assert len(stage_item.rounds) == 2
+
+        # Mark all matches in the last round as IN_PROGRESS to simulate a started round
+        last_round = sorted(stage_item.rounds, key=lambda r: r.id)[-1]
+        for match in last_round.matches:
+            await database.execute(
+                query=matches.update()
+                .where(matches.c.id == match.id)
+                .values(state=MatchState.IN_PROGRESS.value)
+            )
+
+        response = await send_tournament_request(
+            HTTPMethod.PUT,
+            f"stage_items/{stage_item.id}",
+            auth_context,
+            json={
+                "name": stage_item.name,
+                "ranking_id": stage_item.ranking_id,
+                "team_count": stage_item.team_count,
+                "games_per_player": 1,
+            },
+        )
+
+        try:
+            assert response == {
+                "detail": (
+                    "Cannot reduce games-per-player: a trailing round contains "
+                    "matches that have already started or completed"
+                )
+            }
+            # Rounds and games_per_player must be unchanged
+            stages_in_tournament = await get_full_tournament_details(auth_context.tournament.id)
+            stage_item = next(
+                si
+                for stage in stages_in_tournament
+                if stage.id == stage_inserted.id
+                for si in stage.stage_items
+            )
+            assert stage_item.games_per_player == 2
+            assert len(stage_item.rounds) == 2
+        finally:
             await assert_row_count_and_clear(matches, 0)
             await assert_row_count_and_clear(rounds, 0)
             await assert_row_count_and_clear(stage_item_inputs, 0)

--- a/backend/tests/unit_tests/conflicts_test.py
+++ b/backend/tests/unit_tests/conflicts_test.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 
 import pytest
 
-from bracket.models.db.round import RoundLifecycleState
 from bracket.logic.planning.conflicts import (
     get_conflicting_matches,
     get_match_conflict_flags,
@@ -10,6 +9,7 @@ from bracket.logic.planning.conflicts import (
 )
 from bracket.logic.planning.team_windows import get_team_playing_windows
 from bracket.models.db.match import MatchState, MatchWithDetailsDefinitive
+from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.stage_item import StageType
 from bracket.models.db.stage_item_inputs import (
     StageItemInput,

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -15,13 +15,13 @@ from bracket.logic.planning.matches import (
     reorder_all_matches,
 )
 from bracket.models.db.court import Court
-from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.match import (
     MatchState,
     MatchWithDetails,
     MatchWithDetailsDefinitive,
     SchedulerWeights,
 )
+from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.stage_item import StageType
 from bracket.models.db.stage_item_inputs import (
     StageItemInput,

--- a/backend/tests/unit_tests/ranking_calculation_test.py
+++ b/backend/tests/unit_tests/ranking_calculation_test.py
@@ -5,8 +5,8 @@ from heliclockter import datetime_utc
 from bracket.logic.ranking.calculation import determine_ranking_for_stage_item
 from bracket.logic.ranking.statistics import TeamStatistics
 from bracket.models.db.match import MatchState, MatchWithDetails, MatchWithDetailsDefinitive
-from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.ranking import Ranking
+from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.stage_item import StageType
 from bracket.models.db.stage_item_inputs import StageItemInputFinal
 from bracket.models.db.team import Team


### PR DESCRIPTION
Add PUT body field + backend logic to raise or lower games-per-player
on an existing Swiss stage item.

Closes #156.

Raising N appends the extra placeholder rounds/slot-matches (taken
from the new skeleton) as unscheduled, ready for the existing
"Schedule unscheduled matches" pass.

Lowering N removes only trailing rounds whose matches are all
NOT_STARTED; it is rejected with HTTP 400 when any trailing round
contains a match that has started or completed.

Three integration tests cover the acceptance criteria:
- raise N appends new PLACEHOLDER rounds
- lower N removes trailing NOT_STARTED rounds
- lower blocked when a trailing round has started matches

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DJ7PdFcLwxZF3eqSbAsXcj