### PR TITLE
feat: Swiss rework 6/8 — manual override + pinning of resolved rounds (#155)

### DIFF
--- a/backend/bracket/logic/scheduling/swiss_resolution_orchestrator.py
+++ b/backend/bracket/logic/scheduling/swiss_resolution_orchestrator.py
@@ -1,4 +1,7 @@
-from bracket.logic.scheduling.swiss_resolution_policy import get_next_round_to_resolve
+from bracket.logic.scheduling.swiss_resolution_policy import (
+    get_next_round_to_resolve,
+    get_rounds_to_re_resolve,
+)
 from bracket.logic.scheduling.swiss_round_pairing import select_round_pairing
 from bracket.logic.scheduling.swiss_slot_assigner import (
     assign_pairs_to_slots,
@@ -7,7 +10,7 @@ from bracket.logic.scheduling.swiss_slot_assigner import (
 from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.stage_item import StageType
 from bracket.models.db.stage_item_inputs import StageItemInputFinal
-from bracket.models.db.util import StageItemWithRounds
+from bracket.models.db.util import RoundWithMatches, StageItemWithRounds
 from bracket.sql.matches import sql_set_input_ids_for_match
 from bracket.sql.referees import sql_set_match_referee_slot
 from bracket.sql.rounds import set_round_lifecycle_state
@@ -15,24 +18,14 @@ from bracket.sql.stage_items import get_stage_item
 from bracket.utils.id_types import TournamentId
 
 
-async def auto_resolve_next_swiss_round(
+async def _assign_teams_to_round(
     tournament_id: TournamentId,
-    stage_item: StageItemWithRounds,
+    fresh: StageItemWithRounds,
+    round_: RoundWithMatches,
+    *,
+    advance_to_resolved: bool,
 ) -> None:
-    """After ranking recalculation, auto-resolve the next PLACEHOLDER Swiss round if ready."""
-    if stage_item.type != StageType.SWISS:
-        return
-
-    next_round = get_next_round_to_resolve(stage_item.rounds)
-    if next_round is None:
-        return
-
-    # Re-fetch with up-to-date ELO after recalculate_ranking_for_stage_item
-    fresh = await get_stage_item(tournament_id, stage_item.id)
-    round_ = next((r for r in fresh.rounds if r.id == next_round.id), None)
-    if round_ is None or round_.lifecycle_state != RoundLifecycleState.PLACEHOLDER:
-        return
-
+    """Run pairing selection + slot assignment for a single round and persist the result."""
     inputs = [i for i in fresh.inputs if isinstance(i, StageItemInputFinal) and i.team.active]
     if not inputs:
         return
@@ -72,4 +65,42 @@ async def auto_resolve_next_swiss_round(
             if ref_id is not None:
                 await sql_set_match_referee_slot(match.id, ref_id)
 
-    await set_round_lifecycle_state(round_.id, tournament_id, RoundLifecycleState.RESOLVED)
+    if advance_to_resolved:
+        await set_round_lifecycle_state(round_.id, tournament_id, RoundLifecycleState.RESOLVED)
+
+
+async def auto_resolve_next_swiss_round(
+    tournament_id: TournamentId,
+    stage_item: StageItemWithRounds,
+) -> None:
+    """After ranking recalculation, resolve or re-resolve Swiss rounds as the policy dictates.
+
+    Two passes:
+    1. Resolve the next PLACEHOLDER round ready for initial resolution.
+    2. Re-resolve any RESOLVED not-started non-pinned rounds (so upstream score corrections
+       flow into future pairings while leaving pinned and locked rounds untouched).
+    """
+    if stage_item.type != StageType.SWISS:
+        return
+
+    # Re-fetch with up-to-date ELO after recalculate_ranking_for_stage_item
+    fresh = await get_stage_item(tournament_id, stage_item.id)
+
+    # Pass 1: initial resolution of next PLACEHOLDER round
+    next_placeholder = get_next_round_to_resolve(fresh.rounds)
+    if next_placeholder is not None:
+        round_ = next((r for r in fresh.rounds if r.id == next_placeholder.id), None)
+        if round_ is not None and round_.lifecycle_state == RoundLifecycleState.PLACEHOLDER:
+            await _assign_teams_to_round(
+                tournament_id, fresh, round_, advance_to_resolved=True
+            )
+            # Refresh after the first resolution so pass 2 sees the updated state
+            fresh = await get_stage_item(tournament_id, stage_item.id)
+
+    # Pass 2: re-resolve RESOLVED not-started non-pinned rounds
+    for candidate in get_rounds_to_re_resolve(fresh.rounds):
+        round_ = next((r for r in fresh.rounds if r.id == candidate.id), None)
+        if round_ is not None and round_.lifecycle_state == RoundLifecycleState.RESOLVED:
+            await _assign_teams_to_round(
+                tournament_id, fresh, round_, advance_to_resolved=False
+            )

--- a/backend/bracket/logic/scheduling/swiss_resolution_policy.py
+++ b/backend/bracket/logic/scheduling/swiss_resolution_policy.py
@@ -3,6 +3,21 @@ from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.util import RoundWithMatches
 
 
+def get_rounds_to_re_resolve(rounds: list[RoundWithMatches]) -> list[RoundWithMatches]:
+    """Return all RESOLVED not-started non-pinned rounds eligible for re-resolution.
+
+    These are rounds where team assignments can be overwritten by an upstream score correction.
+    Pinned rounds (is_pinned=True) are never touched by the automated policy.
+    """
+    return [
+        r
+        for r in rounds
+        if r.lifecycle_state == RoundLifecycleState.RESOLVED
+        and all(m.state == MatchState.NOT_STARTED for m in r.matches)
+        and not r.is_pinned
+    ]
+
+
 def get_next_round_to_resolve(rounds: list[RoundWithMatches]) -> RoundWithMatches | None:
     """Return the next PLACEHOLDER round that is ready to resolve, or None.
 

--- a/backend/bracket/models/db/round.py
+++ b/backend/bracket/models/db/round.py
@@ -4,7 +4,7 @@ from heliclockter import datetime_utc
 from pydantic import computed_field
 
 from bracket.models.db.shared import BaseModelORM
-from bracket.utils.id_types import RoundId, StageItemId
+from bracket.utils.id_types import MatchId, RoundId, StageItemId
 from bracket.utils.types import EnumAutoStr
 
 
@@ -41,3 +41,8 @@ class RoundUpdateBody(BaseModelORM):
 class RoundCreateBody(BaseModelORM):
     name: str | None = None
     stage_item_id: StageItemId
+
+
+class SwapMatchInputsBody(BaseModelORM):
+    match1_id: MatchId
+    match2_id: MatchId

--- a/backend/bracket/routes/rounds.py
+++ b/backend/bracket/routes/rounds.py
@@ -7,12 +7,14 @@ from bracket.logic.ranking.calculation import (
     recalculate_ranking_for_stage_item,
 )
 from bracket.logic.subscriptions import check_requirement
+from bracket.models.db.match import MatchState
 from bracket.models.db.round import (
     Round,
     RoundCreateBody,
     RoundInsertable,
     RoundLifecycleState,
     RoundUpdateBody,
+    SwapMatchInputsBody,
 )
 from bracket.models.db.tournament import Tournament
 from bracket.models.db.user import UserPublic
@@ -24,12 +26,13 @@ from bracket.routes.util import (
     round_dependency,
     round_with_matches_dependency,
 )
-from bracket.sql.matches import sql_delete_match
+from bracket.sql.matches import sql_delete_match, sql_set_input_ids_for_match
 from bracket.sql.rounds import (
     get_next_round_name,
     set_round_lifecycle_state,
     sql_create_round,
     sql_delete_round,
+    sql_set_round_is_pinned,
 )
 from bracket.sql.stage_items import get_stage_item
 from bracket.sql.stages import get_full_tournament_details
@@ -126,4 +129,79 @@ async def update_round_by_id(
             "lifecycle_state": round_body.lifecycle_state.value,
         },
     )
+    return SuccessResponse()
+
+
+@router.post(
+    "/tournaments/{tournament_id}/rounds/{round_id}/swap_inputs",
+    response_model=SuccessResponse,
+)
+async def swap_match_inputs(
+    tournament_id: TournamentId,
+    round_id: RoundId,
+    body: SwapMatchInputsBody,
+    _: UserPublic = Depends(user_authenticated_for_tournament),
+    __: Tournament = Depends(disallow_archived_tournament),
+    round_with_matches: RoundWithMatches = Depends(round_with_matches_dependency),
+) -> SuccessResponse:
+    """Swap team assignments between two matches in a RESOLVED not-started round.
+
+    Pins the round so the manual override is preserved through upstream score corrections.
+    Validated so that no referee ends up playing in the match they referee.
+    """
+    if round_with_matches.lifecycle_state != RoundLifecycleState.RESOLVED:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Can only swap inputs in a RESOLVED round",
+        )
+
+    if any(m.state != MatchState.NOT_STARTED for m in round_with_matches.matches):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot swap inputs in a round that has already started",
+        )
+
+    matches_by_id = {m.id: m for m in round_with_matches.matches}
+    match1 = matches_by_id.get(body.match1_id)
+    match2 = matches_by_id.get(body.match2_id)
+
+    if match1 is None or match2 is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Both matches must belong to the specified round",
+        )
+
+    if match1.id == match2.id:
+        return SuccessResponse()
+
+    # Validate referee eligibility after swap: referee must not be one of the playing inputs.
+    new_m1_inputs = {match2.stage_item_input1_id, match2.stage_item_input2_id}
+    new_m2_inputs = {match1.stage_item_input1_id, match1.stage_item_input2_id}
+
+    if (
+        match1.referee_stage_item_input_id is not None
+        and match1.referee_stage_item_input_id in new_m1_inputs
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Swap would cause a referee to play in their own match",
+        )
+
+    if (
+        match2.referee_stage_item_input_id is not None
+        and match2.referee_stage_item_input_id in new_m2_inputs
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Swap would cause a referee to play in their own match",
+        )
+
+    await sql_set_input_ids_for_match(
+        round_id, body.match1_id, [match2.stage_item_input1_id, match2.stage_item_input2_id]
+    )
+    await sql_set_input_ids_for_match(
+        round_id, body.match2_id, [match1.stage_item_input1_id, match1.stage_item_input2_id]
+    )
+    await sql_set_round_is_pinned(round_id, is_pinned=True)
+
     return SuccessResponse()

--- a/backend/bracket/sql/rounds.py
+++ b/backend/bracket/sql/rounds.py
@@ -62,6 +62,15 @@ async def get_next_round_name(tournament_id: TournamentId, stage_item_id: StageI
     return f"Round {round_count + 1:02d}"
 
 
+async def sql_set_round_is_pinned(round_id: RoundId, is_pinned: bool) -> None:
+    query = """
+        UPDATE rounds
+        SET is_pinned = :is_pinned
+        WHERE rounds.id = :round_id
+    """
+    await database.execute(query=query, values={"round_id": round_id, "is_pinned": is_pinned})
+
+
 async def sql_delete_rounds_for_stage_item_id(stage_item_id: StageItemId) -> None:
     query = """
         DELETE FROM rounds

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -3472,6 +3472,24 @@
         "title": "SuggestedMatch",
         "type": "object"
       },
+      "SwapMatchInputsBody": {
+        "properties": {
+          "match1_id": {
+            "title": "Match1 Id",
+            "type": "integer"
+          },
+          "match2_id": {
+            "title": "Match2 Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "match1_id",
+          "match2_id"
+        ],
+        "title": "SwapMatchInputsBody",
+        "type": "object"
+      },
       "Team": {
         "properties": {
           "active": {
@@ -6920,6 +6938,73 @@
           }
         ],
         "summary": "Update Round By Id",
+        "tags": [
+          "Rounds"
+        ]
+      }
+    },
+    "/tournaments/{tournament_id}/rounds/{round_id}/swap_inputs": {
+      "post": {
+        "description": "Swap team assignments between two matches in a RESOLVED not-started round.\n\nPins the round so the manual override is preserved through upstream score corrections.\nValidated so that no referee ends up playing in the match they referee.",
+        "operationId": "swap_match_inputs_tournaments__tournament_id__rounds__round_id__swap_inputs_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tournament_id",
+            "required": true,
+            "schema": {
+              "title": "Tournament Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "round_id",
+            "required": true,
+            "schema": {
+              "title": "Round Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SwapMatchInputsBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Swap Match Inputs",
         "tags": [
           "Rounds"
         ]

--- a/backend/tests/integration_tests/api/test_swiss_pinned_round.py
+++ b/backend/tests/integration_tests/api/test_swiss_pinned_round.py
@@ -1,0 +1,232 @@
+"""Integration tests for Swiss pinned rounds (issue #155).
+
+Covers:
+1. POST rounds/{id}/swap_inputs swaps match inputs and pins the round.
+2. A pinned RESOLVED round is not re-resolved after an upstream score correction.
+"""
+
+import pytest
+
+from bracket.logic.scheduling.builder import build_matches_for_stage_item
+from bracket.logic.scheduling.handle_stage_activation import (
+    _resolve_round_1_for_swiss_stage_item,
+)
+from bracket.models.db.match import MatchState
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.stage import Stage
+from bracket.models.db.stage_item import StageItem, StageItemWithInputsCreate, StageType
+from bracket.models.db.stage_item_inputs import StageItemInputCreateBodyFinal
+from bracket.models.db.team import Team
+from bracket.models.db.util import RoundWithMatches, StageItemWithRounds
+from bracket.schema import matches, rounds, stage_item_inputs, stage_items, stages
+from bracket.sql.stage_items import get_stage_item, sql_create_stage_item_with_inputs
+from bracket.utils.dummy_records import DUMMY_STAGE1, DUMMY_TEAM1
+from bracket.utils.http import HTTPMethod
+from bracket.utils.id_types import TournamentId
+from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
+from tests.integration_tests.models import AuthContext
+from tests.integration_tests.sql import (
+    assert_row_count_and_clear,
+    inserted_stage,
+    inserted_team,
+)
+
+
+async def _build_resolved_swiss_stage(
+    tournament_id: TournamentId,
+    auth_context: AuthContext,
+    stage_inserted: Stage,
+    t1: Team,
+    t2: Team,
+    t3: Team,
+    t4: Team,
+) -> tuple[StageItem, RoundWithMatches, RoundWithMatches]:
+    """Helper: create a 4-team 2-round Swiss stage, resolve round 1, complete all round 1 matches.
+
+    Returns (stage_item_raw, round1, round2_resolved).
+    round2_resolved is RESOLVED with concrete team assignments.
+    """
+    stage_item_raw = await sql_create_stage_item_with_inputs(
+        tournament_id,
+        StageItemWithInputsCreate(
+            stage_id=stage_inserted.id,
+            type=StageType.SWISS,
+            team_count=4,
+            games_per_player=2,
+            ranking_id=auth_context.ranking.id,
+            inputs=[
+                StageItemInputCreateBodyFinal(slot=1, team_id=t1.id),
+                StageItemInputCreateBodyFinal(slot=2, team_id=t2.id),
+                StageItemInputCreateBodyFinal(slot=3, team_id=t3.id),
+                StageItemInputCreateBodyFinal(slot=4, team_id=t4.id),
+            ],
+        ),
+    )
+    await build_matches_for_stage_item(stage_item_raw, tournament_id)
+
+    stage_item: StageItemWithRounds = await get_stage_item(tournament_id, stage_item_raw.id)
+    await _resolve_round_1_for_swiss_stage_item(tournament_id, stage_item)
+
+    stage_item = await get_stage_item(tournament_id, stage_item_raw.id)
+    round1, _ = sorted(stage_item.rounds, key=lambda r: r.id)
+
+    for match in round1.matches:
+        # Two-step: first set IN_PROGRESS with a non-zero score, then COMPLETE.
+        resp = await send_tournament_request(
+            HTTPMethod.PUT,
+            f"matches/{match.id}",
+            auth_context,
+            json={
+                "round_id": round1.id,
+                "state": MatchState.IN_PROGRESS.value,
+                "stage_item_input1_score": 1,
+                "stage_item_input2_score": 0,
+            },
+        )
+        assert resp == SUCCESS_RESPONSE
+        resp = await send_tournament_request(
+            HTTPMethod.PUT,
+            f"matches/{match.id}",
+            auth_context,
+            json={"round_id": round1.id, "state": MatchState.COMPLETED.value},
+        )
+        assert resp == SUCCESS_RESPONSE
+
+    stage_item = await get_stage_item(tournament_id, stage_item_raw.id)
+    round1, round2 = sorted(stage_item.rounds, key=lambda r: r.id)
+    assert round2.lifecycle_state == RoundLifecycleState.RESOLVED
+
+    return stage_item_raw, round1, round2
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_swap_inputs_pins_round_and_swaps_match_assignments(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """POST rounds/{id}/swap_inputs swaps team assignments and sets is_pinned=True on the round."""
+    tournament_id = auth_context.tournament.id
+
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id, "is_active": True})
+        ) as stage_inserted,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t1,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t3,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t4,
+    ):
+        try:
+            stage_item_raw, _round1, round2 = await _build_resolved_swiss_stage(
+                tournament_id, auth_context, stage_inserted, t1, t2, t3, t4
+            )
+
+            match_a, match_b = sorted(round2.matches, key=lambda m: m.id)
+            assert match_a.stage_item_input1_id is not None
+            assert match_a.stage_item_input2_id is not None
+            assert match_b.stage_item_input1_id is not None
+            assert match_b.stage_item_input2_id is not None
+
+            original_b_input1 = match_b.stage_item_input1_id
+            original_b_input2 = match_b.stage_item_input2_id
+
+            resp = await send_tournament_request(
+                HTTPMethod.POST,
+                f"rounds/{round2.id}/swap_inputs",
+                auth_context,
+                json={"match1_id": match_a.id, "match2_id": match_b.id},
+            )
+            assert resp == SUCCESS_RESPONSE
+
+            stage_item: StageItemWithRounds = await get_stage_item(
+                tournament_id, stage_item_raw.id
+            )
+            round2_pinned = sorted(stage_item.rounds, key=lambda r: r.id)[1]
+            assert round2_pinned.is_pinned is True
+
+            swapped_a, swapped_b = sorted(round2_pinned.matches, key=lambda m: m.id)
+            assert swapped_a.stage_item_input1_id == original_b_input1
+            assert swapped_a.stage_item_input2_id == original_b_input2
+
+        finally:
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_pinned_round_survives_upstream_correction(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """After pinning round 2 via swap_inputs, correcting a round-1 score leaves it unchanged."""
+    tournament_id = auth_context.tournament.id
+
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id, "is_active": True})
+        ) as stage_inserted,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t1,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t3,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t4,
+    ):
+        try:
+            stage_item_raw, round1, round2 = await _build_resolved_swiss_stage(
+                tournament_id, auth_context, stage_inserted, t1, t2, t3, t4
+            )
+
+            match_a, match_b = sorted(round2.matches, key=lambda m: m.id)
+
+            resp = await send_tournament_request(
+                HTTPMethod.POST,
+                f"rounds/{round2.id}/swap_inputs",
+                auth_context,
+                json={"match1_id": match_a.id, "match2_id": match_b.id},
+            )
+            assert resp == SUCCESS_RESPONSE
+
+            stage_item: StageItemWithRounds = await get_stage_item(
+                tournament_id, stage_item_raw.id
+            )
+            round2_pinned = sorted(stage_item.rounds, key=lambda r: r.id)[1]
+            assert round2_pinned.is_pinned is True
+
+            pinned_a, pinned_b = sorted(round2_pinned.matches, key=lambda m: m.id)
+            pinned_a_input1 = pinned_a.stage_item_input1_id
+            pinned_a_input2 = pinned_a.stage_item_input2_id
+            pinned_b_input1 = pinned_b.stage_item_input1_id
+            pinned_b_input2 = pinned_b.stage_item_input2_id
+
+            # Upstream correction: flip a round-1 score to shift ELO (triggers orchestrator).
+            first_r1_match = sorted(round1.matches, key=lambda m: m.id)[0]
+            resp = await send_tournament_request(
+                HTTPMethod.PUT,
+                f"matches/{first_r1_match.id}",
+                auth_context,
+                json={
+                    "round_id": round1.id,
+                    "state": MatchState.IN_PROGRESS.value,
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 1,
+                },
+            )
+            assert resp == SUCCESS_RESPONSE
+
+            stage_item = await get_stage_item(tournament_id, stage_item_raw.id)
+            round2_after = sorted(stage_item.rounds, key=lambda r: r.id)[1]
+
+            # Pinned round must be untouched by the orchestrator
+            assert round2_after.is_pinned is True
+            after_a, after_b = sorted(round2_after.matches, key=lambda m: m.id)
+            assert after_a.stage_item_input1_id == pinned_a_input1
+            assert after_a.stage_item_input2_id == pinned_a_input2
+            assert after_b.stage_item_input1_id == pinned_b_input1
+            assert after_b.stage_item_input2_id == pinned_b_input2
+
+        finally:
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)

--- a/backend/tests/unit_tests/test_swiss_resolution_policy.py
+++ b/backend/tests/unit_tests/test_swiss_resolution_policy.py
@@ -24,6 +24,7 @@ def _make_round(
     round_id: int,
     lifecycle_state: RoundLifecycleState,
     match_states: list[MatchState],
+    is_pinned: bool | None = None,
 ) -> RoundWithMatches:
     return RoundWithMatches(
         id=RoundId(round_id),
@@ -32,6 +33,7 @@ def _make_round(
         stage_item_id=StageItemId(-1),
         name=f"R{round_id}",
         created=DUMMY_MOCK_TIME,
+        is_pinned=is_pinned,
     )
 
 
@@ -94,3 +96,37 @@ def test_sequential_only_next_placeholder_returned() -> None:
     result = get_next_round_to_resolve([r1, r2, r3])
     assert result is not None
     assert result.id == r2.id
+
+
+# ── Tests for get_rounds_to_re_resolve (issue #155) ──────────────────────────
+
+
+def test_pinned_resolved_round_excluded_from_re_resolution() -> None:
+    """A RESOLVED pinned round must never be returned for re-resolution."""
+    from bracket.logic.scheduling.swiss_resolution_policy import get_rounds_to_re_resolve
+
+    r1 = _make_round(1, RoundLifecycleState.LOCKED, [MatchState.COMPLETED])
+    r2 = _make_round(2, RoundLifecycleState.RESOLVED, [MatchState.NOT_STARTED], is_pinned=True)
+    result = get_rounds_to_re_resolve([r1, r2])
+    assert result == []
+
+
+def test_resolved_not_started_not_pinned_eligible_for_re_resolution() -> None:
+    """A RESOLVED not-started non-pinned round IS returned for re-resolution."""
+    from bracket.logic.scheduling.swiss_resolution_policy import get_rounds_to_re_resolve
+
+    r1 = _make_round(1, RoundLifecycleState.LOCKED, [MatchState.COMPLETED])
+    r2 = _make_round(2, RoundLifecycleState.RESOLVED, [MatchState.NOT_STARTED])
+    result = get_rounds_to_re_resolve([r1, r2])
+    assert len(result) == 1
+    assert result[0].id == r2.id
+
+
+def test_locked_resolved_round_not_eligible_for_re_resolution() -> None:
+    """A RESOLVED round that has started (LOCKED) must never be re-resolved."""
+    from bracket.logic.scheduling.swiss_resolution_policy import get_rounds_to_re_resolve
+
+    r1 = _make_round(1, RoundLifecycleState.LOCKED, [MatchState.COMPLETED])
+    r2 = _make_round(2, RoundLifecycleState.RESOLVED, [MatchState.IN_PROGRESS])
+    result = get_rounds_to_re_resolve([r1, r2])
+    assert result == []


### PR DESCRIPTION
- Add `get_rounds_to_re_resolve()` to the resolution policy: returns all
  RESOLVED not-started non-pinned rounds eligible for re-resolution after
  upstream score corrections. Pinned rounds (`is_pinned=True`) are always
  skipped.
- Extend the resolution orchestrator with a second pass that calls
  `get_rounds_to_re_resolve` so upstream score changes flow into future
  pairings without touching locked or pinned rounds.
- Add `sql_set_round_is_pinned` SQL helper.
- Add `SwapMatchInputsBody` model and
  `POST /tournaments/{id}/rounds/{round_id}/swap_inputs` endpoint: swaps
  team assignments between two matches in a RESOLVED not-started round,
  validates referee eligibility, and sets `is_pinned=True` on the round.
- Unit tests: 3 new cases for `get_rounds_to_re_resolve` (pinned excluded,
  non-pinned included, started round excluded).
- Integration tests: swap_inputs pins and swaps correctly; pinned round
  survives an upstream score correction that would otherwise re-resolve it.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YRwYYkGefq63sqHv5ax2Rv