### PR TITLE
Show round number instead of match number for swiss and single elimination

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -172,6 +172,8 @@
     "match_context_level_label": "Level",
     "match_context_match_label": "Spiel",
     "match_context_match_number": "Spiel {{number}}",
+    "match_context_round_label": "Runde",
+    "match_context_round_number": "Runde {{number}}",
     "match_context_stage_item_label": "Stage-Element",
     "match_context_stage_label": "Phase",
     "max_results_input_label": "Maximale Ergebnisse",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -172,6 +172,8 @@
     "match_context_level_label": "Level",
     "match_context_match_label": "Match",
     "match_context_match_number": "Match {{number}}",
+    "match_context_round_label": "Round",
+    "match_context_round_number": "Round {{number}}",
     "match_context_stage_item_label": "Stage item",
     "match_context_stage_label": "Stage",
     "max_results_input_label": "Max results",

--- a/frontend/src/components/modals/match_modal.tsx
+++ b/frontend/src/components/modals/match_modal.tsx
@@ -255,6 +255,7 @@ function MatchModalForm({
     : [];
   const contextColour =
     level != null && levels != null ? levelSwatchColour(level.id, levels) : 'gray';
+  const isRoundRobin = matchEntry?.stageItem.type === 'ROUND_ROBIN';
   const contextBadges = [
     level != null ? { label: t('match_context_level_label'), value: level.name } : null,
     matchEntry != null
@@ -263,10 +264,16 @@ function MatchModalForm({
     matchEntry != null
       ? { label: t('match_context_stage_item_label'), value: matchEntry.stageItem.name }
       : null,
-    matchEntry != null
+    matchEntry != null && isRoundRobin
       ? {
           label: t('match_context_match_label'),
           value: t('match_context_match_number', { number: matchEntry.matchNumber }),
+        }
+      : null,
+    matchEntry != null && !isRoundRobin
+      ? {
+          label: t('match_context_round_label'),
+          value: t('match_context_round_number', { number: matchEntry.roundNumber }),
         }
       : null,
   ].filter((badge): badge is { label: string; value: string } => badge != null);

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -156,10 +156,13 @@ function MatchCard({
   }
 
   // The match's identity badge, shown at every card height: the stage item plus
-  // its running match number ("Group C · 3"). The colour already carries the
-  // level (and, via its hue cluster, the stage), so the level name is never
-  // written; the stage name is prepended only when the card has a line to spare.
-  const counter = entry?.matchNumber;
+  // its running counter. For round-robin the counter is the match number ("Group C · 3");
+  // for swiss and single-elimination it is the round number ("Group A · R2") so the badge
+  // communicates which round of the bracket the match belongs to. The colour already carries
+  // the level (and, via its hue cluster, the stage), so the level name is never written;
+  // the stage name is prepended only when the card has a line to spare.
+  const isRoundRobin = entry?.stageItem.type === 'ROUND_ROBIN';
+  const counter = isRoundRobin ? entry?.matchNumber : entry?.roundNumber;
   const itemName = entry?.stageItem.name;
   const stageName = entry?.stage.name;
   const coreFull =

--- a/frontend/src/components/scheduling/unscheduled_sheet.tsx
+++ b/frontend/src/components/scheduling/unscheduled_sheet.tsx
@@ -72,9 +72,11 @@ export default function UnscheduledSheet({
     const entry = matchesLookup[match.id];
     const baseLabel =
       badgeLabel ?? (entry != null ? `${entry.stage.name} · ${entry.stageItem.name}` : null);
-    // Mirror the grid badge: append the running match number ("Group C · 3").
+    // Mirror the grid badge: round number for swiss/elimination, match number for round-robin.
+    const isRoundRobin = entry?.stageItem.type === 'ROUND_ROBIN';
+    const counter = isRoundRobin ? entry?.matchNumber : entry?.roundNumber;
     const label =
-      baseLabel != null && entry != null ? `${baseLabel} · ${entry.matchNumber}` : baseLabel;
+      baseLabel != null && entry != null ? `${baseLabel} · ${counter}` : baseLabel;
     const colour =
       (entry != null ? stageItemColours[entry.stageItem.id] : undefined) ??
       NEUTRAL_STAGE_ITEM_COLOUR;

--- a/frontend/src/logic/planning/unscheduled_tray.test.ts
+++ b/frontend/src/logic/planning/unscheduled_tray.test.ts
@@ -45,6 +45,7 @@ function entry(
     stage: parentStage,
     stageItem: parentStageItem,
     matchNumber: 1,
+    roundNumber: 1,
   };
 }
 

--- a/frontend/src/services/lookups.tsx
+++ b/frontend/src/services/lookups.tsx
@@ -104,6 +104,8 @@ export type MatchLookupEntry = {
    * where the match sits on the schedule.
    */
   matchNumber: number;
+  /** 1-based position of the round within its stage item. */
+  roundNumber: number;
 };
 
 /**
@@ -116,10 +118,12 @@ export function getMatchLookup(swrStagesResponse: SWRResponse): Record<number, M
   for (const stage of swrStagesResponse.data.data as StageWithStageItems[]) {
     for (const stageItem of stage.stage_items) {
       let matchNumber = 0;
-      for (const round of stageItem.rounds) {
+      for (let roundIdx = 0; roundIdx < stageItem.rounds.length; roundIdx++) {
+        const round = stageItem.rounds[roundIdx];
+        const roundNumber = roundIdx + 1;
         for (const match of round.matches) {
           matchNumber += 1;
-          result.push([match.id, { match, round, stageItem, stage, matchNumber }]);
+          result.push([match.id, { match, round, stageItem, stage, matchNumber, roundNumber }]);
         }
       }
     }


### PR DESCRIPTION
For swiss and single elimination stage items, the match details modal now
shows "Round N" instead of "Match N" in the context badge row. The schedule
grid cards and unscheduled-matches tray labels mirror this: they display
the round number as the counter suffix for those two types, and keep the
match number for round robin (which has only one round anyway).

The round number is computed as the 1-based index of the round within the
stage item's rounds array and is stored in a new `roundNumber` field on
`MatchLookupEntry`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UhLpNSETKYoNxWibGjBhgc