### PR TITLE
feat: Swiss rework 4/8 — sequential auto-resolve for subsequent rounds

### DIFF
--- a/backend/bracket/logic/scheduling/swiss_resolution_orchestrator.py
+++ b/backend/bracket/logic/scheduling/swiss_resolution_orchestrator.py
@@ -1,0 +1,75 @@
+from bracket.logic.scheduling.swiss_resolution_policy import get_next_round_to_resolve
+from bracket.logic.scheduling.swiss_round_pairing import select_round_pairing
+from bracket.logic.scheduling.swiss_slot_assigner import (
+    assign_pairs_to_slots,
+    skeleton_from_slot_pairs,
+)
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.stage_item import StageType
+from bracket.models.db.stage_item_inputs import StageItemInputFinal
+from bracket.models.db.util import StageItemWithRounds
+from bracket.sql.matches import sql_set_input_ids_for_match
+from bracket.sql.referees import sql_set_match_referee_slot
+from bracket.sql.rounds import set_round_lifecycle_state
+from bracket.sql.stage_items import get_stage_item
+from bracket.utils.id_types import TournamentId
+
+
+async def auto_resolve_next_swiss_round(
+    tournament_id: TournamentId,
+    stage_item: StageItemWithRounds,
+) -> None:
+    """After ranking recalculation, auto-resolve the next PLACEHOLDER Swiss round if ready."""
+    if stage_item.type != StageType.SWISS:
+        return
+
+    next_round = get_next_round_to_resolve(stage_item.rounds)
+    if next_round is None:
+        return
+
+    # Re-fetch with up-to-date ELO after recalculate_ranking_for_stage_item
+    fresh = await get_stage_item(tournament_id, stage_item.id)
+    round_ = next((r for r in fresh.rounds if r.id == next_round.id), None)
+    if round_ is None or round_.lifecycle_state != RoundLifecycleState.PLACEHOLDER:
+        return
+
+    inputs = [i for i in fresh.inputs if isinstance(i, StageItemInputFinal) and i.team.active]
+    if not inputs:
+        return
+
+    previous_rounds = [
+        r
+        for r in fresh.rounds
+        if r.lifecycle_state not in (RoundLifecycleState.PLACEHOLDER, RoundLifecycleState.DRAFT)
+        and r.id != round_.id
+    ]
+
+    slot_pairs = [
+        (m.input1_slot, m.input2_slot)
+        for m in round_.matches
+        if m.input1_slot is not None and m.input2_slot is not None
+    ]
+    bye_slot = next(
+        (m.referee_slot for m in round_.matches if m.referee_slot is not None),
+        None,
+    )
+
+    pairs, bye = select_round_pairing(inputs, previous_rounds)
+    skeleton = skeleton_from_slot_pairs(slot_pairs, bye_slot)
+    slot_mapping = assign_pairs_to_slots(pairs, bye, skeleton)
+
+    for match in round_.matches:
+        if match.input1_slot is None or match.input2_slot is None:
+            continue
+        input1_id = slot_mapping.get(match.input1_slot)
+        input2_id = slot_mapping.get(match.input2_slot)
+        if input1_id is None or input2_id is None:
+            continue
+        await sql_set_input_ids_for_match(round_.id, match.id, [input1_id, input2_id])
+
+        if match.referee_slot is not None:
+            ref_id = slot_mapping.get(match.referee_slot)
+            if ref_id is not None:
+                await sql_set_match_referee_slot(match.id, ref_id)
+
+    await set_round_lifecycle_state(round_.id, tournament_id, RoundLifecycleState.RESOLVED)

--- a/backend/bracket/logic/scheduling/swiss_resolution_policy.py
+++ b/backend/bracket/logic/scheduling/swiss_resolution_policy.py
@@ -1,0 +1,21 @@
+from bracket.models.db.match import MatchState
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.util import RoundWithMatches
+
+
+def get_next_round_to_resolve(rounds: list[RoundWithMatches]) -> RoundWithMatches | None:
+    """Return the next PLACEHOLDER round that is ready to resolve, or None.
+
+    Round R is ready only when every match in round R-1 is COMPLETED.
+    Resolution is strictly sequential.
+    """
+    sorted_rounds = sorted(rounds, key=lambda r: r.id)
+    for i, round_ in enumerate(sorted_rounds):
+        if round_.lifecycle_state != RoundLifecycleState.PLACEHOLDER:
+            continue
+        if i == 0:
+            return round_
+        prev_round = sorted_rounds[i - 1]
+        if prev_round.matches and all(m.state == MatchState.COMPLETED for m in prev_round.matches):
+            return round_
+    return None

