### PR TITLE
Allow score editing in match modal when match is not started

### DIFF
--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -128,10 +128,10 @@ def get_match_body_with_state_updates(existing_match: Match, match_body: MatchBo
         existing_match.stage_item_input1_score != match_body.stage_item_input1_score
         or existing_match.stage_item_input2_score != match_body.stage_item_input2_score
     )
-    if scores_changed and match_body.state is not MatchState.IN_PROGRESS:
+    if scores_changed and match_body.state not in {MatchState.IN_PROGRESS, MatchState.COMPLETED}:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Scores can only be changed while the match is in progress",
+            detail="Scores can only be changed while the match is in progress or being completed",
         )
 
     completed_at = None

--- a/frontend/src/components/modals/match_modal.tsx
+++ b/frontend/src/components/modals/match_modal.tsx
@@ -407,16 +407,28 @@ function MatchModalForm({
           withAsterisk
           label={`${t('score_of_label')} ${team1Name}`}
           placeholder={`${t('score_of_label')} ${team1Name}`}
-          disabled={form.values.state !== 'IN_PROGRESS'}
+          disabled={form.values.state === 'COMPLETED'}
           {...form.getInputProps('stage_item_input1_score')}
+          onChange={(value) => {
+            form.setFieldValue('stage_item_input1_score', value as number);
+            if (form.values.state === 'NOT_STARTED') {
+              form.setFieldValue('state', 'IN_PROGRESS');
+            }
+          }}
         />
         <NumberInput
           withAsterisk
           mt="lg"
           label={`${t('score_of_label')} ${team2Name}`}
           placeholder={`${t('score_of_label')} ${team2Name}`}
-          disabled={form.values.state !== 'IN_PROGRESS'}
+          disabled={form.values.state === 'COMPLETED'}
           {...form.getInputProps('stage_item_input2_score')}
+          onChange={(value) => {
+            form.setFieldValue('stage_item_input2_score', value as number);
+            if (form.values.state === 'NOT_STARTED') {
+              form.setFieldValue('state', 'IN_PROGRESS');
+            }
+          }}
         />
         <Select
           mt="lg"
@@ -427,6 +439,15 @@ function MatchModalForm({
             { value: 'COMPLETED', label: t('match_state_completed') },
           ]}
           {...form.getInputProps('state')}
+          onChange={(value) => {
+            if (value != null) {
+              form.setFieldValue('state', value as MatchWithDetails['state']);
+              if (value === 'NOT_STARTED') {
+                form.setFieldValue('stage_item_input1_score', 0);
+                form.setFieldValue('stage_item_input2_score', 0);
+              }
+            }
+          }}
         />
         {refereesEnabled && (
           <RefereeCombobox


### PR DESCRIPTION
Score inputs are now enabled for NOT_STARTED and IN_PROGRESS states
(only disabled when COMPLETED). Editing a score while NOT_STARTED
automatically advances the state to IN_PROGRESS. Switching the state
selector back to NOT_STARTED resets both scores to zero.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Uxm3FYVAntjJn6BaNdxqJ