### PR TITLE
feat: add round_order_conflict marker for matches starting before previous round ends

### DIFF
--- a/backend/alembic/versions/a2c4e6f8b1d3_add_round_order_conflict_flag.py
+++ b/backend/alembic/versions/a2c4e6f8b1d3_add_round_order_conflict_flag.py
@@ -1,0 +1,31 @@
+"""add round_order_conflict flag to matches
+
+Revision ID: a2c4e6f8b1d3
+Revises: e1f4a9c7b2d3
+Create Date: 2026-06-23 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str | None = "a2c4e6f8b1d3"
+down_revision: str | None = "e1f4a9c7b2d3"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "matches",
+        sa.Column("round_order_conflict", sa.Boolean(), nullable=True, server_default="f"),
+    )
+    op.execute(text("UPDATE matches SET round_order_conflict=false"))
+    op.alter_column("matches", "round_order_conflict", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("matches", "round_order_conflict")

--- a/backend/bracket/logic/planning/conflicts.py
+++ b/backend/bracket/logic/planning/conflicts.py
@@ -57,6 +57,8 @@ class MatchConflictFlags:
     feeder_precedence_conflict: bool = False
     short_break_conflict: bool = False
     referee_conflict: bool = False
+    # Set on a match in round N whose start_time is before the last match of round N-1 ends.
+    round_order_conflict: bool = False
 
 
 def _get_all_matches(
@@ -377,6 +379,34 @@ def _set_slot_overlap_conflicts(
                 _flag_slot_occupancy(occupancy2, flags)
 
 
+def _set_round_order_conflicts(
+    stages: list[StageWithStageItems],
+    flags: dict[MatchId, MatchConflictFlags],
+) -> None:
+    """Flag matches in round N that start before all matches of round N-1 have ended.
+
+    Rounds within a stage item must complete in sequence. If any match in a later round
+    starts before the previous round's last scheduled match has ended, flag it.
+    """
+    for stage in stages:
+        for stage_item in stage.stage_items:
+            rounds = sorted(stage_item.rounds, key=lambda r: r.id)
+            for prev_round, curr_round in zip(rounds, rounds[1:], strict=False):
+                prev_round_end: datetime_utc | None = None
+                for match in prev_round.matches:
+                    if match.start_time is None:
+                        continue
+                    if prev_round_end is None or match.end_time > prev_round_end:
+                        prev_round_end = match.end_time
+
+                if prev_round_end is None:
+                    continue
+
+                for match in curr_round.matches:
+                    if match.start_time is not None and match.start_time < prev_round_end:
+                        flags[match.id].round_order_conflict = True
+
+
 def get_match_conflict_flags(
     stages: list[StageWithStageItems], default_break_minutes: int
 ) -> dict[MatchId, MatchConflictFlags]:
@@ -390,6 +420,7 @@ def get_match_conflict_flags(
     _set_cross_stage_precedence_conflicts(stages, flags)
     _set_cross_stage_feeder_precedence_conflicts(stages, flags)
     _set_short_break_conflicts(matches, default_break_minutes, flags)
+    _set_round_order_conflicts(stages, flags)
 
     return flags
 
@@ -428,7 +459,8 @@ async def set_conflicts(match_conflicts: dict[MatchId, MatchConflictFlags]) -> N
                 precedence_conflict = :precedence_conflict,
                 feeder_precedence_conflict = :feeder_precedence_conflict,
                 short_break_conflict = :short_break_conflict,
-                referee_conflict = :referee_conflict
+                referee_conflict = :referee_conflict,
+                round_order_conflict = :round_order_conflict
             WHERE id = :match_id
             """,
             values={
@@ -439,6 +471,7 @@ async def set_conflicts(match_conflicts: dict[MatchId, MatchConflictFlags]) -> N
                 "feeder_precedence_conflict": conflict.feeder_precedence_conflict,
                 "short_break_conflict": conflict.short_break_conflict,
                 "referee_conflict": conflict.referee_conflict,
+                "round_order_conflict": conflict.round_order_conflict,
             },
         )
 

--- a/backend/bracket/models/db/match.py
+++ b/backend/bracket/models/db/match.py
@@ -44,6 +44,7 @@ class MatchBaseInsertable(BaseModelORM):
     feeder_precedence_conflict: bool = False
     short_break_conflict: bool = False
     referee_conflict: bool = False
