### PR TITLE
fix: allow moving a match back to not started when resetting score to 0-0

### DIFF
--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -128,10 +128,23 @@ def get_match_body_with_state_updates(existing_match: Match, match_body: MatchBo
         existing_match.stage_item_input1_score != match_body.stage_item_input1_score
         or existing_match.stage_item_input2_score != match_body.stage_item_input2_score
     )
-    if scores_changed and match_body.state not in {MatchState.IN_PROGRESS, MatchState.COMPLETED}:
+    scores_are_zero = (
+        match_body.stage_item_input1_score == 0 and match_body.stage_item_input2_score == 0
+    )
+    # A score only carries meaning while a match is in progress or completed. Outside those
+    # states the only valid score is 0–0, so resetting the score (e.g. moving a match back to
+    # "not started") is allowed, but recording a real score there is not.
+    if (
+        scores_changed
+        and match_body.state not in {MatchState.IN_PROGRESS, MatchState.COMPLETED}
+        and not scores_are_zero
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Scores can only be changed while the match is in progress or being completed",
+            detail=(
+                "Scores can only be set while the match is in progress or being completed; "
+                "moving a match to another state requires resetting its score to 0–0"
+            ),
         )
 
     completed_at = None

--- a/backend/tests/integration_tests/api/matches_test.py
+++ b/backend/tests/integration_tests/api/matches_test.py
@@ -242,6 +242,178 @@ async def test_update_match(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_update_match_back_to_not_started_resets_score(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as stage_inserted,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage_inserted.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item_inserted,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item_inserted.id})
+        ) as round_inserted,
+        inserted_team(
+            DUMMY_TEAM1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as team1_inserted,
+        inserted_team(
+            DUMMY_TEAM2.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as team2_inserted,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=0,
+                team_id=team1_inserted.id,
+                tournament_id=auth_context.tournament.id,
+                stage_item_id=stage_item_inserted.id,
+            )
+        ) as stage_item_input1_inserted,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=1,
+                team_id=team2_inserted.id,
+                tournament_id=auth_context.tournament.id,
+                stage_item_id=stage_item_inserted.id,
+            )
+        ) as stage_item_input2_inserted,
+        inserted_court(
+            DUMMY_COURT1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as court1_inserted,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_inserted.id,
+                    "stage_item_input1_id": stage_item_input1_inserted.id,
+                    "stage_item_input2_id": stage_item_input2_inserted.id,
+                    "court_id": court1_inserted.id,
+                    "stage_item_input1_score": 1,
+                    "stage_item_input2_score": 0,
+                    "state": MatchState.IN_PROGRESS,
+                    "completed_at": None,
+                }
+            )
+        ) as match_inserted,
+    ):
+        # Moving an in-progress match back to "not started" is allowed as long as the score
+        # is reset to 0–0 at the same time (the match modal does exactly this).
+        assert (
+            await send_tournament_request(
+                HTTPMethod.PUT,
+                f"matches/{match_inserted.id}",
+                auth_context,
+                None,
+                {
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "round_id": round_inserted.id,
+                    "court_id": court1_inserted.id,
+                    "state": "NOT_STARTED",
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+        updated_match = await fetch_one_parsed_certain(
+            database,
+            Match,
+            query=matches.select().where(matches.c.id == match_inserted.id),
+        )
+        assert updated_match.state is MatchState.NOT_STARTED
+        assert updated_match.stage_item_input1_score == 0
+        assert updated_match.stage_item_input2_score == 0
+
+        await assert_row_count_and_clear(matches, 1)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_match_cannot_set_nonzero_score_while_not_started(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as stage_inserted,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage_inserted.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item_inserted,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item_inserted.id})
+        ) as round_inserted,
+        inserted_team(
+            DUMMY_TEAM1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as team1_inserted,
+        inserted_team(
+            DUMMY_TEAM2.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as team2_inserted,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=0,
+                team_id=team1_inserted.id,
+                tournament_id=auth_context.tournament.id,
+                stage_item_id=stage_item_inserted.id,
+            )
+        ) as stage_item_input1_inserted,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=1,
+                team_id=team2_inserted.id,
+                tournament_id=auth_context.tournament.id,
+                stage_item_id=stage_item_inserted.id,
+            )
+        ) as stage_item_input2_inserted,
+        inserted_court(
+            DUMMY_COURT1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as court1_inserted,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_inserted.id,
+                    "stage_item_input1_id": stage_item_input1_inserted.id,
+                    "stage_item_input2_id": stage_item_input2_inserted.id,
+                    "court_id": court1_inserted.id,
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "state": MatchState.NOT_STARTED,
+                    "completed_at": None,
+                }
+            )
+        ) as match_inserted,
+    ):
+        response = await send_tournament_request(
+            HTTPMethod.PUT,
+            f"matches/{match_inserted.id}",
+            auth_context,
+            None,
+            {
+                "stage_item_input1_score": 1,
+                "stage_item_input2_score": 0,
+                "round_id": round_inserted.id,
+                "court_id": court1_inserted.id,
+                "state": "NOT_STARTED",
+            },
+        )
+        updated_match = await fetch_one_parsed_certain(
+            database,
+            Match,
+            query=matches.select().where(matches.c.id == match_inserted.id),
+        )
+
+        await assert_row_count_and_clear(matches, 1)
+
+    assert response["detail"] == (
+        "Scores can only be set while the match is in progress or being completed; "
+        "moving a match to another state requires resetting its score to 0–0"
+    )
+    assert updated_match.state is MatchState.NOT_STARTED
+    assert updated_match.stage_item_input1_score == 0
+    assert updated_match.stage_item_input2_score == 0
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_update_match_fails_when_stage_has_not_started(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:


### PR DESCRIPTION
The score-entry rework rejected any score change when the target state was
not IN_PROGRESS or COMPLETED. The match modal resets the score to 0-0 when a
match is moved back to NOT_STARTED, so saving that transition failed with
"Scores can only be changed while the match is in progress".

Allow a score change to a non-active state when the resulting score is 0-0
(a reset), while still rejecting recording a real (non-zero) score outside
the in-progress/completed states.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JGTgdocCezzscxYHc9KbQB