### PR TITLE
fix: skip round-robin stage items in round order conflict detection

### DIFF
--- a/backend/bracket/logic/planning/conflicts.py
+++ b/backend/bracket/logic/planning/conflicts.py
@@ -6,6 +6,7 @@ from heliclockter import datetime_utc
 from bracket.database import database
 from bracket.logic.planning.team_windows import PlayingWindow, get_team_playing_windows
 from bracket.models.db.match import Match, MatchWithDetails, MatchWithDetailsDefinitive
+from bracket.models.db.stage_item import StageType
 from bracket.models.db.util import StageWithStageItems
 from bracket.utils.id_types import (
     CourtId,
@@ -387,9 +388,13 @@ def _set_round_order_conflicts(
 
     Rounds within a stage item must complete in sequence. If any match in a later round
     starts before the previous round's last scheduled match has ended, flag it.
+
+    Round-robin stage items are excluded: their rounds have no required ordering.
     """
     for stage in stages:
         for stage_item in stage.stage_items:
+            if stage_item.type == StageType.ROUND_ROBIN:
+                continue
             rounds = sorted(stage_item.rounds, key=lambda r: r.id)
             for prev_round, curr_round in zip(rounds, rounds[1:], strict=False):
                 prev_round_end: datetime_utc | None = None

--- a/backend/tests/unit_tests/conflicts_test.py
+++ b/backend/tests/unit_tests/conflicts_test.py
@@ -1064,3 +1064,58 @@ def test_round_order_conflict_skips_rounds_with_no_scheduled_matches() -> None:
     flags = get_match_conflict_flags([stage], default_break_minutes=0)
 
     assert flags[r2_match.id].round_order_conflict is False
+
+
+def test_round_order_conflict_not_flagged_for_round_robin() -> None:
+    """Round-robin stage items are never flagged for round order conflicts."""
+    # Build an overlapping two-round scenario (same as the "flags" test) but with ROUND_ROBIN type.
+    # Despite round 2 starting before round 1 ends, no conflict should be raised.
+    tid = TournamentId(-1)
+    inp = _make_inputs(tid)
+    r1_match = _make_definitive_match(
+        MatchId(-41), inp[0], inp[1], RoundId(-41), CourtId(-1), T
+    )
+    r2_match = _make_definitive_match(
+        MatchId(-40), inp[2], inp[3], RoundId(-40), CourtId(-2), T + timedelta(minutes=30)
+    )
+    round1 = RoundWithMatches(
+        id=RoundId(-41),
+        matches=[r1_match],
+        stage_item_id=StageItemId(-40),
+        created=MOCK_NOW,
+        lifecycle_state=RoundLifecycleState.ACTIVE,
+        name="Round 1",
+    )
+    round2 = RoundWithMatches(
+        id=RoundId(-40),
+        matches=[r2_match],
+        stage_item_id=StageItemId(-40),
+        created=MOCK_NOW,
+        lifecycle_state=RoundLifecycleState.ACTIVE,
+        name="Round 2",
+    )
+    stage_item = StageItemWithRounds(
+        rounds=[round1, round2],
+        inputs=[inp[0], inp[1]],
+        type_name="Round Robin",
+        team_count=4,
+        ranking_id=None,
+        id=StageItemId(-40),
+        stage_id=StageId(-40),
+        name="",
+        created=MOCK_NOW,
+        type=StageType.ROUND_ROBIN,
+    )
+    stage = StageWithStageItems(
+        id=StageId(-40),
+        tournament_id=tid,
+        name="",
+        created=MOCK_NOW,
+        is_active=False,
+        stage_items=[stage_item],
+    )
+
+    flags = get_match_conflict_flags([stage], default_break_minutes=0)
+
+    assert flags[r1_match.id].round_order_conflict is False
+    assert flags[r2_match.id].round_order_conflict is False


### PR DESCRIPTION
Round-robin tournaments have no required round ordering, so consecutive
rounds are free to overlap. Add a StageType.ROUND_ROBIN guard to
_set_round_order_conflicts and a corresponding regression test.