+    round_order_conflict: bool = False
     state: MatchState = MatchState.NOT_STARTED
     completed_at: datetime_utc | None = None
 

--- a/backend/bracket/schema.py
+++ b/backend/bracket/schema.py
@@ -175,6 +175,7 @@ matches = Table(
     Column("feeder_precedence_conflict", Boolean, nullable=False, server_default="f"),
     Column("short_break_conflict", Boolean, nullable=False, server_default="f"),
     Column("referee_conflict", Boolean, nullable=False, server_default="f"),
+    Column("round_order_conflict", Boolean, nullable=False, server_default="f"),
     Column(
         "stage_item_input1_winner_from_match_id",
         BigInteger,

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -532,6 +532,11 @@
             "title": "Round Id",
             "type": "integer"
           },
+          "round_order_conflict": {
+            "default": false,
+            "title": "Round Order Conflict",
+            "type": "boolean"
+          },
           "short_break_conflict": {
             "default": false,
             "title": "Short Break Conflict",
@@ -665,6 +670,7 @@
           "feeder_precedence_conflict",
           "short_break_conflict",
           "referee_conflict",
+          "round_order_conflict",
           "state",
           "completed_at",
           "stage_item_input1_id",
@@ -1115,6 +1121,11 @@
             "title": "Round Id",
             "type": "integer"
           },
+          "round_order_conflict": {
+            "default": false,
+            "title": "Round Order Conflict",
+            "type": "boolean"
+          },
           "short_break_conflict": {
             "default": false,
             "title": "Short Break Conflict",
@@ -1248,6 +1259,7 @@
           "feeder_precedence_conflict",
           "short_break_conflict",
           "referee_conflict",
+          "round_order_conflict",
           "state",
           "completed_at",
           "stage_item_input1_id",
@@ -1428,6 +1440,11 @@
             "title": "Round Id",
             "type": "integer"
           },
+          "round_order_conflict": {
+            "default": false,
+            "title": "Round Order Conflict",
+            "type": "boolean"
+          },
           "short_break_conflict": {
             "default": false,
             "title": "Short Break Conflict",
@@ -1555,6 +1572,7 @@
           "feeder_precedence_conflict",
           "short_break_conflict",
           "referee_conflict",
+          "round_order_conflict",
           "state",
           "completed_at",
           "stage_item_input1_id",

--- a/backend/tests/unit_tests/conflicts_test.py
+++ b/backend/tests/unit_tests/conflicts_test.py
@@ -901,3 +901,166 @@ def test_conflict_placeholder_playing_slots_non_overlapping_no_conflict() -> Non
 
     assert flags[match1.id].stage_item_input1_conflict is False
     assert flags[match2.id].stage_item_input1_conflict is False
+
+
+# ---------------------------------------------------------------------------
+# Round order conflict tests
+# ---------------------------------------------------------------------------
+
+
+def _make_two_round_stage(
+    round1_match_start: object,
+    round2_match_start: object,
+    duration_minutes: int = 60,
+) -> tuple[StageWithStageItems, MatchId, MatchId]:
+    """Build a single-stage-item with two rounds, one match each; return their IDs.
+
+    Round 1 has a lower (more negative) ID so sorting by id puts it before round 2,
+    matching the real database where earlier rounds are created first and get lower auto-increment
+    IDs.
+    """
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    r1_match = _make_definitive_match(
+        MatchId(-41),
+        inp[0],
+        inp[1],
+        RoundId(-41),
+        CourtId(-1),
+        round1_match_start,
+        duration_minutes,
+    )
+    r2_match = _make_definitive_match(
+        MatchId(-40),
+        inp[2],
+        inp[3],
+        RoundId(-40),
+        CourtId(-2),
+        round2_match_start,
+        duration_minutes,
+    )
+    round1 = RoundWithMatches(
+        id=RoundId(-41),
+        matches=[r1_match],
+        stage_item_id=StageItemId(-40),
+        created=MOCK_NOW,
+        lifecycle_state=RoundLifecycleState.ACTIVE,
+        name="Round 1",
+    )
+    round2 = RoundWithMatches(
+        id=RoundId(-40),
+        matches=[r2_match],
+        stage_item_id=StageItemId(-40),
+        created=MOCK_NOW,
+        lifecycle_state=RoundLifecycleState.ACTIVE,
+        name="Round 2",
+    )
+    stage_item = StageItemWithRounds(
+        rounds=[round1, round2],
+        inputs=[inp[0], inp[1]],
+        type_name="Single Elimination",
+        team_count=4,
+        ranking_id=None,
+        id=StageItemId(-40),
+        stage_id=StageId(-40),
+        name="",
+        created=MOCK_NOW,
+        type=StageType.SINGLE_ELIMINATION,
+    )
+    stage = StageWithStageItems(
+        id=StageId(-40),
+        tournament_id=tid,
+        name="",
+        created=MOCK_NOW,
+        is_active=False,
+        stage_items=[stage_item],
+    )
+    return stage, r1_match.id, r2_match.id
+
+
+def test_round_order_conflict_flags_match_starting_before_previous_round_ends() -> None:
+    """A match in round 2 that starts before round 1's match ends is flagged."""
+    # Round 1: T → T+60; Round 2 starts at T+30 (before round 1 ends) → conflict
+    stage, r1_id, r2_id = _make_two_round_stage(T, T + timedelta(minutes=30))
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[r1_id].round_order_conflict is False
+    assert flags[r2_id].round_order_conflict is True
+
+
+def test_round_order_conflict_not_flagged_when_previous_round_finishes_first() -> None:
+    """A match in round 2 that starts after round 1's last match ends is not flagged."""
+    # Round 1: T → T+60; Round 2 starts at T+90 (after round 1 ends) → no conflict
+    stage, r1_id, r2_id = _make_two_round_stage(T, T + timedelta(minutes=90))
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[r1_id].round_order_conflict is False
+    assert flags[r2_id].round_order_conflict is False
+
+
+def test_round_order_conflict_not_flagged_for_back_to_back_rounds() -> None:
+    """A round 2 match starting exactly when round 1's last match ends is not a conflict."""
+    # Round 1: T → T+60; Round 2 starts at T+60 (back-to-back) → no conflict
+    stage, r1_id, r2_id = _make_two_round_stage(T, T + timedelta(minutes=60))
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[r1_id].round_order_conflict is False
+    assert flags[r2_id].round_order_conflict is False
+
+
+def test_round_order_conflict_skips_rounds_with_no_scheduled_matches() -> None:
+    """If round 1 has no scheduled matches, round 2 is not flagged."""
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    r1_match = _make_definitive_match(
+        MatchId(-41),
+        inp[0],
+        inp[1],
+        RoundId(-41),
+        CourtId(-1),
+        None,  # no start_time
+    )
+    r2_match = _make_definitive_match(MatchId(-40), inp[2], inp[3], RoundId(-40), CourtId(-2), T)
+    round1 = RoundWithMatches(
+        id=RoundId(-41),
+        matches=[r1_match],
+        stage_item_id=StageItemId(-40),
+        created=MOCK_NOW,
+        lifecycle_state=RoundLifecycleState.ACTIVE,
+        name="Round 1",
+    )
+    round2 = RoundWithMatches(
+        id=RoundId(-40),
+        matches=[r2_match],
+        stage_item_id=StageItemId(-40),
+        created=MOCK_NOW,
+        lifecycle_state=RoundLifecycleState.ACTIVE,
+        name="Round 2",
+    )
+    stage_item = StageItemWithRounds(
+        rounds=[round1, round2],
+        inputs=[inp[0], inp[1]],
+        type_name="Single Elimination",
+        team_count=4,
+        ranking_id=None,
+        id=StageItemId(-40),
+        stage_id=StageId(-40),
+        name="",
+        created=MOCK_NOW,
+        type=StageType.SINGLE_ELIMINATION,
+    )
+    stage = StageWithStageItems(
+        id=StageId(-40),
+        tournament_id=tid,
+        name="",
+        created=MOCK_NOW,
+        is_active=False,
+        stage_items=[stage_item],
+    )
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[r2_match.id].round_order_conflict is False

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -276,6 +276,7 @@
     "round_lifecycle_placeholder": "Ausstehend",
     "round_lifecycle_resolved": "Aufgelöst",
     "round_name_input_placeholder": "Beste Runde aller Zeiten",
+    "round_order_conflict_label": "Beginnt, bevor alle Spiele der vorherigen Runde beendet sind",
     "round_robin_label": "Jeder gegen Jeden",
     "round_robin_description": "Jedes Team spiel einmal gegen jedes andere Team.",
     "save_button": "Speichern",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -276,6 +276,7 @@
     "round_lifecycle_placeholder": "Pending",
     "round_lifecycle_resolved": "Resolved",
     "round_name_input_placeholder": "Best Round Ever",
+    "round_order_conflict_label": "Starts before all matches of the previous round have ended",
     "round_robin_label": "Round Robin",
     "round_robin_description": "Each team plays every other team once.",
     "save_button": "Save",

--- a/frontend/src/components/modals/match_modal.tsx
+++ b/frontend/src/components/modals/match_modal.tsx
@@ -314,6 +314,13 @@ function MatchModalForm({
           label: t('feeder_precedence_conflict_label'),
         }
       : null,
+    match.round_order_conflict
+      ? {
+          key: 'round_order',
+          colour: CONFLICT_COLOURS.roundOrder,
+          label: t('round_order_conflict_label'),
+        }
+      : null,
     match.short_break_conflict
       ? {
           key: 'short_break',

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -261,7 +261,8 @@ function MatchCard({
     </Box>
   );
   // A match can sit on either (or both) sides of a precedence dependency, plus the earlier-stage
-  // ordering violation — collect every applicable description so the tooltip explains them all.
+  // ordering violation or a round-order conflict — collect every applicable description so the
+  // tooltip explains them all.
   const precedenceWarningLabels = [
     match.precedence_conflict
       ? t(
@@ -273,6 +274,12 @@ function MatchCard({
       ? t(
           'feeder_precedence_conflict_label',
           'Ends after a match depending on the results of this one starts'
+        )
+      : null,
+    match.round_order_conflict
+      ? t(
+          'round_order_conflict_label',
+          'Starts before all matches of the previous round have ended'
         )
       : null,
     isViolation ? t('match_scheduled_before_previous_stage_label') : null,

--- a/frontend/src/components/scheduling/unscheduled_sheet.tsx
+++ b/frontend/src/components/scheduling/unscheduled_sheet.tsx
@@ -75,12 +75,12 @@ export default function UnscheduledSheet({
     // Mirror the grid badge: round number for swiss/elimination, match number for round-robin.
     const isRoundRobin = entry?.stageItem.type === 'ROUND_ROBIN';
     const counter = isRoundRobin ? entry?.matchNumber : entry?.roundNumber;
-    const label =
-      baseLabel != null && entry != null ? `${baseLabel} · ${counter}` : baseLabel;
+    const label = baseLabel != null && entry != null ? `${baseLabel} · ${counter}` : baseLabel;
     const colour =
       (entry != null ? stageItemColours[entry.stageItem.id] : undefined) ??
       NEUTRAL_STAGE_ITEM_COLOUR;
-    const emptyLabelKey = entry?.round.lifecycle_state === 'PLACEHOLDER' ? 'tbd_label' : 'empty_slot';
+    const emptyLabelKey =
+      entry?.round.lifecycle_state === 'PLACEHOLDER' ? 'tbd_label' : 'empty_slot';
 
     return (
       <UnstyledButton key={match.id} onClick={() => onSelectMatch(match)} w="100%" py="xs">

--- a/frontend/src/logic/colors.ts
+++ b/frontend/src/logic/colors.ts
@@ -294,6 +294,8 @@ export const CONFLICT_COLOURS = {
   precedence: 'orange',
   /** The break before the match is shorter than the tournament default. */
   shortBreak: 'var(--mantine-color-yellow-filled)',
+  /** The match starts before all matches of the previous round have ended. */
+  roundOrder: 'orange',
 } as const;
 
 // ── Score colours ───────────────────────────────────────────────────────────

--- a/frontend/src/openapi/types.gen.ts
+++ b/frontend/src/openapi/types.gen.ts
@@ -322,6 +322,10 @@ export type Match = {
    */
   round_id: number;
   /**
+   * Round Order Conflict
+   */
+  round_order_conflict: boolean;
+  /**
    * Short Break Conflict
    */
   short_break_conflict: boolean;
@@ -583,6 +587,10 @@ export type MatchWithDetails = {
    */
   round_id: number;
   /**
+   * Round Order Conflict
+   */
+  round_order_conflict: boolean;
+  /**
    * Short Break Conflict
    */
   short_break_conflict: boolean;
@@ -706,6 +714,10 @@ export type MatchWithDetailsDefinitive = {
    * Round Id
    */
   round_id: number;
+  /**
+   * Round Order Conflict
+   */
+  round_order_conflict: boolean;
   /**
    * Short Break Conflict
    */


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FLFJcrHrViNcmA9bRJSzn