### PR TITLE
Add client-side conflict engine and derive schedule icons from it

### DIFF
--- a/frontend/src/components/modals/match_modal.tsx
+++ b/frontend/src/components/modals/match_modal.tsx
@@ -15,7 +15,7 @@ import {
 import { useForm } from '@mantine/form';
 import { AiFillWarning } from '@react-icons/all-files/ai/AiFillWarning';
 import { GiWhistle } from '@react-icons/all-files/gi/GiWhistle';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SWRResponse } from 'swr';
 
@@ -23,6 +23,7 @@ import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
 import { formatStageItemInput } from '@components/utils/stage_item_input';
 import { TournamentMinimal } from '@components/utils/tournament';
 import { CONFLICT_COLOURS, levelSwatchColour } from '@logic/colors';
+import { computeConflictFlags } from '@logic/planning/conflicts';
 import {
   LevelResponse,
   MatchWithDetails,
@@ -281,54 +282,64 @@ function MatchModalForm({
   const team1Name = formatMatchInput1(t, stageItemsLookup, matchesLookup, match);
   const team2Name = formatMatchInput2(t, stageItemsLookup, matchesLookup, match);
 
+  // Conflict flags are derived client-side from the current schedule with the same engine
+  // the planner grid uses, so the modal and the grid always agree — and update together on
+  // an optimistic move — instead of reading the backend-persisted columns.
+  const marginMinutes = swrTournamentResponse.data?.data.margin_minutes ?? 0;
+  const conflictFlags = useMemo(
+    () => computeConflictFlags(swrStagesResponse.data?.data ?? [], marginMinutes),
+    [swrStagesResponse.data?.data, marginMinutes]
+  );
+  const conflicts = conflictFlags.get(match.id);
+
   // Surface the same scheduling conflicts the planner grid flags on this match, each as an
   // icon plus a brief description. Colours come from the shared CONFLICT_COLOURS so the
   // grid and this list always agree.
   type ActiveConflict = { key: string; colour: string; label: string };
   const activeConflicts: (ActiveConflict | null)[] = [
-    match.stage_item_input1_conflict
+    conflicts?.stage_item_input1_conflict
       ? {
           key: 'input1',
           colour: CONFLICT_COLOURS.teamDoubleBooked,
           label: t('team_double_booked_conflict_label', { team: team1Name }),
         }
       : null,
-    match.stage_item_input2_conflict
+    conflicts?.stage_item_input2_conflict
       ? {
           key: 'input2',
           colour: CONFLICT_COLOURS.teamDoubleBooked,
           label: t('team_double_booked_conflict_label', { team: team2Name }),
         }
       : null,
-    match.precedence_conflict
+    conflicts?.precedence_conflict
       ? {
           key: 'precedence',
           colour: CONFLICT_COLOURS.precedence,
           label: t('precedence_conflict_label'),
         }
       : null,
-    match.feeder_precedence_conflict
+    conflicts?.feeder_precedence_conflict
       ? {
           key: 'feeder_precedence',
           colour: CONFLICT_COLOURS.precedence,
           label: t('feeder_precedence_conflict_label'),
         }
       : null,
-    match.round_order_conflict
+    conflicts?.round_order_conflict
       ? {
           key: 'round_order',
           colour: CONFLICT_COLOURS.roundOrder,
           label: t('round_order_conflict_label'),
         }
       : null,
-    match.short_break_conflict
+    conflicts?.short_break_conflict
       ? {
           key: 'short_break',
           colour: CONFLICT_COLOURS.shortBreak,
           label: t('short_break_conflict_label'),
         }
       : null,
-    refereesEnabled && match.referee_conflict
+    refereesEnabled && conflicts?.referee_conflict
       ? {
           key: 'referee',
           colour: CONFLICT_COLOURS.referee,

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -15,7 +15,7 @@ import {
 import { useMediaQuery } from '@mantine/hooks';
 import { AiFillWarning } from '@react-icons/all-files/ai/AiFillWarning';
 import { format } from 'date-fns';
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
@@ -27,6 +27,7 @@ import {
   type StageItemColour,
 } from '@logic/colors';
 import { ConflictPreview, insertionLineKey } from '@logic/planning/conflict_preview';
+import { ConflictFlags, ConflictStage, computeConflictFlags } from '@logic/planning/conflicts';
 import { HighlightTarget, matchInvolvesHighlight } from '@logic/planning/highlight';
 import { abbreviateStageItem, abbreviateTeamName, shortCourtLabel } from '@logic/planning/labels';
 import {
@@ -44,6 +45,17 @@ import { MatchLookupEntry, getStageItemLookup } from '@services/lookups';
 
 import { COURT_CONTENT_ATTRIBUTE, PLANNER_GRID_ATTRIBUTE } from './planner_anchor';
 import classes from './schedule_grid.module.css';
+
+/** Fallback for a match with no computed flags entry (every match normally has one). */
+const NO_CONFLICTS: ConflictFlags = {
+  stage_item_input1_conflict: false,
+  stage_item_input2_conflict: false,
+  precedence_conflict: false,
+  feeder_precedence_conflict: false,
+  short_break_conflict: false,
+  referee_conflict: false,
+  round_order_conflict: false,
+};
 
 const RULER_WIDTH = '3.25rem';
 const HEADER_HEIGHT = '2.5rem';
@@ -88,6 +100,7 @@ function MatchCard({
   block,
   zoom,
   pxPerMinute,
+  conflicts,
   isViolation,
   hasPlacementWarning,
   isSelected,
@@ -102,6 +115,7 @@ function MatchCard({
   block: MatchBlock<MatchWithDetails>;
   zoom: 'agenda' | 'compact';
   pxPerMinute: number;
+  conflicts: ConflictFlags;
   isViolation: boolean;
   hasPlacementWarning: boolean;
   isSelected: boolean;
@@ -264,19 +278,19 @@ function MatchCard({
   // ordering violation or a round-order conflict — collect every applicable description so the
   // tooltip explains them all.
   const precedenceWarningLabels = [
-    match.precedence_conflict
+    conflicts.precedence_conflict
       ? t(
           'precedence_conflict_label',
           'Starts before a match it depends on the results of has finished'
         )
       : null,
-    match.feeder_precedence_conflict
+    conflicts.feeder_precedence_conflict
       ? t(
           'feeder_precedence_conflict_label',
           'Ends after a match depending on the results of this one starts'
         )
       : null,
-    match.round_order_conflict
+    conflicts.round_order_conflict
       ? t(
           'round_order_conflict_label',
           'Starts before all matches of the previous round have ended'
@@ -302,7 +316,7 @@ function MatchCard({
         </Box>
       </Tooltip>
     ) : null;
-  const shortBreakIcon = match.short_break_conflict ? (
+  const shortBreakIcon = conflicts.short_break_conflict ? (
     <Tooltip
       label={t('short_break_conflict_label', 'Break before this match is shorter than the default')}
     >
@@ -315,7 +329,7 @@ function MatchCard({
     </Tooltip>
   ) : null;
   const refereeConflictIcon =
-    refereesEnabled && match.referee_conflict ? (
+    refereesEnabled && conflicts.referee_conflict ? (
       <Tooltip
         label={t(
           'referee_conflict_label',
@@ -344,27 +358,27 @@ function MatchCard({
   // The colour follows the same severity order as the overview blocks; the tooltip
   // lists every active conflict so nothing is silently hidden.
   const allConflictLabels: string[] = [
-    ...(match.stage_item_input1_conflict
+    ...(conflicts.stage_item_input1_conflict
       ? [t('team_double_booked_conflict_label', { team: input1 })]
       : []),
-    ...(match.stage_item_input2_conflict
+    ...(conflicts.stage_item_input2_conflict
       ? [t('team_double_booked_conflict_label', { team: input2 })]
       : []),
     ...precedenceWarningLabels,
-    ...(match.short_break_conflict ? [t('short_break_conflict_label')] : []),
-    ...(refereesEnabled && match.referee_conflict ? [t('referee_conflict_label')] : []),
+    ...(conflicts.short_break_conflict ? [t('short_break_conflict_label')] : []),
+    ...(refereesEnabled && conflicts.referee_conflict ? [t('referee_conflict_label')] : []),
     ...(hasPlacementWarning ? [t('placement_conflict_preview_label')] : []),
   ];
   const mergedConflictColour =
-    match.stage_item_input1_conflict || match.stage_item_input2_conflict
+    conflicts.stage_item_input1_conflict || conflicts.stage_item_input2_conflict
       ? CONFLICT_COLOURS.teamDoubleBooked
-      : refereesEnabled && match.referee_conflict
+      : refereesEnabled && conflicts.referee_conflict
         ? CONFLICT_COLOURS.referee
         : precedenceWarningLabels.length > 0
           ? CONFLICT_COLOURS.precedence
           : hasPlacementWarning
             ? 'var(--mantine-color-orange-filled)'
-            : match.short_break_conflict
+            : conflicts.short_break_conflict
               ? CONFLICT_COLOURS.shortBreak
               : null;
   const mergedConflictIcon =
@@ -464,7 +478,7 @@ function MatchCard({
             mergedConflictIcon
           ) : (
             <>
-              {match.stage_item_input1_conflict && (
+              {conflicts.stage_item_input1_conflict && (
                 <Tooltip label={t('team_double_booked_conflict_label', { team: input1 })}>
                   <Box
                     component="span"
@@ -476,7 +490,7 @@ function MatchCard({
               )}
               {!metaLine && placementWarningIcon}
               {!metaLine && shortBreakIcon}
-              {combineTeams && match.stage_item_input2_conflict && (
+              {combineTeams && conflicts.stage_item_input2_conflict && (
                 <Tooltip label={t('team_double_booked_conflict_label', { team: input2 })}>
                   <Box
                     component="span"
@@ -503,7 +517,7 @@ function MatchCard({
         </Flex>
         {lines >= 2 && !combineTeams && (
           <Flex gap={4} align="center" wrap="nowrap">
-            {match.stage_item_input2_conflict && (
+            {conflicts.stage_item_input2_conflict && (
               <Tooltip label={t('team_double_booked_conflict_label', { team: input2 })}>
                 <Box
                   component="span"
@@ -544,6 +558,7 @@ function OverviewBlock({
   block,
   pxPerMinute,
   colour,
+  conflicts,
   isViolation,
   refereesEnabled,
   isSelected,
@@ -553,6 +568,7 @@ function OverviewBlock({
   block: MatchBlock<MatchWithDetails>;
   pxPerMinute: number;
   colour: StageItemColour;
+  conflicts: ConflictFlags;
   isViolation: boolean;
   refereesEnabled: boolean;
   isSelected: boolean;
@@ -574,14 +590,14 @@ function OverviewBlock({
   // precedence/referee violation (orange), which outranks a short break (yellow).
   // This is the same palette the cards use for each conflict.
   const conflictColour =
-    match.stage_item_input1_conflict || match.stage_item_input2_conflict
+    conflicts.stage_item_input1_conflict || conflicts.stage_item_input2_conflict
       ? 'red'
       : isViolation ||
-          match.precedence_conflict ||
-          match.feeder_precedence_conflict ||
-          (refereesEnabled && match.referee_conflict)
+          conflicts.precedence_conflict ||
+          conflicts.feeder_precedence_conflict ||
+          (refereesEnabled && conflicts.referee_conflict)
         ? 'orange'
-        : match.short_break_conflict
+        : conflicts.short_break_conflict
           ? 'var(--mantine-color-yellow-filled)'
           : null;
   // The marker must stay legible on the smallest blocks (a 10-minute match is only
@@ -946,6 +962,7 @@ function InsertionLineTarget({
  */
 export default function ScheduleGrid({
   layout,
+  stages,
   violations,
   conflictPreview,
   stageItemsLookup,
@@ -960,6 +977,7 @@ export default function ScheduleGrid({
   onSelectionEvent,
 }: {
   layout: ScheduleGridLayout<Court, MatchWithDetails>;
+  stages: ConflictStage[];
   violations: Set<number>;
   conflictPreview: ConflictPreview;
   stageItemsLookup: ReturnType<typeof getStageItemLookup> | never[];
@@ -974,6 +992,13 @@ export default function ScheduleGrid({
   onSelectionEvent: (event: PlannerEvent) => void;
 }) {
   const pxPerMinute = ZOOM_PX_PER_MINUTE[zoom];
+  // Conflict icons are derived client-side from the current (optimistic) schedule, so
+  // they update the instant a drag/swap repacks the grid — no server round-trip. The
+  // backend still persists the conflict columns, but they are ignored here.
+  const conflictFlags = useMemo(
+    () => computeConflictFlags(stages, layout.defaultBreakMinutes),
+    [stages, layout.defaultBreakMinutes]
+  );
   const gridHeight = layout.totalMinutes * pxPerMinute;
   // On phones an anchored break popover can open off-screen, so the editor
   // switches to a centered modal at the same breakpoint as the default zoom.
@@ -1212,6 +1237,7 @@ export default function ScheduleGrid({
                 const colour =
                   (entry != null ? stageItemColours[entry.stageItem.id] : undefined) ??
                   NEUTRAL_STAGE_ITEM_COLOUR;
+                const conflicts = conflictFlags.get(block.match.id) ?? NO_CONFLICTS;
                 if (isOverview) {
                   return (
                     <OverviewBlock
@@ -1219,6 +1245,7 @@ export default function ScheduleGrid({
                       block={block}
                       pxPerMinute={pxPerMinute}
                       colour={colour}
+                      conflicts={conflicts}
                       isViolation={violations.has(block.match.id)}
                       refereesEnabled={refereesEnabled}
                       isSelected={selectedMatch?.matchId === block.match.id}
@@ -1240,6 +1267,7 @@ export default function ScheduleGrid({
                     block={block}
                     zoom={zoom}
                     pxPerMinute={pxPerMinute}
+                    conflicts={conflicts}
                     isViolation={violations.has(block.match.id)}
                     hasPlacementWarning={conflictPreview.swapTargets.has(block.match.id)}
                     isSelected={selectedMatch?.matchId === block.match.id}

--- a/frontend/src/logic/planning/conflicts.test.ts
+++ b/frontend/src/logic/planning/conflicts.test.ts
@@ -1,0 +1,802 @@
+import { describe, expect, it } from 'vitest';
+
+import { ConflictInput, ConflictMatch, ConflictStage, computeConflictFlags } from './conflicts';
+
+// A fixed tournament start; all match times are expressed as minute offsets from it.
+const START = '2026-06-10T09:00:00.000Z';
+
+function minutesAfterStart(minutes: number): string {
+  return new Date(new Date(START).getTime() + minutes * 60_000).toISOString();
+}
+
+let nextInputId = 1;
+
+/** A resolved (team-backed) playing/referee slot. */
+function teamInput(teamId: number, id: number = nextInputId++): ConflictInput {
+  return { id, team_id: teamId, winner_from_stage_item_id: null };
+}
+
+/** A placeholder ("winner of …") slot with no resolved team yet. */
+function tentativeInput(
+  winnerFromStageItemId: number | null = null,
+  id: number = nextInputId++
+): ConflictInput {
+  return { id, team_id: null, winner_from_stage_item_id: winnerFromStageItemId };
+}
+
+function makeMatch({
+  id,
+  startMinutes,
+  durationMinutes = 90,
+  courtId = null,
+  input1 = null,
+  input2 = null,
+  referee = null,
+  input1WinnerFromMatchId = null,
+  input2WinnerFromMatchId = null,
+}: {
+  id: number;
+  startMinutes: number | null;
+  durationMinutes?: number;
+  courtId?: number | null;
+  input1?: ConflictInput | null;
+  input2?: ConflictInput | null;
+  referee?: ConflictInput | null;
+  input1WinnerFromMatchId?: number | null;
+  input2WinnerFromMatchId?: number | null;
+}): ConflictMatch {
+  return {
+    id,
+    start_time: startMinutes == null ? null : minutesAfterStart(startMinutes),
+    duration_minutes: durationMinutes,
+    court_id: courtId,
+    stage_item_input1: input1,
+    stage_item_input2: input2,
+    stage_item_input1_id: input1?.id ?? null,
+    stage_item_input2_id: input2?.id ?? null,
+    stage_item_input1_winner_from_match_id: input1WinnerFromMatchId,
+    stage_item_input2_winner_from_match_id: input2WinnerFromMatchId,
+    referee_stage_item_input_id: referee?.id ?? null,
+    referee,
+  };
+}
+
+function makeRound(id: number, matches: ConflictMatch[]) {
+  return { id, matches };
+}
+
+function makeStageItem({
+  id = -10,
+  type = 'SINGLE_ELIMINATION' as ConflictStage['stage_items'][number]['type'],
+  inputs = [] as ConflictInput[],
+  rounds,
+}: {
+  id?: number;
+  type?: ConflictStage['stage_items'][number]['type'];
+  inputs?: ConflictInput[];
+  rounds: ReturnType<typeof makeRound>[];
+}) {
+  return { id, type, inputs, rounds };
+}
+
+function stageOf(stageItems: ReturnType<typeof makeStageItem>[]): ConflictStage {
+  return { stage_items: stageItems };
+}
+
+/** Single stage item, single round, two definitive matches. */
+function twoMatchStage(match1: ConflictMatch, match2: ConflictMatch): ConflictStage {
+  return stageOf([makeStageItem({ rounds: [makeRound(-3, [match1, match2])] })]);
+}
+
+// ---------------------------------------------------------------------------
+// Team double-booking (stage_item_input conflicts)
+// ---------------------------------------------------------------------------
+
+describe('computeConflictFlags — team double-booking', () => {
+  it('flags both matches on their shared input side for identical start times', () => {
+    // Same team -1 plays input1 of both matches, both starting at minute 0.
+    const team1a = teamInput(-1);
+    const team1b = teamInput(-1);
+    const match1 = makeMatch({ id: -1, startMinutes: 0, input1: team1a, input2: teamInput(-2) });
+    const match2 = makeMatch({ id: -2, startMinutes: 0, input1: team1b, input2: teamInput(-4) });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0);
+
+    expect(flags.get(-1)!.stage_item_input1_conflict).toBe(true);
+    expect(flags.get(-1)!.stage_item_input2_conflict).toBe(false);
+    expect(flags.get(-2)!.stage_item_input1_conflict).toBe(true);
+    expect(flags.get(-2)!.stage_item_input2_conflict).toBe(false);
+  });
+
+  it('detects partial overlap (issue #64 staggered-start scenario)', () => {
+    // match1: 0 → 105, match2: 60 → 165 (45-minute overlap).
+    const team = teamInput(-1);
+    const match1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      durationMinutes: 105,
+      input1: team,
+      input2: teamInput(-2),
+    });
+    const match2 = makeMatch({
+      id: -2,
+      startMinutes: 60,
+      durationMinutes: 105,
+      input1: teamInput(-1),
+      input2: teamInput(-4),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0);
+
+    expect(flags.get(-1)!.stage_item_input1_conflict).toBe(true);
+    expect(flags.get(-2)!.stage_item_input1_conflict).toBe(true);
+  });
+
+  it('does not flag matches separated by more than their duration', () => {
+    // Each 90 min; a 120-min gap between starts means no overlap.
+    const match1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      input1: teamInput(-1),
+      input2: teamInput(-2),
+    });
+    const match2 = makeMatch({
+      id: -2,
+      startMinutes: 120,
+      input1: teamInput(-1),
+      input2: teamInput(-4),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0);
+
+    expect(flags.get(-1)!.stage_item_input1_conflict).toBe(false);
+    expect(flags.get(-2)!.stage_item_input1_conflict).toBe(false);
+  });
+
+  it('does not flag back-to-back matches (half-open intervals, end1 == start2)', () => {
+    const match1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      input1: teamInput(-1),
+      input2: teamInput(-2),
+    });
+    const match2 = makeMatch({
+      id: -2,
+      startMinutes: 90,
+      input1: teamInput(-1),
+      input2: teamInput(-4),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0);
+
+    expect(flags.get(-1)!.stage_item_input1_conflict).toBe(false);
+    expect(flags.get(-2)!.stage_item_input1_conflict).toBe(false);
+  });
+
+  it('resolves double-booking by team_id, not raw input id', () => {
+    // The same team -5 occupies input1 of match1 (slot id 1) and input2 of match2 (slot id 99):
+    // different slot ids, same team. A raw-id check would miss this; a team-id check flags it.
+    const match1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      input1: teamInput(-5, 1),
+      input2: teamInput(-6, 2),
+    });
+    const match2 = makeMatch({
+      id: -2,
+      startMinutes: 0,
+      input1: teamInput(-7, 3),
+      input2: teamInput(-5, 99),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0);
+
+    expect(flags.get(-1)!.stage_item_input1_conflict).toBe(true);
+    expect(flags.get(-1)!.stage_item_input2_conflict).toBe(false);
+    expect(flags.get(-2)!.stage_item_input2_conflict).toBe(true);
+    expect(flags.get(-2)!.stage_item_input1_conflict).toBe(false);
+  });
+
+  it('honors the definitive-match restriction (a half-resolved match is not team-double-booked)', () => {
+    // match1 is definitive (both inputs resolved); match2 has only input1 resolved.
+    // They share team -5 but on different slot ids, so only the team-id path could flag them —
+    // and that path is restricted to definitive matches, so neither is flagged.
+    const match1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      input1: teamInput(-5, 1),
+      input2: teamInput(-6, 2),
+    });
+    const match2 = makeMatch({
+      id: -2,
+      startMinutes: 0,
+      input1: teamInput(-5, 99),
+      input2: null,
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0);
+
+    expect(flags.get(-1)!.stage_item_input1_conflict).toBe(false);
+    expect(flags.get(-2)!.stage_item_input1_conflict).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Winner-of precedence
+// ---------------------------------------------------------------------------
+
+describe('computeConflictFlags — winner-of precedence', () => {
+  it('flags a match starting before one of its winner-of feeders ends, on both sides', () => {
+    // Feeders run 0 → 90; the final starts at 30 while both are still running.
+    const feeder1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      input1: teamInput(-1),
+      input2: teamInput(-2),
+    });
+    const feeder2 = makeMatch({
+      id: -2,
+      startMinutes: 0,
+      input1: teamInput(-3),
+      input2: teamInput(-4),
+    });
+    const final = makeMatch({
+      id: -3,
+      startMinutes: 30,
+      input1WinnerFromMatchId: -1,
+      input2WinnerFromMatchId: -2,
+    });
+    const stage = stageOf([
+      makeStageItem({
+        rounds: [makeRound(-3, [feeder1, feeder2]), makeRound(-2, [final])],
+      }),
+    ]);
+
+    const flags = computeConflictFlags([stage], 5);
+
+    expect(flags.get(-3)!.precedence_conflict).toBe(true);
+    expect(flags.get(-1)!.feeder_precedence_conflict).toBe(true);
+    expect(flags.get(-2)!.feeder_precedence_conflict).toBe(true);
+  });
+
+  it('does not flag a winner-of feeder that finishes before its dependent starts', () => {
+    // Feeders run 0 → 90; the final starts at 90 (back-to-back).
+    const feeder1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      input1: teamInput(-1),
+      input2: teamInput(-2),
+    });
+    const feeder2 = makeMatch({
+      id: -2,
+      startMinutes: 0,
+      input1: teamInput(-3),
+      input2: teamInput(-4),
+    });
+    const final = makeMatch({
+      id: -3,
+      startMinutes: 90,
+      input1WinnerFromMatchId: -1,
+      input2WinnerFromMatchId: -2,
+    });
+    const stage = stageOf([
+      makeStageItem({
+        rounds: [makeRound(-3, [feeder1, feeder2]), makeRound(-2, [final])],
+      }),
+    ]);
+
+    const flags = computeConflictFlags([stage], 5);
+
+    expect(flags.get(-3)!.precedence_conflict).toBe(false);
+    expect(flags.get(-1)!.feeder_precedence_conflict).toBe(false);
+    expect(flags.get(-2)!.feeder_precedence_conflict).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-stage precedence (winner_from_stage_item_id)
+// ---------------------------------------------------------------------------
+
+describe('computeConflictFlags — cross-stage precedence', () => {
+  const SOURCE_STAGE_ITEM_ID = -1;
+  const TARGET_STAGE_ITEM_ID = -2;
+
+  function crossStage(targetStartMinutes: number): ConflictStage {
+    // Source group: match1 0 → 10, match2 10 → 20 (group ends at minute 20).
+    const sourceMatch1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      durationMinutes: 10,
+      input1: teamInput(-1),
+      input2: teamInput(-2),
+    });
+    const sourceMatch2 = makeMatch({
+      id: -2,
+      startMinutes: 10,
+      durationMinutes: 10,
+      input1: teamInput(-3),
+      input2: teamInput(-4),
+    });
+    const sourceItem = makeStageItem({
+      id: SOURCE_STAGE_ITEM_ID,
+      rounds: [makeRound(-3, [sourceMatch1, sourceMatch2])],
+    });
+
+    const dependentInput = tentativeInput(SOURCE_STAGE_ITEM_ID);
+    const targetMatch = makeMatch({
+      id: -3,
+      startMinutes: targetStartMinutes,
+      durationMinutes: 10,
+      input1: dependentInput,
+      input2: teamInput(-2),
+    });
+    const targetItem = makeStageItem({
+      id: TARGET_STAGE_ITEM_ID,
+      inputs: [dependentInput],
+      rounds: [makeRound(-4, [targetMatch])],
+    });
+
+    return stageOf([sourceItem, targetItem]);
+  }
+
+  it('flags a dependent match starting before the feeding group has finished', () => {
+    // Target starts at minute 15, before the source group's last match ends (minute 20).
+    const flags = computeConflictFlags([crossStage(15)], 5);
+
+    expect(flags.get(-3)!.precedence_conflict).toBe(true);
+    // source match1 (0 → 10) finished before the target started, so it is not flagged.
+    expect(flags.get(-1)!.feeder_precedence_conflict).toBe(false);
+    // source match2 (10 → 20) is still running when the target starts at 15, so it is flagged.
+    expect(flags.get(-2)!.feeder_precedence_conflict).toBe(true);
+  });
+
+  it('does not flag when the feeding group fully finishes before the dependent starts', () => {
+    // Target starts at minute 20, exactly when the source group ends (back-to-back).
+    const flags = computeConflictFlags([crossStage(20)], 5);
+
+    expect(flags.get(-3)!.precedence_conflict).toBe(false);
+    expect(flags.get(-1)!.feeder_precedence_conflict).toBe(false);
+    expect(flags.get(-2)!.feeder_precedence_conflict).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Short break
+// ---------------------------------------------------------------------------
+
+describe('computeConflictFlags — short break', () => {
+  it('flags only the later match when a court gap is shorter than the default break', () => {
+    // Both on court -1: match1 0 → 10, match2 starts at 12 (2-min gap < 5-min default).
+    const court = -1;
+    const match1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      durationMinutes: 10,
+      courtId: court,
+      input1: teamInput(-1),
+      input2: teamInput(-2),
+    });
+    const match2 = makeMatch({
+      id: -2,
+      startMinutes: 12,
+      durationMinutes: 10,
+      courtId: court,
+      input1: teamInput(-3),
+      input2: teamInput(-4),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 5);
+
+    expect(flags.get(-1)!.short_break_conflict).toBe(false);
+    expect(flags.get(-2)!.short_break_conflict).toBe(true);
+  });
+
+  it('does not flag a court gap at least as long as the default break', () => {
+    const court = -1;
+    const match1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      durationMinutes: 10,
+      courtId: court,
+      input1: teamInput(-1),
+      input2: teamInput(-2),
+    });
+    const match2 = makeMatch({
+      id: -2,
+      startMinutes: 15,
+      durationMinutes: 10,
+      courtId: court,
+      input1: teamInput(-3),
+      input2: teamInput(-4),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 5);
+
+    expect(flags.get(-2)!.short_break_conflict).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Referee conflicts (team-backed referee)
+// ---------------------------------------------------------------------------
+
+describe('computeConflictFlags — referee', () => {
+  it('flags both sides when a team plays and referees in overlapping windows', () => {
+    // Team -20 plays input1 of the playing match and referees the other, overlapping match.
+    const team20 = teamInput(-20);
+    const playingMatch = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: team20,
+      input2: teamInput(-21),
+    });
+    const refereeingMatch = makeMatch({
+      id: -21,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-22),
+      input2: teamInput(-23),
+      referee: teamInput(-20),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(playingMatch, refereeingMatch)], 0);
+
+    expect(flags.get(-21)!.referee_conflict).toBe(true);
+    expect(flags.get(-20)!.stage_item_input1_conflict).toBe(true);
+    expect(flags.get(-20)!.stage_item_input2_conflict).toBe(false);
+    expect(flags.get(-20)!.referee_conflict).toBe(false);
+  });
+
+  it('never flags a free-text referee (no team_id)', () => {
+    const playingMatch = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: teamInput(-20),
+      input2: teamInput(-21),
+    });
+    const refereeingMatch = makeMatch({
+      id: -21,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-22),
+      input2: teamInput(-23),
+      referee: null,
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(playingMatch, refereeingMatch)], 0);
+
+    expect(flags.get(-21)!.referee_conflict).toBe(false);
+    expect(flags.get(-20)!.stage_item_input1_conflict).toBe(false);
+  });
+
+  it('does not flag non-overlapping playing and refereeing windows', () => {
+    const playingMatch = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: teamInput(-20),
+      input2: teamInput(-21),
+    });
+    const refereeingMatch = makeMatch({
+      id: -21,
+      startMinutes: 120,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-22),
+      input2: teamInput(-23),
+      referee: teamInput(-20),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(playingMatch, refereeingMatch)], 0);
+
+    expect(flags.get(-21)!.referee_conflict).toBe(false);
+    expect(flags.get(-20)!.stage_item_input1_conflict).toBe(false);
+  });
+
+  it('flags both matches when a team referees two overlapping matches', () => {
+    const team20 = teamInput(-20);
+    const refMatch1 = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: teamInput(-21),
+      input2: teamInput(-22),
+      referee: team20,
+    });
+    const refMatch2 = makeMatch({
+      id: -21,
+      startMinutes: 30,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-21),
+      input2: teamInput(-23),
+      referee: teamInput(-20),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(refMatch1, refMatch2)], 0);
+
+    expect(flags.get(-20)!.referee_conflict).toBe(true);
+    expect(flags.get(-21)!.referee_conflict).toBe(true);
+  });
+
+  it('does not flag a team refereeing two non-overlapping matches', () => {
+    const refMatch1 = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: teamInput(-21),
+      input2: teamInput(-22),
+      referee: teamInput(-20),
+    });
+    const refMatch2 = makeMatch({
+      id: -21,
+      startMinutes: 120,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-21),
+      input2: teamInput(-23),
+      referee: teamInput(-20),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(refMatch1, refMatch2)], 0);
+
+    expect(flags.get(-20)!.referee_conflict).toBe(false);
+    expect(flags.get(-21)!.referee_conflict).toBe(false);
+  });
+
+  it('flags a team that plays and referees the same match', () => {
+    const team20 = teamInput(-20);
+    const match = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: team20,
+      input2: teamInput(-21),
+      referee: teamInput(-20),
+    });
+    const stage = stageOf([makeStageItem({ rounds: [makeRound(-10, [match])] })]);
+
+    const flags = computeConflictFlags([stage], 0);
+
+    expect(flags.get(-20)!.referee_conflict).toBe(true);
+    expect(flags.get(-20)!.stage_item_input1_conflict).toBe(true);
+    expect(flags.get(-20)!.stage_item_input2_conflict).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Placeholder (tentative/empty) slot conflicts (issue #132, slot-id based)
+// ---------------------------------------------------------------------------
+
+describe('computeConflictFlags — placeholder slot overlap', () => {
+  it('flags a tentative slot that referees one match and plays in an overlapping one', () => {
+    // Inputs [A, B, C(tentative), D]: match1 is A vs B refereed by C; match2 is C vs D overlapping.
+    const tentativeC = tentativeInput(null, -30);
+    const refereeMatch = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: teamInput(-20),
+      input2: teamInput(-21),
+      referee: tentativeC,
+    });
+    const playingMatch = makeMatch({
+      id: -21,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: tentativeInput(null, -30),
+      input2: teamInput(-23),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(refereeMatch, playingMatch)], 0);
+
+    expect(flags.get(-20)!.referee_conflict).toBe(true);
+    expect(flags.get(-21)!.stage_item_input1_conflict).toBe(true);
+    expect(flags.get(-21)!.stage_item_input2_conflict).toBe(false);
+    expect(flags.get(-21)!.referee_conflict).toBe(false);
+  });
+
+  it('flags a tentative slot refereeing two overlapping matches', () => {
+    const refMatch1 = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: teamInput(-20),
+      input2: teamInput(-21),
+      referee: tentativeInput(null, -30),
+    });
+    const refMatch2 = makeMatch({
+      id: -21,
+      startMinutes: 30,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-22),
+      input2: teamInput(-23),
+      referee: tentativeInput(null, -30),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(refMatch1, refMatch2)], 0);
+
+    expect(flags.get(-20)!.referee_conflict).toBe(true);
+    expect(flags.get(-21)!.referee_conflict).toBe(true);
+  });
+
+  it('flags two overlapping matches that share the same placeholder playing slot', () => {
+    const match1 = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: tentativeInput(null, -30),
+      input2: teamInput(-21),
+    });
+    const match2 = makeMatch({
+      id: -21,
+      startMinutes: 30,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: tentativeInput(null, -30),
+      input2: teamInput(-23),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0);
+
+    expect(flags.get(-20)!.stage_item_input1_conflict).toBe(true);
+    expect(flags.get(-21)!.stage_item_input1_conflict).toBe(true);
+    expect(flags.get(-20)!.stage_item_input2_conflict).toBe(false);
+    expect(flags.get(-21)!.stage_item_input2_conflict).toBe(false);
+  });
+
+  it('does not flag the same placeholder playing slot across non-overlapping matches', () => {
+    const match1 = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: tentativeInput(null, -30),
+      input2: teamInput(-21),
+    });
+    const match2 = makeMatch({
+      id: -21,
+      startMinutes: 120,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: tentativeInput(null, -30),
+      input2: teamInput(-23),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0);
+
+    expect(flags.get(-20)!.stage_item_input1_conflict).toBe(false);
+    expect(flags.get(-21)!.stage_item_input1_conflict).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round order conflicts
+// ---------------------------------------------------------------------------
+
+describe('computeConflictFlags — round order', () => {
+  function twoRoundStage(
+    round1Start: number | null,
+    round2Start: number | null,
+    type: ConflictStage['stage_items'][number]['type'] = 'SINGLE_ELIMINATION'
+  ): ConflictStage {
+    // Round 1 has the lower id so it sorts first, mirroring DB insertion order.
+    const r1Match = makeMatch({
+      id: -41,
+      startMinutes: round1Start,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: teamInput(-20),
+      input2: teamInput(-21),
+    });
+    const r2Match = makeMatch({
+      id: -40,
+      startMinutes: round2Start,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-22),
+      input2: teamInput(-23),
+    });
+    return stageOf([
+      makeStageItem({
+        id: -40,
+        type,
+        rounds: [makeRound(-41, [r1Match]), makeRound(-40, [r2Match])],
+      }),
+    ]);
+  }
+
+  it('flags a round-2 match starting before round 1 ends', () => {
+    // Round 1: 0 → 60; round 2 starts at 30.
+    const flags = computeConflictFlags([twoRoundStage(0, 30)], 0);
+
+    expect(flags.get(-41)!.round_order_conflict).toBe(false);
+    expect(flags.get(-40)!.round_order_conflict).toBe(true);
+  });
+
+  it('does not flag a round-2 match starting after round 1 ends', () => {
+    const flags = computeConflictFlags([twoRoundStage(0, 90)], 0);
+
+    expect(flags.get(-40)!.round_order_conflict).toBe(false);
+  });
+
+  it('does not flag back-to-back rounds (round 2 starts exactly when round 1 ends)', () => {
+    const flags = computeConflictFlags([twoRoundStage(0, 60)], 0);
+
+    expect(flags.get(-40)!.round_order_conflict).toBe(false);
+  });
+
+  it('skips rounds with no scheduled matches', () => {
+    const flags = computeConflictFlags([twoRoundStage(null, 0)], 0);
+
+    expect(flags.get(-40)!.round_order_conflict).toBe(false);
+  });
+
+  it('never flags round-robin stage items', () => {
+    const flags = computeConflictFlags([twoRoundStage(0, 30, 'ROUND_ROBIN')], 0);
+
+    expect(flags.get(-41)!.round_order_conflict).toBe(false);
+    expect(flags.get(-40)!.round_order_conflict).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "Matches of interest" filter
+// ---------------------------------------------------------------------------
+
+describe('computeConflictFlags — matches of interest', () => {
+  it('returns a flag entry for every match when passed "all"', () => {
+    const match1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      input1: teamInput(-1),
+      input2: teamInput(-2),
+    });
+    const match2 = makeMatch({
+      id: -2,
+      startMinutes: 0,
+      input1: teamInput(-1),
+      input2: teamInput(-4),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0, 'all');
+
+    expect(new Set(flags.keys())).toEqual(new Set([-1, -2]));
+  });
+
+  it('restricts the returned map to the matches of interest', () => {
+    const match1 = makeMatch({
+      id: -1,
+      startMinutes: 0,
+      input1: teamInput(-1),
+      input2: teamInput(-2),
+    });
+    const match2 = makeMatch({
+      id: -2,
+      startMinutes: 0,
+      input1: teamInput(-1),
+      input2: teamInput(-4),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0, new Set([-1]));
+
+    expect(new Set(flags.keys())).toEqual(new Set([-1]));
+    // The conflict is still detected using the full schedule, only the output is filtered.
+    expect(flags.get(-1)!.stage_item_input1_conflict).toBe(true);
+  });
+});

--- a/frontend/src/logic/planning/conflicts.ts
+++ b/frontend/src/logic/planning/conflicts.ts
@@ -1,0 +1,644 @@
+/**
+ * Client-side conflict engine: a faithful 1:1 port of the backend
+ * `bracket/logic/planning/conflicts.py`.
+ *
+ * `computeConflictFlags(stages, defaultBreakMinutes, matchesOfInterest)` returns a
+ * `Map<matchId, ConflictFlags>` covering every conflict type the backend persists:
+ *
+ *   - team double-booking (`stage_item_input{1,2}_conflict`), resolved by **team_id**
+ *     and restricted to definitive matches;
+ *   - winner-of precedence (`precedence_conflict` / `feeder_precedence_conflict`);
+ *   - cross-stage precedence (a stage item must wait for the group it feeds off);
+ *   - short break (`short_break_conflict`);
+ *   - referee double-booking (`referee_conflict`), both team-backed and placeholder
+ *     (slot-id based, mirroring the auto-scheduler and the placement preview);
+ *   - round order (`round_order_conflict`).
+ *
+ * Times are handled as epoch-millisecond numbers; a match's playing window is
+ * `[start, start + duration_minutes)` — half-open, so back-to-back matches do not
+ * conflict, exactly as the backend's `matches_overlap` / `_time_ranges_overlap`.
+ */
+
+/** A playing or referee slot, as much of it as conflict detection needs. */
+export interface ConflictInput {
+  id: number;
+  team_id: number | null;
+  winner_from_stage_item_id: number | null;
+}
+
+export interface ConflictMatch {
+  id: number;
+  start_time: string | null;
+  duration_minutes: number;
+  court_id: number | null;
+  stage_item_input1: ConflictInput | null;
+  stage_item_input2: ConflictInput | null;
+  stage_item_input1_id: number | null;
+  stage_item_input2_id: number | null;
+  stage_item_input1_winner_from_match_id: number | null;
+  stage_item_input2_winner_from_match_id: number | null;
+  referee_stage_item_input_id: number | null;
+  referee: ConflictInput | null;
+}
+
+export interface ConflictRound {
+  id: number;
+  matches: ConflictMatch[];
+}
+
+export interface ConflictStageItem {
+  id: number;
+  type: 'ROUND_ROBIN' | 'SINGLE_ELIMINATION' | 'SWISS';
+  inputs: ConflictInput[];
+  rounds: ConflictRound[];
+}
+
+export interface ConflictStage {
+  stage_items: ConflictStageItem[];
+}
+
+export interface ConflictFlags {
+  stage_item_input1_conflict: boolean;
+  stage_item_input2_conflict: boolean;
+  /** Set on the dependent match: it starts before a match it depends on has finished. */
+  precedence_conflict: boolean;
+  /** Set on the source match: it ends after a match depending on its results has started. */
+  feeder_precedence_conflict: boolean;
+  short_break_conflict: boolean;
+  referee_conflict: boolean;
+  /** Set on a round-N match whose start is before the last round-(N-1) match ends. */
+  round_order_conflict: boolean;
+}
+
+interface PlayingWindow {
+  stageItemInputId: number;
+  startMillis: number;
+  endMillis: number;
+}
+
+function emptyFlags(): ConflictFlags {
+  return {
+    stage_item_input1_conflict: false,
+    stage_item_input2_conflict: false,
+    precedence_conflict: false,
+    feeder_precedence_conflict: false,
+    short_break_conflict: false,
+    referee_conflict: false,
+    round_order_conflict: false,
+  };
+}
+
+function startMillis(match: ConflictMatch): number | null {
+  return match.start_time == null ? null : new Date(match.start_time).getTime();
+}
+
+function endMillis(match: ConflictMatch): number {
+  // Callers guard start_time != null before reading the end of a window.
+  return new Date(match.start_time!).getTime() + match.duration_minutes * 60_000;
+}
+
+/** Half-open intervals [start, end): back-to-back ranges (end1 == start2) do not overlap. */
+function timeRangesOverlap(start1: number, end1: number, start2: number, end2: number): boolean {
+  return start1 < end2 && start2 < end1;
+}
+
+function windowsOverlap(window1: PlayingWindow, window2: PlayingWindow): boolean {
+  return timeRangesOverlap(
+    window1.startMillis,
+    window1.endMillis,
+    window2.startMillis,
+    window2.endMillis
+  );
+}
+
+function matchesOverlap(match1: ConflictMatch, match2: ConflictMatch): boolean {
+  if (match1.start_time == null || match2.start_time == null) {
+    return false;
+  }
+  return timeRangesOverlap(
+    startMillis(match1)!,
+    endMillis(match1),
+    startMillis(match2)!,
+    endMillis(match2)
+  );
+}
+
+/**
+ * A "definitive" match has both playing slots resolved to concrete inputs. The
+ * backend models these as `MatchWithDetailsDefinitive`; here both input objects
+ * are present.
+ */
+function isDefinitive(match: ConflictMatch): boolean {
+  return match.stage_item_input1 != null && match.stage_item_input2 != null;
+}
+
+function getAllMatches(stages: ConflictStage[]): ConflictMatch[] {
+  return stages.flatMap((stage) =>
+    stage.stage_items.flatMap((stageItem) => stageItem.rounds.flatMap((round) => round.matches))
+  );
+}
+
+function getMatchInputs(match: ConflictMatch): [number | null, ConflictInput | null][] {
+  return [
+    [match.stage_item_input1_id, match.stage_item_input1],
+    [match.stage_item_input2_id, match.stage_item_input2],
+  ];
+}
+
+function getTeamIdsByInputId(stages: ConflictStage[]): Map<number, number> {
+  const teamIdsByInputId = new Map<number, number>();
+  const set = (input: ConflictInput | null): void => {
+    if (input != null && input.team_id != null) {
+      teamIdsByInputId.set(input.id, input.team_id);
+    }
+  };
+  for (const stage of stages) {
+    for (const stageItem of stage.stage_items) {
+      for (const input of stageItem.inputs) {
+        set(input);
+      }
+      for (const round of stageItem.rounds) {
+        for (const match of round.matches) {
+          set(match.stage_item_input1);
+          set(match.stage_item_input2);
+        }
+      }
+    }
+  }
+  return teamIdsByInputId;
+}
+
+function getTeamId(
+  inputId: number,
+  input: ConflictInput | null,
+  teamIdsByInputId: Map<number, number>
+): number | null {
+  if (input != null && input.team_id != null) {
+    return input.team_id;
+  }
+  return teamIdsByInputId.get(inputId) ?? null;
+}
+
+type TeamPlayingWindows = Map<number, [ConflictMatch, PlayingWindow][]>;
+
+function getTeamPlayingWindows(stages: ConflictStage[]): TeamPlayingWindows {
+  const teamIdsByInputId = getTeamIdsByInputId(stages);
+  const windowsByTeamId: TeamPlayingWindows = new Map();
+
+  for (const match of getAllMatches(stages)) {
+    const start = startMillis(match);
+    if (start == null) {
+      continue;
+    }
+    for (const [inputId, input] of getMatchInputs(match)) {
+      if (inputId == null) {
+        continue;
+      }
+      const teamId = getTeamId(inputId, input, teamIdsByInputId);
+      if (teamId == null) {
+        continue;
+      }
+      const window: PlayingWindow = {
+        stageItemInputId: inputId,
+        startMillis: start,
+        endMillis: endMillis(match),
+      };
+      const existing = windowsByTeamId.get(teamId);
+      if (existing == null) {
+        windowsByTeamId.set(teamId, [[match, window]]);
+      } else {
+        existing.push([match, window]);
+      }
+    }
+  }
+
+  return windowsByTeamId;
+}
+
+function setStageItemInputConflict(
+  match: ConflictMatch,
+  window: PlayingWindow,
+  flags: Map<number, ConflictFlags>
+): void {
+  const matchFlags = flags.get(match.id)!;
+  if (window.stageItemInputId === match.stage_item_input1_id) {
+    matchFlags.stage_item_input1_conflict = true;
+    return;
+  }
+  if (window.stageItemInputId === match.stage_item_input2_id) {
+    matchFlags.stage_item_input2_conflict = true;
+    return;
+  }
+  throw new Error('Playing window input does not belong to match');
+}
+
+function setTeamOverlapConflicts(stages: ConflictStage[], flags: Map<number, ConflictFlags>): void {
+  for (const teamWindows of getTeamPlayingWindows(stages).values()) {
+    const definitiveWindows = teamWindows.filter(([match]) => isDefinitive(match));
+    for (let i = 0; i < definitiveWindows.length; i += 1) {
+      const [match1, window1] = definitiveWindows[i];
+      for (let j = i + 1; j < definitiveWindows.length; j += 1) {
+        const [match2, window2] = definitiveWindows[j];
+        if (match1.id === match2.id || !windowsOverlap(window1, window2)) {
+          continue;
+        }
+        setStageItemInputConflict(match1, window1, flags);
+        setStageItemInputConflict(match2, window2, flags);
+      }
+    }
+  }
+}
+
+function setWinnerOfPrecedenceConflicts(
+  matches: ConflictMatch[],
+  flags: Map<number, ConflictFlags>
+): void {
+  const matchesById = new Map(matches.map((match) => [match.id, match]));
+
+  for (const match of matches) {
+    if (match.start_time == null) {
+      continue;
+    }
+    const feederIds = [
+      match.stage_item_input1_winner_from_match_id,
+      match.stage_item_input2_winner_from_match_id,
+    ];
+    for (const feederId of feederIds) {
+      if (feederId == null) {
+        continue;
+      }
+      const feeder = matchesById.get(feederId);
+      if (feeder != null && feeder.start_time != null && startMillis(match)! < endMillis(feeder)) {
+        // The dependent match starts before its feeder finishes; flag both sides.
+        flags.get(match.id)!.precedence_conflict = true;
+        flags.get(feeder.id)!.feeder_precedence_conflict = true;
+      }
+    }
+  }
+}
+
+function getStageItemEndTimes(stages: ConflictStage[]): Map<number, number> {
+  const endTimes = new Map<number, number>();
+  for (const stage of stages) {
+    for (const stageItem of stage.stage_items) {
+      let latest: number | null = null;
+      for (const round of stageItem.rounds) {
+        for (const match of round.matches) {
+          if (match.start_time == null) {
+            continue;
+          }
+          const end = endMillis(match);
+          if (latest == null || end > latest) {
+            latest = end;
+          }
+        }
+      }
+      if (latest != null) {
+        endTimes.set(stageItem.id, latest);
+      }
+    }
+  }
+  return endTimes;
+}
+
+function getStageItemStartTimes(stages: ConflictStage[]): Map<number, number> {
+  const startTimes = new Map<number, number>();
+  for (const stage of stages) {
+    for (const stageItem of stage.stage_items) {
+      let earliest: number | null = null;
+      for (const round of stageItem.rounds) {
+        for (const match of round.matches) {
+          const start = startMillis(match);
+          if (start == null) {
+            continue;
+          }
+          if (earliest == null || start < earliest) {
+            earliest = start;
+          }
+        }
+      }
+      if (earliest != null) {
+        startTimes.set(stageItem.id, earliest);
+      }
+    }
+  }
+  return startTimes;
+}
+
+/**
+ * Map each source stage item to the earliest start of any stage item feeding off it
+ * (i.e. one of its matches has an input whose `winner_from_stage_item_id` points there).
+ */
+function getEarliestDependentStartTimes(stages: ConflictStage[]): Map<number, number> {
+  const stageItemStartTimes = getStageItemStartTimes(stages);
+  const earliestDependentStart = new Map<number, number>();
+
+  for (const stage of stages) {
+    for (const stageItem of stage.stage_items) {
+      const dependentStart = stageItemStartTimes.get(stageItem.id);
+      if (dependentStart == null) {
+        continue;
+      }
+      for (const round of stageItem.rounds) {
+        for (const match of round.matches) {
+          for (const input of [match.stage_item_input1, match.stage_item_input2]) {
+            if (input == null || input.winner_from_stage_item_id == null) {
+              continue;
+            }
+            const sourceId = input.winner_from_stage_item_id;
+            const existing = earliestDependentStart.get(sourceId);
+            if (existing == null || dependentStart < existing) {
+              earliestDependentStart.set(sourceId, dependentStart);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return earliestDependentStart;
+}
+
+function setCrossStagePrecedenceConflicts(
+  stages: ConflictStage[],
+  flags: Map<number, ConflictFlags>
+): void {
+  const stageItemEndTimes = getStageItemEndTimes(stages);
+
+  for (const match of getAllMatches(stages)) {
+    if (match.start_time == null) {
+      continue;
+    }
+    for (const input of [match.stage_item_input1, match.stage_item_input2]) {
+      if (input == null || input.winner_from_stage_item_id == null) {
+        continue;
+      }
+      const sourceEnd = stageItemEndTimes.get(input.winner_from_stage_item_id);
+      if (sourceEnd != null && startMillis(match)! < sourceEnd) {
+        flags.get(match.id)!.precedence_conflict = true;
+      }
+    }
+  }
+}
+
+function setCrossStageFeederPrecedenceConflicts(
+  stages: ConflictStage[],
+  flags: Map<number, ConflictFlags>
+): void {
+  const earliestDependentStart = getEarliestDependentStartTimes(stages);
+
+  for (const stage of stages) {
+    for (const stageItem of stage.stage_items) {
+      const dependentStart = earliestDependentStart.get(stageItem.id);
+      if (dependentStart == null) {
+        continue;
+      }
+      for (const round of stageItem.rounds) {
+        for (const match of round.matches) {
+          if (match.start_time == null) {
+            continue;
+          }
+          if (endMillis(match) > dependentStart) {
+            flags.get(match.id)!.feeder_precedence_conflict = true;
+          }
+        }
+      }
+    }
+  }
+}
+
+function setShortBreakConflicts(
+  matches: ConflictMatch[],
+  defaultBreakMinutes: number,
+  flags: Map<number, ConflictFlags>
+): void {
+  const matchesByCourt = new Map<number, ConflictMatch[]>();
+  for (const match of matches) {
+    if (match.court_id != null && match.start_time != null) {
+      const existing = matchesByCourt.get(match.court_id);
+      if (existing == null) {
+        matchesByCourt.set(match.court_id, [match]);
+      } else {
+        existing.push(match);
+      }
+    }
+  }
+
+  for (const courtMatches of matchesByCourt.values()) {
+    const scheduled = [...courtMatches].sort((a, b) => {
+      const startDiff = startMillis(a)! - startMillis(b)!;
+      return startDiff !== 0 ? startDiff : a.id - b.id;
+    });
+    for (let i = 0; i + 1 < scheduled.length; i += 1) {
+      const previous = scheduled[i];
+      const match = scheduled[i + 1];
+      const breakMinutes = (startMillis(match)! - endMillis(previous)) / 60_000;
+      if (breakMinutes < defaultBreakMinutes) {
+        flags.get(match.id)!.short_break_conflict = true;
+      }
+    }
+  }
+}
+
+function setRefereeOverlapConflicts(
+  stages: ConflictStage[],
+  flags: Map<number, ConflictFlags>
+): void {
+  const teamPlayingWindows = getTeamPlayingWindows(stages);
+  const refereeingMatchesByTeam = new Map<number, ConflictMatch[]>();
+
+  for (const match of getAllMatches(stages)) {
+    if (match.start_time == null) {
+      continue;
+    }
+    const referee = match.referee;
+    if (referee == null || referee.team_id == null) {
+      continue;
+    }
+
+    const existing = refereeingMatchesByTeam.get(referee.team_id);
+    if (existing == null) {
+      refereeingMatchesByTeam.set(referee.team_id, [match]);
+    } else {
+      existing.push(match);
+    }
+
+    for (const [playingMatch, playingWindow] of teamPlayingWindows.get(referee.team_id) ?? []) {
+      if (
+        !timeRangesOverlap(
+          startMillis(match)!,
+          endMillis(match),
+          playingWindow.startMillis,
+          playingWindow.endMillis
+        )
+      ) {
+        continue;
+      }
+      flags.get(match.id)!.referee_conflict = true;
+      if (isDefinitive(playingMatch)) {
+        setStageItemInputConflict(playingMatch, playingWindow, flags);
+      }
+    }
+  }
+
+  // A team cannot referee two matches that overlap in time; flag both of them.
+  for (const refereeingMatches of refereeingMatchesByTeam.values()) {
+    for (let i = 0; i < refereeingMatches.length; i += 1) {
+      for (let j = i + 1; j < refereeingMatches.length; j += 1) {
+        if (matchesOverlap(refereeingMatches[i], refereeingMatches[j])) {
+          flags.get(refereeingMatches[i].id)!.referee_conflict = true;
+          flags.get(refereeingMatches[j].id)!.referee_conflict = true;
+        }
+      }
+    }
+  }
+}
+
+interface SlotOccupancy {
+  match: ConflictMatch;
+  startMillis: number;
+  endMillis: number;
+  /** 1 or 2 for the playing slots, null when the slot is occupied as the referee. */
+  playingSide: 1 | 2 | null;
+}
+
+function flagSlotOccupancy(occupancy: SlotOccupancy, flags: Map<number, ConflictFlags>): void {
+  const matchFlags = flags.get(occupancy.match.id)!;
+  if (occupancy.playingSide === 1) {
+    matchFlags.stage_item_input1_conflict = true;
+  } else if (occupancy.playingSide === 2) {
+    matchFlags.stage_item_input2_conflict = true;
+  } else {
+    matchFlags.referee_conflict = true;
+  }
+}
+
+/**
+ * Flag any two overlapping matches that share a `stage_item_input` slot id. This is
+ * slot-id based rather than team-id based, so it flags placeholder (tentative/empty)
+ * slots too — a slot that isn't yet resolved to a concrete team is still a resource
+ * that cannot play and/or referee two overlapping matches.
+ */
+function setSlotOverlapConflicts(stages: ConflictStage[], flags: Map<number, ConflictFlags>): void {
+  const occupanciesBySlot = new Map<number, SlotOccupancy[]>();
+  for (const match of getAllMatches(stages)) {
+    const start = startMillis(match);
+    if (start == null) {
+      continue;
+    }
+    const slots: [number | null, 1 | 2 | null][] = [
+      [match.stage_item_input1_id, 1],
+      [match.stage_item_input2_id, 2],
+      [match.referee_stage_item_input_id, null],
+    ];
+    for (const [slotId, playingSide] of slots) {
+      if (slotId == null) {
+        continue;
+      }
+      const occupancy: SlotOccupancy = {
+        match,
+        startMillis: start,
+        endMillis: endMillis(match),
+        playingSide,
+      };
+      const existing = occupanciesBySlot.get(slotId);
+      if (existing == null) {
+        occupanciesBySlot.set(slotId, [occupancy]);
+      } else {
+        existing.push(occupancy);
+      }
+    }
+  }
+
+  for (const occupancies of occupanciesBySlot.values()) {
+    for (let i = 0; i < occupancies.length; i += 1) {
+      for (let j = i + 1; j < occupancies.length; j += 1) {
+        const occupancy1 = occupancies[i];
+        const occupancy2 = occupancies[j];
+        if (
+          !timeRangesOverlap(
+            occupancy1.startMillis,
+            occupancy1.endMillis,
+            occupancy2.startMillis,
+            occupancy2.endMillis
+          )
+        ) {
+          continue;
+        }
+        flagSlotOccupancy(occupancy1, flags);
+        flagSlotOccupancy(occupancy2, flags);
+      }
+    }
+  }
+}
+
+/**
+ * Flag matches in round N that start before all matches of round N-1 have ended.
+ * Round-robin stage items are excluded: their rounds have no required ordering.
+ */
+function setRoundOrderConflicts(stages: ConflictStage[], flags: Map<number, ConflictFlags>): void {
+  for (const stage of stages) {
+    for (const stageItem of stage.stage_items) {
+      if (stageItem.type === 'ROUND_ROBIN') {
+        continue;
+      }
+      const rounds = [...stageItem.rounds].sort((a, b) => a.id - b.id);
+      for (let i = 0; i + 1 < rounds.length; i += 1) {
+        const prevRound = rounds[i];
+        const currRound = rounds[i + 1];
+        let prevRoundEnd: number | null = null;
+        for (const match of prevRound.matches) {
+          if (match.start_time == null) {
+            continue;
+          }
+          const end = endMillis(match);
+          if (prevRoundEnd == null || end > prevRoundEnd) {
+            prevRoundEnd = end;
+          }
+        }
+        if (prevRoundEnd == null) {
+          continue;
+        }
+        for (const match of currRound.matches) {
+          const start = startMillis(match);
+          if (start != null && start < prevRoundEnd) {
+            flags.get(match.id)!.round_order_conflict = true;
+          }
+        }
+      }
+    }
+  }
+}
+
+export function computeConflictFlags(
+  stages: ConflictStage[],
+  defaultBreakMinutes: number,
+  matchesOfInterest: 'all' | ReadonlySet<number> = 'all'
+): Map<number, ConflictFlags> {
+  const matches = getAllMatches(stages);
+  const flags = new Map<number, ConflictFlags>(matches.map((match) => [match.id, emptyFlags()]));
+
+  setTeamOverlapConflicts(stages, flags);
+  setRefereeOverlapConflicts(stages, flags);
+  setSlotOverlapConflicts(stages, flags);
+  setWinnerOfPrecedenceConflicts(matches, flags);
+  setCrossStagePrecedenceConflicts(stages, flags);
+  setCrossStageFeederPrecedenceConflicts(stages, flags);
+  setShortBreakConflicts(matches, defaultBreakMinutes, flags);
+  setRoundOrderConflicts(stages, flags);
+
+  if (matchesOfInterest === 'all') {
+    return flags;
+  }
+
+  // Conflicts are relational, so they are always computed over the whole schedule;
+  // only the returned map is narrowed to the matches of interest.
+  const filtered = new Map<number, ConflictFlags>();
+  for (const matchId of matchesOfInterest) {
+    const matchFlags = flags.get(matchId);
+    if (matchFlags != null) {
+      filtered.set(matchId, matchFlags);
+    }
+  }
+  return filtered;
+}

--- a/frontend/src/logic/planning/conflicts.ts
+++ b/frontend/src/logic/planning/conflicts.ts
@@ -5,8 +5,10 @@
  * `computeConflictFlags(stages, defaultBreakMinutes, matchesOfInterest)` returns a
  * `Map<matchId, ConflictFlags>` covering every conflict type the backend persists:
  *
- *   - team double-booking (`stage_item_input{1,2}_conflict`), resolved by **team_id**
- *     and restricted to definitive matches;
+ *   - team double-booking (`stage_item_input{1,2}_conflict`), flagged two ways: a
+ *     **team_id** pass (definitive matches only, catching the same team under different
+ *     slot ids across stage items) and a **slot-id** pass that also covers placeholder
+ *     (tentative/empty) playing slots not yet resolved to a team;
  *   - winner-of precedence (`precedence_conflict` / `feeder_precedence_conflict`);
  *   - cross-stage precedence (a stage item must wait for the group it feeds off);
  *   - short break (`short_break_conflict`);

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -588,6 +588,7 @@ export default function SchedulePage() {
             )}
             <ScheduleGrid
               layout={layout}
+              stages={rawStages}
               violations={violations}
               conflictPreview={conflictPreview}
               stageItemsLookup={stageItemsLookup}


### PR DESCRIPTION
Port the backend planner conflict detection to the frontend as a pure
`computeConflictFlags(stages, defaultBreakMinutes, matchesOfInterest)` in
`logic/planning/conflicts.ts`, a 1:1 port of `bracket/logic/planning/conflicts.py`.

It covers every conflict type the backend currently persists (the issue's
original four-type list is out of date):
- team double-booking, resolved by team_id and restricted to definitive matches
- winner-of precedence and its feeder mirror
- cross-stage precedence and its feeder mirror
- short break
- referee double-booking (team-backed and placeholder slot-id based)
- round order

The schedule grid now renders conflict icons from a memoized
`computeConflictFlags(rawStages, margin)` instead of the persisted
`match.*_conflict` columns, so icons update instantly on optimistic drag/swap.
The backend still persists the columns; the UI ignores them.

The curated cases from `conflicts_test.py` are ported to
`conflicts.test.ts`, locking behavioral parity.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LaGrJTBZRsNCWx8iaKvYFR