### PR TITLE
Wire TBD labels into planning view for placeholder-round matches

### DIFF
--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -116,6 +116,7 @@ function MatchCard({
   const { t } = useTranslation();
   const { match } = block;
   const entry = matchesLookup[match.id];
+  const isPlaceholder = entry?.round.lifecycle_state === 'PLACEHOLDER';
 
   // The card covers only the playing time; the margin after the match shows as a
   // calendar-style gap before the next card.
@@ -146,8 +147,9 @@ function MatchCard({
   // four-line card, and on the compact three-line card where both teams share a line.
   const showReferee = lines >= 3 || (lines === 2 && combineTeams);
 
-  let input1 = formatMatchInput1(t, stageItemsLookup, matchesLookup, match);
-  let input2 = formatMatchInput2(t, stageItemsLookup, matchesLookup, match);
+  const emptyLabelKey = isPlaceholder ? 'tbd_label' : 'empty_slot';
+  let input1 = formatMatchInput1(t, stageItemsLookup, matchesLookup, match, emptyLabelKey);
+  let input2 = formatMatchInput2(t, stageItemsLookup, matchesLookup, match, emptyLabelKey);
   if (zoom === 'compact') {
     input1 = abbreviateTeamName(input1);
     input2 = abbreviateTeamName(input2);
@@ -514,6 +516,7 @@ function MatchCard({
             stageItemsLookup={stageItemsLookup}
             conflictIcon={mergeConflictIcons ? null : refereeConflictIcon}
             abbreviated={zoom === 'compact'}
+            placeholderLabel={isPlaceholder ? t('tbd_label') : undefined}
           />
         )}
       </Box>

--- a/frontend/src/components/scheduling/unscheduled_sheet.tsx
+++ b/frontend/src/components/scheduling/unscheduled_sheet.tsx
@@ -78,16 +78,17 @@ export default function UnscheduledSheet({
     const colour =
       (entry != null ? stageItemColours[entry.stageItem.id] : undefined) ??
       NEUTRAL_STAGE_ITEM_COLOUR;
+    const emptyLabelKey = entry?.round.lifecycle_state === 'PLACEHOLDER' ? 'tbd_label' : 'empty_slot';
 
     return (
       <UnstyledButton key={match.id} onClick={() => onSelectMatch(match)} w="100%" py="xs">
         <Flex justify="space-between" align="center" gap="xs" wrap="nowrap">
           <Box style={{ minWidth: 0 }}>
             <Text size="sm" fw={500} truncate>
-              {formatMatchInput1(t, stageItemsLookup, matchesLookup, match)}
+              {formatMatchInput1(t, stageItemsLookup, matchesLookup, match, emptyLabelKey)}
             </Text>
             <Text size="sm" fw={500} truncate>
-              {formatMatchInput2(t, stageItemsLookup, matchesLookup, match)}
+              {formatMatchInput2(t, stageItemsLookup, matchesLookup, match, emptyLabelKey)}
             </Text>
           </Box>
           {entry != null && label != null && (

--- a/frontend/src/logic/planning/unscheduled_tray.test.ts
+++ b/frontend/src/logic/planning/unscheduled_tray.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type {
   LevelResponse,
   MatchWithDetails,
+  RoundWithMatches,
   StageItemWithRounds,
   StageWithStageItems,
 } from '@openapi';
@@ -40,6 +41,7 @@ function entry(
 ): MatchLookupEntry {
   return {
     match: matchDetails,
+    round: { lifecycle_state: 'ACTIVE' } as RoundWithMatches,
     stage: parentStage,
     stageItem: parentStageItem,
     matchNumber: 1,

--- a/frontend/src/services/lookups.tsx
+++ b/frontend/src/services/lookups.tsx
@@ -4,6 +4,7 @@ import { groupBy, responseIsValid } from '@components/utils/util';
 import {
   FullTeamWithPlayers,
   MatchWithDetails,
+  RoundWithMatches,
   StageItemWithRounds,
   StageWithStageItems,
 } from '@openapi';
@@ -94,6 +95,7 @@ export function getStageItemTeamsLookup(swrStagesResponse: SWRResponse) {
 /** One match in the schedule tree with its parent stage item and top-level stage. */
 export type MatchLookupEntry = {
   match: MatchWithDetails;
+  round: RoundWithMatches;
   stageItem: StageItemWithRounds;
   stage: StageWithStageItems;
   /**
@@ -117,7 +119,7 @@ export function getMatchLookup(swrStagesResponse: SWRResponse): Record<number, M
       for (const round of stageItem.rounds) {
         for (const match of round.matches) {
           matchNumber += 1;
-          result.push([match.id, { match, stageItem, stage, matchNumber }]);
+          result.push([match.id, { match, round, stageItem, stage, matchNumber }]);
         }
       }
     }


### PR DESCRIPTION
`MatchLookupEntry` now carries the parent `RoundWithMatches` so the
schedule grid and unscheduled tray can check `lifecycle_state` and
substitute `tbd_label` for `empty_slot` on PLACEHOLDER rounds, matching
the behaviour already in the brackets view.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FypV4sxiJ6QHphRDpdWZqY