### PR TITLE
Fix Swiss scheduler sequence bug: enforce round-N-before-round-N+1 ordering

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -18,6 +18,7 @@ from bracket.models.db.match import (
     MatchWithDetailsDefinitive,
     SchedulerWeights,
 )
+from bracket.models.db.stage_item import StageType
 from bracket.models.db.stage_item_inputs import StageItemInputEmpty
 from bracket.models.db.tournament import Tournament
 from bracket.models.db.util import StageItemWithRounds, StageWithStageItems
@@ -78,6 +79,7 @@ class _MatchContext:
     # True when the match's stage item has at least one unwired (empty) input slot, e.g. a
     # knockout place filled manually only once the previous stage is fully played.
     stage_item_has_open_slot: bool
+    is_swiss: bool = False
 
 
 @dataclass(frozen=True)
@@ -245,6 +247,7 @@ def _get_match_contexts(
             input_ids=_input_ids(match, slot_id_map, stage_item.id),
             cross_stage_source_ids=_cross_stage_source_ids(match),
             stage_item_has_open_slot=_has_open_slot(stage_item),
+            is_swiss=stage_item.type == StageType.SWISS,
         )
         for stage in stages
         for stage_item in stage.stage_items
@@ -554,6 +557,23 @@ def _precedence_pairs(contexts: list[_MatchContext]) -> list[tuple[_MatchContext
         for source_stage_item_id in successor.cross_stage_source_ids:
             for feeder in contexts_by_stage_item[source_stage_item_id]:
                 if feeder.match.id != successor.match.id:
+                    pair_ids.add((feeder.match.id, successor.match.id))
+
+    # Swiss stage items require strictly sequential rounds: every match in round N must
+    # finish (plus the default break) before any match in round N+1 can start, because
+    # Swiss pairings for round N+1 are determined by the results of round N.
+    swiss_by_item: dict[StageItemId, dict[int, list[_MatchContext]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for context in contexts:
+        if context.is_swiss:
+            swiss_by_item[context.stage_item_id][context.round_index].append(context)
+    for rounds_by_index in swiss_by_item.values():
+        for round_index in sorted(rounds_by_index):
+            if round_index + 1 not in rounds_by_index:
+                continue
+            for feeder in rounds_by_index[round_index]:
+                for successor in rounds_by_index[round_index + 1]:
                     pair_ids.add((feeder.match.id, successor.match.id))
 
     pair_ids |= _open_slot_precedence_ids(contexts)

--- a/backend/tests/unit_tests/planning_test.py
+++ b/backend/tests/unit_tests/planning_test.py
@@ -84,6 +84,7 @@ def _stage_with_rounds(
     rounds_per_item: list[list[list[MatchWithDetails]]],
     level_id: LevelId | None = None,
     inputs_per_item: list[list[StageItemInput]] | None = None,
+    stage_type: StageType = StageType.SINGLE_ELIMINATION,
 ) -> StageWithStageItems:
     stage_items = []
     for item_idx, rounds in enumerate(rounds_per_item):
@@ -112,7 +113,7 @@ def _stage_with_rounds(
                 ranking_id=None,
                 created=T0,
                 name=f"Group {item_idx}",
-                type=StageType.SINGLE_ELIMINATION,
+                type=stage_type,
             )
         )
     return StageWithStageItems(
@@ -630,6 +631,35 @@ def test_groups_in_a_stage_progress_round_for_round_when_free() -> None:
     # Each round's matches across the two groups finish at the same time (zero spread).
     assert _end_time(by_id[a1.id]) == _end_time(by_id[b1.id])
     assert _end_time(by_id[a2.id]) == _end_time(by_id[b2.id])
+
+
+# ── Swiss round sequencing ────────────────────────────────────────────────────
+
+
+def test_swiss_rounds_are_scheduled_sequentially() -> None:
+    """Swiss skeleton rounds must run in order: all round-N matches must end
+    (plus the default break) before any round-N+1 match can start.
+
+    Setup: one Swiss stage item, round 0 has 1 match, round 1 has 4 matches,
+    3 courts available.  Without a hard ordering constraint the optimizer can
+    fill spare courts in round 1 while round 0 is still running, producing a
+    smaller makespan — so without the fix the solver reliably picks that
+    invalid layout.
+    """
+    r0 = _match(1)
+    r1a, r1b, r1c, r1d = _match(2), _match(3), _match(4), _match(5)
+    stages = [_stage_with_rounds(1, [[[r0], [r1a, r1b, r1c, r1d]]], stage_type=StageType.SWISS)]
+
+    ops = build_schedule_plan(stages, [_court(1), _court(2), _court(3)], _tournament())
+
+    _assert_match_ids_scheduled(ops, [r0, r1a, r1b, r1c, r1d])
+    by_id = {op.match.id: op for op in ops}
+    r0_end = _end_time(by_id[r0.id])
+    r1_start = min(by_id[m.id].start_time for m in [r1a, r1b, r1c, r1d])
+    assert r1_start >= r0_end + timedelta(minutes=MARGIN), (
+        f"Round 1 starts at {r1_start} before round 0 ends at {r0_end} "
+        f"(margin={MARGIN}min); Swiss rounds must be strictly sequential"
+    )
 
 
 # ── Edge cases ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Swiss tournament rounds must run sequentially — round N+1 pairings depend on
round N results, so the auto-scheduler must not place any round-N+1 match before
all round-N matches have finished.

The CP-SAT optimizer had no such constraint: it treated Swiss skeleton matches
as independent and freely interleaved rounds to minimise makespan, letting a
round-2 match start before a round-1 match ended.

Fix: add `is_swiss: bool` to `_MatchContext` (populated from `stage_item.type`)
and extend `_precedence_pairs` to emit a (round-N-match, round-N+1-match) pair
for every consecutive-round combination in each Swiss stage item. The existing
`_add_precedence_constraints` machinery then enforces the ordering plus the
default break, exactly as it does for elimination feeder dependencies.

Test: `test_swiss_rounds_are_scheduled_sequentially` sets up 1 round-0 match
and 4 round-1 matches on 3 courts. Without the fix the optimizer fills spare
courts in round 1 alongside round 0 (strictly better makespan), so the test
fails reliably; with the fix it passes.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MHXCY14rTWB4tEEY52Vmg9