--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -21,6 +21,7 @@ from bracket.logic.ranking.calculation import (
     recalculate_ranking_for_stage_item,
 )
 from bracket.logic.ranking.elimination import update_inputs_in_subsequent_elimination_rounds
+from bracket.logic.scheduling.swiss_resolution_orchestrator import auto_resolve_next_swiss_round
 from bracket.logic.scheduling.upcoming_matches import (
     get_draft_round_in_stage_item,
     get_upcoming_matches_for_swiss,
@@ -406,6 +407,7 @@ async def update_match_by_id(
     round_ = await get_round_by_id(tournament_id, match.round_id)
     stage_item = await get_stage_item(tournament_id, round_.stage_item_id)
     await recalculate_ranking_for_stage_item(tournament_id, stage_item)
+    await auto_resolve_next_swiss_round(tournament_id, stage_item)
 
     if (
         match_body.custom_duration_minutes != match.custom_duration_minutes

--- a/backend/bracket/routes/score_tracking.py
+++ b/backend/bracket/routes/score_tracking.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from bracket.config import config
 from bracket.logic.ranking.calculation import recalculate_ranking_for_stage_item
 from bracket.logic.ranking.elimination import update_inputs_in_subsequent_elimination_rounds
+from bracket.logic.scheduling.swiss_resolution_orchestrator import auto_resolve_next_swiss_round
 from bracket.models.db.match import Match, MatchScoreTrackingBody
 from bracket.models.db.stage_item import StageType
 from bracket.models.db.tournament import LevelResponse, Tournament
@@ -147,6 +148,7 @@ async def update_authenticated_score_tracking_match(
     round_ = await get_round_by_id(tournament_id, match.round_id)
     stage_item = await get_stage_item(tournament_id, round_.stage_item_id)
     await recalculate_ranking_for_stage_item(tournament_id, stage_item)
+    await auto_resolve_next_swiss_round(tournament_id, stage_item)
 
     if stage_item.type == StageType.SINGLE_ELIMINATION:
         await update_inputs_in_subsequent_elimination_rounds(round_.id, stage_item, {match_id})
@@ -186,6 +188,7 @@ async def update_score_tracking_match(
     round_ = await get_round_by_id(tournament.id, match.round_id)
     stage_item = await get_stage_item(tournament.id, round_.stage_item_id)
     await recalculate_ranking_for_stage_item(tournament.id, stage_item)
+    await auto_resolve_next_swiss_round(tournament.id, stage_item)
 
     if stage_item.type == StageType.SINGLE_ELIMINATION:
         await update_inputs_in_subsequent_elimination_rounds(round_.id, stage_item, {match_id})

--- a/backend/tests/integration_tests/api/test_swiss_auto_resolution.py
+++ b/backend/tests/integration_tests/api/test_swiss_auto_resolution.py
@@ -1,0 +1,101 @@
+"""Integration test: completing round 1 of a Swiss stage item auto-resolves round 2 (issue #153)."""
+
+import pytest
+
+from bracket.logic.scheduling.builder import build_matches_for_stage_item
+from bracket.logic.scheduling.handle_stage_activation import (
+    _resolve_round_1_for_swiss_stage_item,
+)
+from bracket.models.db.match import MatchState
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.stage_item import StageItemWithInputsCreate, StageType
+from bracket.models.db.stage_item_inputs import StageItemInputCreateBodyFinal
+from bracket.schema import matches, rounds, stage_item_inputs, stage_items, stages
+from bracket.sql.stage_items import get_stage_item, sql_create_stage_item_with_inputs
+from bracket.utils.dummy_records import DUMMY_STAGE1, DUMMY_TEAM1
+from bracket.utils.http import HTTPMethod
+from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
+from tests.integration_tests.models import AuthContext
+from tests.integration_tests.sql import (
+    assert_row_count_and_clear,
+    inserted_stage,
+    inserted_team,
+)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_completing_round1_auto_resolves_round2(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Completing all matches in round 1 of a Swiss stage automatically fills round 2."""
+    tournament_id = auth_context.tournament.id
+
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id, "is_active": True})
+        ) as stage_inserted,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t1,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t3,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t4,
+    ):
+        stage_item_raw = await sql_create_stage_item_with_inputs(
+            tournament_id,
+            StageItemWithInputsCreate(
+                stage_id=stage_inserted.id,
+                type=StageType.SWISS,
+                team_count=4,
+                games_per_player=2,
+                ranking_id=auth_context.ranking.id,
+                inputs=[
+                    StageItemInputCreateBodyFinal(slot=1, team_id=t1.id),
+                    StageItemInputCreateBodyFinal(slot=2, team_id=t2.id),
+                    StageItemInputCreateBodyFinal(slot=3, team_id=t3.id),
+                    StageItemInputCreateBodyFinal(slot=4, team_id=t4.id),
+                ],
+            ),
+        )
+        await build_matches_for_stage_item(stage_item_raw, tournament_id)
+
+        stage_item = await get_stage_item(tournament_id, stage_item_raw.id)
+        assert len(stage_item.rounds) == 2
+
+        # Resolve round 1 (simulates stage activation)
+        await _resolve_round_1_for_swiss_stage_item(tournament_id, stage_item)
+
+        stage_item = await get_stage_item(tournament_id, stage_item_raw.id)
+        round1 = sorted(stage_item.rounds, key=lambda r: r.id)[0]
+        round2 = sorted(stage_item.rounds, key=lambda r: r.id)[1]
+        assert round1.lifecycle_state == RoundLifecycleState.RESOLVED
+        assert round2.lifecycle_state == RoundLifecycleState.PLACEHOLDER
+
+        try:
+            # Complete all round 1 matches via the HTTP API — this triggers the orchestrator
+            for match in round1.matches:
+                resp = await send_tournament_request(
+                    HTTPMethod.PUT,
+                    f"matches/{match.id}",
+                    auth_context,
+                    json={
+                        "round_id": round1.id,
+                        "state": MatchState.COMPLETED.value,
+                        "stage_item_input1_score": 0,
+                        "stage_item_input2_score": 0,
+                    },
+                )
+                assert resp == SUCCESS_RESPONSE
+
+            # Round 2 must now be RESOLVED with concrete teams
+            stage_item = await get_stage_item(tournament_id, stage_item_raw.id)
+            round2_resolved = sorted(stage_item.rounds, key=lambda r: r.id)[1]
+            assert round2_resolved.lifecycle_state == RoundLifecycleState.RESOLVED
+            for match in round2_resolved.matches:
+                assert match.stage_item_input1_id is not None
+                assert match.stage_item_input2_id is not None
+
+        finally:
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)

--- a/backend/tests/unit_tests/test_swiss_resolution_policy.py
+++ b/backend/tests/unit_tests/test_swiss_resolution_policy.py
@@ -1,0 +1,96 @@
+"""Unit tests for the Swiss resolution policy (issue #153)."""
+
+from bracket.models.db.match import MatchState, MatchWithDetails
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.util import RoundWithMatches
+from bracket.utils.dummy_records import DUMMY_MATCH1, DUMMY_MOCK_TIME
+from bracket.utils.id_types import MatchId, RoundId, StageItemId
+
+
+def _make_match(match_id: int, state: MatchState) -> MatchWithDetails:
+    return MatchWithDetails(
+        **DUMMY_MATCH1.model_dump()
+        | {
+            "id": MatchId(match_id),
+            "state": state,
+            "stage_item_input1_id": None,
+            "stage_item_input2_id": None,
+            "court_id": None,
+        }
+    )
+
+
+def _make_round(
+    round_id: int,
+    lifecycle_state: RoundLifecycleState,
+    match_states: list[MatchState],
+) -> RoundWithMatches:
+    return RoundWithMatches(
+        id=RoundId(round_id),
+        matches=[_make_match(round_id * 100 + i, s) for i, s in enumerate(match_states)],
+        lifecycle_state=lifecycle_state,
+        stage_item_id=StageItemId(-1),
+        name=f"R{round_id}",
+        created=DUMMY_MOCK_TIME,
+    )
+
+
+# ── Test 1: Empty list ─────────────────────────────────────────────────────────
+
+
+def test_returns_none_for_no_rounds() -> None:
+    from bracket.logic.scheduling.swiss_resolution_policy import get_next_round_to_resolve
+
+    assert get_next_round_to_resolve([]) is None
+
+
+# ── Test 2: Single PLACEHOLDER, no predecessor ────────────────────────────────
+
+
+def test_placeholder_with_no_predecessor_resolves() -> None:
+    from bracket.logic.scheduling.swiss_resolution_policy import get_next_round_to_resolve
+
+    r1 = _make_round(1, RoundLifecycleState.PLACEHOLDER, [MatchState.NOT_STARTED])
+    result = get_next_round_to_resolve([r1])
+    assert result is not None
+    assert result.id == r1.id
+
+
+# ── Test 3: PLACEHOLDER after a fully completed predecessor ───────────────────
+
+
+def test_placeholder_after_completed_round_resolves() -> None:
+    from bracket.logic.scheduling.swiss_resolution_policy import get_next_round_to_resolve
+
+    r1 = _make_round(1, RoundLifecycleState.LOCKED, [MatchState.COMPLETED])
+    r2 = _make_round(2, RoundLifecycleState.PLACEHOLDER, [MatchState.NOT_STARTED])
+    result = get_next_round_to_resolve([r1, r2])
+    assert result is not None
+    assert result.id == r2.id
+
+
+# ── Test 4: PLACEHOLDER blocked when predecessor is incomplete ────────────────
+
+
+def test_placeholder_blocked_when_predecessor_incomplete() -> None:
+    from bracket.logic.scheduling.swiss_resolution_policy import get_next_round_to_resolve
+
+    r1 = _make_round(1, RoundLifecycleState.LOCKED, [MatchState.COMPLETED, MatchState.NOT_STARTED])
+    r2 = _make_round(2, RoundLifecycleState.PLACEHOLDER, [MatchState.NOT_STARTED])
+    result = get_next_round_to_resolve([r1, r2])
+    assert result is None
+
+
+# ── Test 5: Sequential — only the next PLACEHOLDER is returned ────────────────
+
+
+def test_sequential_only_next_placeholder_returned() -> None:
+    """When R1 is complete and R2+R3 are PLACEHOLDER, only R2 is returned."""
+    from bracket.logic.scheduling.swiss_resolution_policy import get_next_round_to_resolve
+
+    r1 = _make_round(1, RoundLifecycleState.LOCKED, [MatchState.COMPLETED])
+    r2 = _make_round(2, RoundLifecycleState.PLACEHOLDER, [MatchState.NOT_STARTED])
+    r3 = _make_round(3, RoundLifecycleState.PLACEHOLDER, [MatchState.NOT_STARTED])
+    result = get_next_round_to_resolve([r1, r2, r3])
+    assert result is not None
+    assert result.id == r2.id


### PR DESCRIPTION
When every match in round R-1 completes, a pure resolution policy detects
the next PLACEHOLDER round and an async orchestrator fills it with concrete
teams from the current ELO standings, matching the acceptance criteria in
issue #153.

- Add `swiss_resolution_policy.get_next_round_to_resolve` (pure, no DB):
  returns the first PLACEHOLDER round whose predecessor is fully COMPLETED,
  enforcing strict sequential ordering.
- Add `swiss_resolution_orchestrator.auto_resolve_next_swiss_round`: async
  coordinator that re-fetches fresh ELO, calls the pairing selector and
  pair→slot assigner, persists slot assignments, and transitions the round
  to RESOLVED.
- Hook orchestrator after `recalculate_ranking_for_stage_item` in both the
  regular match update route and both score-tracking update routes.
- 5 unit tests cover the policy's sequential/blocking/auto behaviour from
  constructed round-state inputs.
- 1 integration test: create Swiss stage item → activate round 1 → complete
  all round 1 matches via HTTP API → assert round 2 is RESOLVED with concrete
  teams.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UvC9puRLDWGAx1enhanw63