### PR TITLE
Rebuild planner conflict preview on the shared conflict engine

### DIFF
--- a/frontend/src/logic/planning/conflict_preview.test.ts
+++ b/frontend/src/logic/planning/conflict_preview.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  ConflictPreviewMatch,
-  actionCreatesSelectedConflict,
-  computeConflictPreview,
-  insertionLineKey,
-} from './conflict_preview';
+import { computeConflictPreview, insertionLineKey } from './conflict_preview';
+import { ConflictMatch, ConflictStage } from './conflicts';
 import { computeScheduleLayout } from './layout';
 
 const START = '2026-06-10T09:00:00.000Z';
@@ -23,6 +19,8 @@ function match({
   input2,
   referee = null,
   durationMinutes = 90,
+  winnerFromMatch1 = null,
+  winnerFromMatch2 = null,
 }: {
   id: number;
   courtId: number | null;
@@ -31,165 +29,42 @@ function match({
   input2: number;
   referee?: number | null;
   durationMinutes?: number;
-}): ConflictPreviewMatch {
+  winnerFromMatch1?: number | null;
+  winnerFromMatch2?: number | null;
+}): ConflictMatch {
   return {
     id,
     court_id: courtId,
     start_time: startMinutes == null ? null : minutesAfterStart(startMinutes),
     duration_minutes: durationMinutes,
+    stage_item_input1: null,
+    stage_item_input2: null,
     stage_item_input1_id: input1,
     stage_item_input2_id: input2,
+    stage_item_input1_winner_from_match_id: winnerFromMatch1,
+    stage_item_input2_winner_from_match_id: winnerFromMatch2,
     referee_stage_item_input_id: referee,
+    referee: null,
   };
 }
 
-function stagesWith(matches: ConflictPreviewMatch[]) {
-  return [{ stage_items: [{ rounds: [{ matches }] }] }];
+function stagesWith(matches: ConflictMatch[]): ConflictStage[] {
+  return [
+    {
+      stage_items: [
+        { id: 1, type: 'SINGLE_ELIMINATION', inputs: [], rounds: [{ id: 1, matches }] },
+      ],
+    },
+  ];
 }
-
-describe('actionCreatesSelectedConflict', () => {
-  it('detects a selected-match team overlap after a simulated insertion repacks courts', () => {
-    const stages = stagesWith([
-      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20 }),
-      match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 50 }),
-      match({ id: 3, courtId: 3, startMinutes: 0, input1: 10, input2: 30 }),
-    ]);
-
-    expect(
-      actionCreatesSelectedConflict({
-        stages,
-        selectedMatchId: 1,
-        tournamentStartTime: START,
-        action: {
-          type: 'reschedule',
-          matchId: 1,
-          body: {
-            old_court_id: 1,
-            old_position: 0,
-            new_court_id: 2,
-            new_position: 0,
-          },
-        },
-      })
-    ).toBe(true);
-  });
-
-  it('applies the default break when repacking, pushing the moved match into a team overlap', () => {
-    // Inserted after match 2, match 1 lands at 20 (end) + 10 break = 30, playing
-    // [30, 50). With no break it would sit at [20, 40) and clear match 3 at [45, 65).
-    const stages = stagesWith([
-      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20, durationMinutes: 20 }),
-      match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 50, durationMinutes: 20 }),
-      match({ id: 3, courtId: 3, startMinutes: 45, input1: 10, input2: 30, durationMinutes: 20 }),
-    ]);
-
-    expect(
-      actionCreatesSelectedConflict({
-        stages,
-        selectedMatchId: 1,
-        tournamentStartTime: START,
-        defaultBreakMinutes: 10,
-        action: {
-          type: 'reschedule',
-          matchId: 1,
-          body: {
-            old_court_id: 1,
-            old_position: 0,
-            new_court_id: 2,
-            new_position: 1,
-          },
-        },
-      })
-    ).toBe(true);
-  });
-
-  it('detects a conflict when the selected match referees a team that is playing an overlapping match', () => {
-    // Match 1 referees team 60; match 3 plays team 60 at the same time. They share
-    // no playing input, so only the referee slot makes them conflict.
-    const stages = stagesWith([
-      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20, referee: 60 }),
-      match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 50 }),
-      match({ id: 3, courtId: 3, startMinutes: 0, input1: 60, input2: 30 }),
-    ]);
-
-    expect(
-      actionCreatesSelectedConflict({
-        stages,
-        selectedMatchId: 1,
-        tournamentStartTime: START,
-        action: {
-          type: 'reschedule',
-          matchId: 1,
-          body: {
-            old_court_id: 1,
-            old_position: 0,
-            new_court_id: 2,
-            new_position: 0,
-          },
-        },
-      })
-    ).toBe(true);
-  });
-
-  it('detects a conflict when the selected match referees a team that referees an overlapping match', () => {
-    // Both match 1 and match 3 have team 60 as referee, at the same time.
-    const stages = stagesWith([
-      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20, referee: 60 }),
-      match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 50 }),
-      match({ id: 3, courtId: 3, startMinutes: 0, input1: 70, input2: 30, referee: 60 }),
-    ]);
-
-    expect(
-      actionCreatesSelectedConflict({
-        stages,
-        selectedMatchId: 1,
-        tournamentStartTime: START,
-        action: {
-          type: 'reschedule',
-          matchId: 1,
-          body: {
-            old_court_id: 1,
-            old_position: 0,
-            new_court_id: 2,
-            new_position: 0,
-          },
-        },
-      })
-    ).toBe(true);
-  });
-
-  it('ignores the referee slot when referees are disabled', () => {
-    const stages = stagesWith([
-      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20, referee: 60 }),
-      match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 50 }),
-      match({ id: 3, courtId: 3, startMinutes: 0, input1: 60, input2: 30 }),
-    ]);
-
-    expect(
-      actionCreatesSelectedConflict({
-        stages,
-        selectedMatchId: 1,
-        tournamentStartTime: START,
-        refereesEnabled: false,
-        action: {
-          type: 'reschedule',
-          matchId: 1,
-          body: {
-            old_court_id: 1,
-            old_position: 0,
-            new_court_id: 2,
-            new_position: 0,
-          },
-        },
-      })
-    ).toBe(false);
-  });
-});
 
 describe('computeConflictPreview', () => {
   it('flags insertion lines that would create a selected-match team overlap', () => {
+    // Match 1 starts at minute 200, so it does not overlap its slot-10 twin (match
+    // 4) where it currently sits; inserting it into court 2 reseeds it to minute 0,
+    // where it would collide with match 4.
     const matches = [
-      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20 }),
+      match({ id: 1, courtId: 1, startMinutes: 200, input1: 10, input2: 20 }),
       match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 50 }),
       match({ id: 3, courtId: 2, startMinutes: PACKED_SLOT_MINUTES, input1: 40, input2: 50 }),
       match({ id: 4, courtId: 3, startMinutes: 0, input1: 10, input2: 30 }),
@@ -211,6 +86,7 @@ describe('computeConflictPreview', () => {
         kind: 'match-selected',
         match: { matchId: 1, courtId: 1, position: 0 },
       },
+      tournamentStartTime: START,
     });
 
     expect([...preview.insertionLines]).toContain(insertionLineKey(2, 0));
@@ -236,6 +112,7 @@ describe('computeConflictPreview', () => {
       stages: stagesWith(matches),
       layout,
       selection: { kind: 'tray-match-selected', matchId: 1 },
+      tournamentStartTime: START,
     });
 
     expect([...preview.insertionLines]).toContain(insertionLineKey(1, 0));
@@ -272,10 +149,49 @@ describe('computeConflictPreview', () => {
       stages: stagesWith(matches),
       layout,
       selection: { kind: 'tray-match-selected', matchId: 1 },
+      tournamentStartTime: START,
     });
 
     expect([...preview.insertionLines]).toContain(insertionLineKey(1, 0));
     expect([...preview.insertionLines]).not.toContain(insertionLineKey(1, 2));
+  });
+
+  it('flags insertion lines that would create a winner-of precedence conflict', () => {
+    // Match 2 is fed by match 1's winner. Match 1 plays [0, 90) on court 1. Placed
+    // ahead of court 2's existing match, the dependent reseeds to minute 0 and would
+    // start before its feeder finishes — a precedence conflict the team-overlap-only
+    // preview never saw, since the two share no playing slot.
+    const matches = [
+      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20 }),
+      match({
+        id: 2,
+        courtId: null,
+        startMinutes: null,
+        input1: 60,
+        input2: 70,
+        winnerFromMatch1: 1,
+      }),
+      match({ id: 3, courtId: 2, startMinutes: 0, input1: 40, input2: 50 }),
+    ];
+    const layout = computeScheduleLayout({
+      courts: [
+        { id: 1, name: 'Court 1' },
+        { id: 2, name: 'Court 2' },
+      ],
+      matchesByCourtId: { 1: [matches[0]], 2: [matches[2]] },
+      tournamentStartTime: START,
+      defaultBreakMinutes: 10,
+    });
+
+    const preview = computeConflictPreview({
+      stages: stagesWith(matches),
+      layout,
+      selection: { kind: 'tray-match-selected', matchId: 2 },
+      tournamentStartTime: START,
+    });
+
+    expect([...preview.insertionLines]).toContain(insertionLineKey(2, 0));
+    expect([...preview.insertionLines]).not.toContain(insertionLineKey(2, 1));
   });
 
   it('flags swap targets that would put the selected match into a conflicting slot', () => {
@@ -297,6 +213,7 @@ describe('computeConflictPreview', () => {
       stages: stagesWith(matches),
       layout,
       selection: { kind: 'tray-match-selected', matchId: 1 },
+      tournamentStartTime: START,
     });
 
     expect([...preview.swapTargets]).toContain(2);
@@ -304,8 +221,10 @@ describe('computeConflictPreview', () => {
   });
 
   it('flags scheduled-match swap targets after simulating the traded slots', () => {
+    // Match 1 sits at minute 200, clear of its slot-10 twin (match 3 at minute 0).
+    // Swapping it into match 2's minute-0 slot would drop it onto match 3.
     const matches = [
-      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20 }),
+      match({ id: 1, courtId: 1, startMinutes: 200, input1: 10, input2: 20 }),
       match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 50 }),
       match({ id: 3, courtId: 3, startMinutes: 0, input1: 10, input2: 30 }),
       match({ id: 4, courtId: 2, startMinutes: PACKED_SLOT_MINUTES, input1: 60, input2: 70 }),
@@ -327,6 +246,7 @@ describe('computeConflictPreview', () => {
         kind: 'match-selected',
         match: { matchId: 1, courtId: 1, position: 0 },
       },
+      tournamentStartTime: START,
     });
 
     expect([...preview.swapTargets]).toContain(2);
@@ -363,10 +283,45 @@ describe('computeConflictPreview', () => {
         kind: 'match-selected',
         match: { matchId: 1, courtId: 1, position: 0 },
       },
+      tournamentStartTime: START,
     });
 
     expect([...preview.swapTargets]).toContain(4);
     expect([...preview.swapTargets]).not.toContain(2);
+  });
+
+  it('flags swap targets that would create a short-break conflict', () => {
+    // Court 1 packs match 1 [0, 20) then match 3 [30, 50) — a clean 10-minute break.
+    // Court 2's match 2 runs 40 minutes. Swapping match 2 into match 1's slot lands a
+    // [0, 40) block in front of match 3, leaving a negative break: a short-break
+    // conflict between matches that share no playing slot.
+    const matches = [
+      match({ id: 1, courtId: 1, startMinutes: 0, input1: 10, input2: 20, durationMinutes: 20 }),
+      match({ id: 2, courtId: 2, startMinutes: 0, input1: 40, input2: 41, durationMinutes: 40 }),
+      match({ id: 3, courtId: 1, startMinutes: 30, input1: 30, input2: 31, durationMinutes: 20 }),
+    ];
+    const layout = computeScheduleLayout({
+      courts: [
+        { id: 1, name: 'Court 1' },
+        { id: 2, name: 'Court 2' },
+      ],
+      matchesByCourtId: { 1: [matches[0], matches[2]], 2: [matches[1]] },
+      tournamentStartTime: START,
+      defaultBreakMinutes: 10,
+    });
+
+    const preview = computeConflictPreview({
+      stages: stagesWith(matches),
+      layout,
+      selection: {
+        kind: 'match-selected',
+        match: { matchId: 1, courtId: 1, position: 0 },
+      },
+      tournamentStartTime: START,
+    });
+
+    expect([...preview.swapTargets]).toContain(2);
+    expect([...preview.swapTargets]).not.toContain(3);
   });
 
   it('flags a swap target whose slot would double-book the selected match referee', () => {
@@ -391,7 +346,7 @@ describe('computeConflictPreview', () => {
       stages: stagesWith(matches),
       layout,
       selection: { kind: 'tray-match-selected', matchId: 1 },
-      refereesEnabled: true,
+      tournamentStartTime: START,
     });
 
     expect([...preview.swapTargets]).toContain(2);

--- a/frontend/src/logic/planning/conflict_preview.ts
+++ b/frontend/src/logic/planning/conflict_preview.ts
@@ -1,35 +1,35 @@
-import { InsertionLine, LayoutCourt, ScheduleGridLayout, computeInsertionLines } from './layout';
-import { OptimisticMatch, OptimisticStage, applyPlanningActions } from './optimistic';
+/**
+ * Conflict preview for the planning grid, built on the shared client conflict
+ * engine (`computeConflictFlags`).
+ *
+ * Every placement affordance — an insertion line on a court, or a scheduled match
+ * the current selection could swap with — is previewed by simulating the candidate
+ * action with `applyPlanningActions`, recomputing the conflict flags for the
+ * resulting schedule, and diffing them against the pre-action flags. An affordance
+ * is highlighted when the action would introduce a conflict that was not already
+ * present, so the highlight reflects every conflict type the engine detects
+ * (team/slot double-booking, referee, winner-of and cross-stage precedence, short
+ * break, round order) rather than just team overlap.
+ */
+import { ConflictFlags, ConflictStage, computeConflictFlags } from './conflicts';
+import { ScheduleGridLayout, computeInsertionLines } from './layout';
+import { applyPlanningActions } from './optimistic';
 import { PlanningAction, SelectionState, selectionReducer } from './selection';
-
-export interface ConflictPreviewMatch extends OptimisticMatch {
-  stage_item_input1_id: number | null;
-  stage_item_input2_id: number | null;
-  referee_stage_item_input_id: number | null;
-}
-
-export interface ConflictPreviewStage extends OptimisticStage {
-  stage_items: { rounds: { matches: ConflictPreviewMatch[] }[] }[];
-}
 
 export interface ConflictPreview {
   insertionLines: Set<string>;
   swapTargets: Set<number>;
 }
 
-interface PreviewBlock {
-  courtId: number;
-  match: ConflictPreviewMatch;
-  startMinutes: number;
-}
-
-interface PreparedPreview {
-  matchesById: Map<number, ConflictPreviewMatch>;
-  blocksByCourtId: Map<number, PreviewBlock[]>;
-  blockByMatchId: Map<number, PreviewBlock>;
-  defaultBreakMinutes: number;
-  refereesEnabled: boolean;
-}
+const CONFLICT_FLAG_KEYS = [
+  'stage_item_input1_conflict',
+  'stage_item_input2_conflict',
+  'precedence_conflict',
+  'feeder_precedence_conflict',
+  'short_break_conflict',
+  'referee_conflict',
+  'round_order_conflict',
+] as const satisfies readonly (keyof ConflictFlags)[];
 
 export function insertionLineKey(courtId: number, index: number): string {
   return `${courtId}:${index}`;
@@ -50,379 +50,73 @@ function getSelectedMatchId(selection: SelectionState): number | null {
   }
 }
 
-function getMatches(stages: ConflictPreviewStage[]): ConflictPreviewMatch[] {
-  return stages.flatMap((stage) =>
-    stage.stage_items.flatMap((stageItem) => stageItem.rounds.flatMap((round) => round.matches))
-  );
+/**
+ * The actions a tap would trigger from the current selection. A tap that needs a
+ * move confirmation stashes its action in the resulting `confirm-move` state
+ * rather than emitting it, so the preview reaches in to recover the pending action.
+ */
+function transitionActions(transition: ReturnType<typeof selectionReducer>): PlanningAction[] {
+  if (transition.actions.length > 0) return transition.actions;
+  return transition.state.kind === 'confirm-move' ? [transition.state.action] : [];
 }
 
 /**
- * The stage-item-input slots a match occupies for conflict purposes: its two
- * playing slots and — when referees are enabled — the referee slot, mirroring the
- * backend's "referee is a third match slot" model. This is the single place that
- * decides which slots a match ties up; both the simulated-action check and the
- * block-based preview share it, so referee double-booking is handled identically.
+ * Whether applying `actions` to `stages` introduces a conflict flag the pre-action
+ * `baseline` did not already carry. Conflicts are relational, so the whole schedule
+ * is re-evaluated and every match compared — a move can push an unrelated match
+ * into a conflict, not just the one being placed.
  */
-function occupiedSlotIds(match: ConflictPreviewMatch, refereesEnabled: boolean): Set<number> {
-  const slotIds = [match.stage_item_input1_id, match.stage_item_input2_id];
-  if (refereesEnabled) slotIds.push(match.referee_stage_item_input_id);
-  return new Set(slotIds.filter((id): id is number => id != null));
-}
-
-function sharesSlot(
-  match1: ConflictPreviewMatch,
-  match2: ConflictPreviewMatch,
-  refereesEnabled: boolean
+function actionsIntroduceConflict(
+  stages: ConflictStage[],
+  baseline: Map<number, ConflictFlags>,
+  defaultBreakMinutes: number,
+  tournamentStartTime: string | Date,
+  actions: PlanningAction[]
 ): boolean {
-  const slots1 = occupiedSlotIds(match1, refereesEnabled);
-  return [...occupiedSlotIds(match2, refereesEnabled)].some((id) => slots1.has(id));
-}
+  if (actions.length === 0) return false;
 
-function playingIntervalMillis(match: ConflictPreviewMatch): [number, number] | null {
-  if (match.start_time == null) return null;
+  const simulated = applyPlanningActions(stages, actions, tournamentStartTime, defaultBreakMinutes);
+  const postFlags = computeConflictFlags(simulated, defaultBreakMinutes);
 
-  const start = new Date(match.start_time).getTime();
-  return [start, start + slotLengthMinutes(match) * 60_000];
-}
-
-function playingTimesOverlap(match1: ConflictPreviewMatch, match2: ConflictPreviewMatch): boolean {
-  const interval1 = playingIntervalMillis(match1);
-  const interval2 = playingIntervalMillis(match2);
-  if (interval1 == null || interval2 == null) return false;
-
-  // Half-open intervals [start, end): adjacent playing windows do not conflict.
-  return interval1[0] < interval2[1] && interval2[0] < interval1[1];
-}
-
-function slotLengthMinutes(match: ConflictPreviewMatch): number {
-  return match.duration_minutes;
-}
-
-function playingMinutesOverlap(
-  startMinutes1: number,
-  durationMinutes1: number,
-  startMinutes2: number,
-  durationMinutes2: number
-): boolean {
-  return (
-    startMinutes1 < startMinutes2 + durationMinutes2 &&
-    startMinutes2 < startMinutes1 + durationMinutes1
-  );
-}
-
-export function actionCreatesSelectedConflict({
-  stages,
-  selectedMatchId,
-  tournamentStartTime,
-  defaultBreakMinutes = 0,
-  refereesEnabled = true,
-  action,
-}: {
-  stages: ConflictPreviewStage[];
-  selectedMatchId: number;
-  tournamentStartTime: string | Date;
-  defaultBreakMinutes?: number;
-  refereesEnabled?: boolean;
-  action: PlanningAction;
-}): boolean {
-  const simulated = applyPlanningActions(
-    stages,
-    [action],
-    tournamentStartTime,
-    defaultBreakMinutes
-  );
-  const matches = getMatches(simulated);
-  const selected = matches.find((match) => match.id === selectedMatchId);
-  if (selected == null || occupiedSlotIds(selected, refereesEnabled).size === 0) return false;
-
-  return matches.some(
-    (match) =>
-      match.id !== selected.id &&
-      sharesSlot(selected, match, refereesEnabled) &&
-      playingTimesOverlap(selected, match)
-  );
-}
-
-function preparePreview(
-  stages: ConflictPreviewStage[],
-  layout: ScheduleGridLayout<LayoutCourt, ConflictPreviewMatch>,
-  selection: SelectionState,
-  refereesEnabled: boolean
-): PreparedPreview | null {
-  const selectedMatchId = getSelectedMatchId(selection);
-  if (selectedMatchId == null) return null;
-
-  const matchesById = new Map(getMatches(stages).map((match) => [match.id, match]));
-  if (!matchesById.has(selectedMatchId)) return null;
-
-  const blocksByCourtId = new Map<number, PreviewBlock[]>();
-  const blockByMatchId = new Map<number, PreviewBlock>();
-
-  for (const { court, blocks } of layout.courts) {
-    const previewBlocks = blocks.map((block) => ({
-      courtId: court.id,
-      match: block.match,
-      startMinutes: block.startMinutes,
-    }));
-    blocksByCourtId.set(court.id, previewBlocks);
-    for (const block of previewBlocks) {
-      blockByMatchId.set(block.match.id, block);
-    }
-  }
-
-  return {
-    matchesById,
-    blocksByCourtId,
-    blockByMatchId,
-    defaultBreakMinutes: layout.defaultBreakMinutes,
-    refereesEnabled,
-  };
-}
-
-/**
- * A match queued for a court, paired with the start it would keep if nothing
- * forced it later. Matches that stay put carry their existing start; a match
- * that moves into a slot adopts that slot's start (mirroring the backend, which
- * copies the swapped match's `start_time` or resets a rescheduled one to None).
- */
-interface RescheduleEntry {
-  match: ConflictPreviewMatch;
-  baseStartMinutes: number;
-}
-
-function rescheduleCourt(
-  prepared: PreparedPreview,
-  courtId: number,
-  entries: RescheduleEntry[]
-): PreviewBlock[] {
-  let previousEnd: number | null = null;
-  return entries.map(({ match, baseStartMinutes }) => {
-    let startMinutes = baseStartMinutes;
-    if (previousEnd != null) {
-      startMinutes = Math.max(startMinutes, previousEnd + prepared.defaultBreakMinutes);
-    }
-    const block = { courtId, match, startMinutes };
-    previousEnd = startMinutes + slotLengthMinutes(match);
-    return block;
-  });
-}
-
-/** Existing matches on a court as entries that keep their current starts. */
-function courtEntries(
-  prepared: PreparedPreview,
-  courtId: number,
-  excludeMatchId?: number
-): RescheduleEntry[] {
-  return (prepared.blocksByCourtId.get(courtId) ?? [])
-    .filter((block) => block.match.id !== excludeMatchId)
-    .map((block) => ({ match: block.match, baseStartMinutes: block.startMinutes }));
-}
-
-function blocksConflict(
-  block1: PreviewBlock,
-  block2: PreviewBlock,
-  refereesEnabled: boolean
-): boolean {
-  return (
-    sharesSlot(block1.match, block2.match, refereesEnabled) &&
-    playingMinutesOverlap(
-      block1.startMinutes,
-      slotLengthMinutes(block1.match),
-      block2.startMinutes,
-      slotLengthMinutes(block2.match)
-    )
-  );
-}
-
-function postScheduleBlocks(
-  prepared: PreparedPreview,
-  affectedCourts: Map<number, PreviewBlock[]>
-): PreviewBlock[] {
-  const courtIds = new Set([...prepared.blocksByCourtId.keys(), ...affectedCourts.keys()]);
-  return [...courtIds].flatMap(
-    (courtId) => affectedCourts.get(courtId) ?? prepared.blocksByCourtId.get(courtId) ?? []
-  );
-}
-
-function changedPostBlocks(prepared: PreparedPreview, postBlocks: PreviewBlock[]): PreviewBlock[] {
-  return postBlocks.filter((block) => {
-    const previous = prepared.blockByMatchId.get(block.match.id);
-    return (
-      previous == null ||
-      previous.courtId !== block.courtId ||
-      previous.startMinutes !== block.startMinutes
-    );
-  });
-}
-
-function affectedScheduleCreatesConflict(
-  prepared: PreparedPreview,
-  affectedCourts: Map<number, PreviewBlock[]>
-): boolean {
-  const postBlocks = postScheduleBlocks(prepared, affectedCourts);
-  const changedBlocks = changedPostBlocks(prepared, postBlocks);
-
-  for (const changedBlock of changedBlocks) {
-    for (const block of postBlocks) {
-      if (
-        changedBlock.match.id !== block.match.id &&
-        blocksConflict(changedBlock, block, prepared.refereesEnabled)
-      ) {
+  for (const [matchId, flags] of postFlags) {
+    const before = baseline.get(matchId);
+    for (const key of CONFLICT_FLAG_KEYS) {
+      if (flags[key] && before?.[key] !== true) {
         return true;
       }
     }
   }
-
   return false;
-}
-
-function rescheduleAffectedCourts(
-  prepared: PreparedPreview,
-  action: Extract<PlanningAction, { type: 'reschedule' }>
-): Map<number, PreviewBlock[]> | null {
-  const match = prepared.matchesById.get(action.matchId);
-  if (match == null) return null;
-
-  const { old_court_id, new_court_id, new_position } = action.body;
-  const targetEntries = courtEntries(prepared, new_court_id, match.id);
-  const index = Math.min(Math.max(new_position, 0), targetEntries.length);
-  // The moved match seeds at the tournament start (backend resets start_time to None).
-  const newCourtEntries: RescheduleEntry[] = [
-    ...targetEntries.slice(0, index),
-    { match, baseStartMinutes: 0 },
-    ...targetEntries.slice(index),
-  ];
-  const affectedCourts = new Map<number, PreviewBlock[]>();
-  affectedCourts.set(new_court_id, rescheduleCourt(prepared, new_court_id, newCourtEntries));
-
-  if (old_court_id != null && old_court_id !== new_court_id) {
-    affectedCourts.set(
-      old_court_id,
-      rescheduleCourt(prepared, old_court_id, courtEntries(prepared, old_court_id, match.id))
-    );
-  }
-
-  return affectedCourts;
-}
-
-function swapAffectedCourts(
-  prepared: PreparedPreview,
-  action: Extract<PlanningAction, { type: 'swap' }>
-): Map<number, PreviewBlock[]> | null {
-  const match1 = prepared.matchesById.get(action.matchId1);
-  const match2 = prepared.matchesById.get(action.matchId2);
-  if (match1 == null || match2 == null) return null;
-
-  const block1 = prepared.blockByMatchId.get(match1.id);
-  const block2 = prepared.blockByMatchId.get(match2.id);
-  if (block1 == null && block2 == null) return null;
-
-  const affectedCourts = new Map<number, PreviewBlock[]>();
-
-  if (block1 != null && block2 != null) {
-    // Two scheduled matches trade slots: each adopts the other slot's start.
-    const swapEntry = (block: PreviewBlock): RescheduleEntry => {
-      if (block.match.id === match1.id)
-        return { match: match2, baseStartMinutes: block.startMinutes };
-      if (block.match.id === match2.id)
-        return { match: match1, baseStartMinutes: block.startMinutes };
-      return { match: block.match, baseStartMinutes: block.startMinutes };
-    };
-
-    if (block1.courtId === block2.courtId) {
-      const entries = (prepared.blocksByCourtId.get(block1.courtId) ?? []).map(swapEntry);
-      affectedCourts.set(block1.courtId, rescheduleCourt(prepared, block1.courtId, entries));
-      return affectedCourts;
-    }
-
-    affectedCourts.set(
-      block1.courtId,
-      rescheduleCourt(
-        prepared,
-        block1.courtId,
-        (prepared.blocksByCourtId.get(block1.courtId) ?? []).map(swapEntry)
-      )
-    );
-    affectedCourts.set(
-      block2.courtId,
-      rescheduleCourt(
-        prepared,
-        block2.courtId,
-        (prepared.blocksByCourtId.get(block2.courtId) ?? []).map(swapEntry)
-      )
-    );
-    return affectedCourts;
-  }
-
-  // Mixed swap: the tray match takes over the scheduled match's slot.
-  const scheduledBlock = block1 ?? block2!;
-  const incomingMatch = block1 == null ? match1 : match2;
-  const entries = (prepared.blocksByCourtId.get(scheduledBlock.courtId) ?? []).map(
-    (block): RescheduleEntry =>
-      block.match.id === scheduledBlock.match.id
-        ? { match: incomingMatch, baseStartMinutes: block.startMinutes }
-        : { match: block.match, baseStartMinutes: block.startMinutes }
-  );
-  affectedCourts.set(
-    scheduledBlock.courtId,
-    rescheduleCourt(prepared, scheduledBlock.courtId, entries)
-  );
-  return affectedCourts;
-}
-
-function planningActionCreatesConflict(prepared: PreparedPreview, action: PlanningAction): boolean {
-  let affectedCourts: Map<number, PreviewBlock[]> | null = null;
-
-  switch (action.type) {
-    case 'reschedule':
-      affectedCourts = rescheduleAffectedCourts(prepared, action);
-      break;
-    case 'swap':
-      affectedCourts = swapAffectedCourts(prepared, action);
-      break;
-    default:
-      return false;
-  }
-
-  return affectedCourts != null && affectedScheduleCreatesConflict(prepared, affectedCourts);
 }
 
 export function computeConflictPreview({
   stages,
   layout,
   selection,
-  refereesEnabled = true,
+  tournamentStartTime,
 }: {
-  stages: ConflictPreviewStage[];
-  layout: ScheduleGridLayout<LayoutCourt, ConflictPreviewMatch>;
+  stages: ConflictStage[];
+  layout: ScheduleGridLayout;
   selection: SelectionState;
-  refereesEnabled?: boolean;
+  tournamentStartTime: string | Date;
 }): ConflictPreview {
-  if (selection.kind === 'idle') return emptyPreview();
-  const prepared = preparePreview(stages, layout, selection, refereesEnabled);
-  if (prepared == null) return emptyPreview();
-  const preparedPreview = prepared;
+  if (getSelectedMatchId(selection) == null) return emptyPreview();
 
+  const defaultBreakMinutes = layout.defaultBreakMinutes;
+  const baseline = computeConflictFlags(stages, defaultBreakMinutes);
   const preview = emptyPreview();
 
-  function hasConflict(actions: PlanningAction[]): boolean {
-    return actions.some((action) => planningActionCreatesConflict(preparedPreview, action));
-  }
-
-  function transitionActions(transition: ReturnType<typeof selectionReducer>): PlanningAction[] {
-    if (transition.actions.length > 0) return transition.actions;
-    return transition.state.kind === 'confirm-move' ? [transition.state.action] : [];
-  }
+  const introducesConflict = (actions: PlanningAction[]): boolean =>
+    actionsIntroduceConflict(stages, baseline, defaultBreakMinutes, tournamentStartTime, actions);
 
   for (const { court, blocks } of layout.courts) {
-    const lines: InsertionLine[] = computeInsertionLines(blocks);
-    for (const line of lines) {
+    for (const line of computeInsertionLines(blocks)) {
       const transition = selectionReducer(selection, {
         type: 'tap-insertion-line',
         courtId: court.id,
         index: line.index,
       });
-      if (hasConflict(transitionActions(transition))) {
+      if (introducesConflict(transitionActions(transition))) {
         preview.insertionLines.add(insertionLineKey(court.id, line.index));
       }
     }
@@ -430,13 +124,9 @@ export function computeConflictPreview({
     blocks.forEach((block, blockIndex) => {
       const transition = selectionReducer(selection, {
         type: 'tap-match',
-        match: {
-          matchId: block.match.id,
-          courtId: court.id,
-          position: blockIndex,
-        },
+        match: { matchId: block.match.id, courtId: court.id, position: blockIndex },
       });
-      if (hasConflict(transitionActions(transition))) {
+      if (introducesConflict(transitionActions(transition))) {
         preview.swapTargets.add(block.match.id);
       }
     });

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -27,7 +27,7 @@ import {
   IconWand,
 } from '@tabler/icons-react';
 import { isAxiosError } from 'axios';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import CourtModal from '@components/modals/create_court_modal';
@@ -36,7 +36,7 @@ import { NoContent } from '@components/no_content/empty_table_info';
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
 import { getTournamentIdFromRouter, responseIsValid } from '@components/utils/util';
 import { computeStageItemColours, levelSwatchColour } from '@logic/colors';
-import { computeConflictPreview } from '@logic/planning/conflict_preview';
+import { ConflictPreview, computeConflictPreview } from '@logic/planning/conflict_preview';
 import { stageHighlightOptions } from '@logic/planning/highlight';
 import { computeScheduleLayout } from '@logic/planning/layout';
 import { currentTimeOffsetMinutes } from '@logic/planning/now_line';
@@ -244,6 +244,46 @@ export default function SchedulePage() {
     previousSelectionRef.current = planner.selection;
   }, [planner.selection, refreshSchedule]);
 
+  // The conflict preview simulates every candidate placement against the shared
+  // conflict engine, so it is memoized on the inputs that actually change its
+  // result — the schedule, courts, tournament settings, the active selection and
+  // the zoom level — instead of being recomputed on every unrelated re-render
+  // (e.g. the minute clock tick). At overview zoom placement is disabled, so there
+  // is nothing to preview.
+  const conflictPreview = useMemo<ConflictPreview>(() => {
+    if (
+      planner.zoom === 'overview' ||
+      !responseIsValid(swrStagesResponse) ||
+      !responseIsValid(swrCourtsResponse) ||
+      !responseIsValid(swrTournamentResponse)
+    ) {
+      return { insertionLines: new Set<string>(), swapTargets: new Set<number>() };
+    }
+    const tournamentValue = swrTournamentResponse.data!.data;
+    const courtsValue: Court[] = swrCourtsResponse.data?.data ?? [];
+    const stagesValue: StageWithStageItems[] = swrStagesResponse.data?.data ?? [];
+    const previewLayout = computeScheduleLayout({
+      courts: courtsValue,
+      matchesByCourtId: getMatchLookupByCourt(swrStagesResponse),
+      tournamentStartTime: tournamentValue.start_time,
+      defaultBreakMinutes: tournamentValue.margin_minutes,
+      tickIntervalMinutes: ZOOM_TICK_INTERVAL_MINUTES[planner.zoom],
+    });
+    return computeConflictPreview({
+      stages: stagesValue,
+      layout: previewLayout,
+      selection: planner.selection,
+      tournamentStartTime: tournamentValue.start_time,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    swrStagesResponse.data?.data,
+    swrCourtsResponse.data?.data,
+    swrTournamentResponse.data?.data,
+    planner.selection,
+    planner.zoom,
+  ]);
+
   const stageItemsLookup = responseIsValid(swrStagesResponse)
     ? getStageItemLookup(swrStagesResponse)
     : [];
@@ -418,14 +458,6 @@ export default function SchedulePage() {
   const detailsMatch =
     detailsMatchId != null ? (matchesLookup[detailsMatchId]?.match ?? null) : null;
   const isOverview = planner.zoom === 'overview';
-  const conflictPreview = isOverview
-    ? { insertionLines: new Set<string>(), swapTargets: new Set<number>() }
-    : computeConflictPreview({
-        stages: rawStages,
-        layout,
-        selection: planner.selection,
-        refereesEnabled: tournament.referees_enabled,
-      });
 
   // Pieces of the selection pill, extracted so the mobile (stacked) and desktop
   // (single row) layouts can compose them without duplicating the markup.


### PR DESCRIPTION
## What

Rebuilds the planner's conflict **preview** on top of the shared client conflict engine from #107, replacing the bespoke block-diffing implementation in `conflict_preview.ts`.

Instead of rescheduling affected courts into `PreviewBlock`s and diffing changed blocks, the preview now simulates the candidate action and recomputes flags: for every insertion line and swap target, `applyPlanningActions` produces the resulting schedule, `computeConflictFlags` recomputes the flags, and the affordance is highlighted when the action **introduces** a conflict the pre-action flags did not already carry.

This unifies the planner on a single overlap implementation and makes the preview strictly more complete: insertion-line and swap-target highlights now reflect winner-of/cross-stage precedence, short-break, referee and round-order conflicts — not just team overlap.

## Changes

- `conflict_preview.ts`: preview computed via simulate → `computeConflictFlags` → diff against baseline flags. Bespoke `PreviewBlock` rescheduling and the now-unused `actionCreatesSelectedConflict` helper removed.
- `schedule.tsx`: `conflictPreview` is memoized on the schedule, courts, tournament settings, selection and zoom, so it no longer recomputes on unrelated re-renders (e.g. the minute-clock tick). The memo sits before the component's early returns to respect the rules of hooks.
- `conflict_preview.test.ts`: updated to the engine-based API and extended with precedence and short-break cases (developed red/green — both fail on the old team-overlap-only implementation).

## Behavior note

The preview no longer takes a `refereesEnabled` flag — it now mirrors `computeConflictFlags`, which (like the grid icons and match modal) always evaluates referee slots from the schedule data.

## Acceptance criteria

- [x] `conflict_preview.ts` preview is computed via simulate + `computeConflictFlags` + diff (bespoke block-diffing removed)
- [x] Insertion-line and swap-target highlights reflect all four conflict types
- [x] `conflictPreview` is memoized on `[rawStages, layout, selection]` (keyed on the underlying data so memoization is effective)
- [x] Existing `conflict_preview.test.ts` updated/passing
- [x] `pnpm test` green (213/213; typecheck + prettier clean)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ikiHg4CxksuxQhkWbbpFt

---
_Generated by [Claude Code](https://claude.ai/code/session_015ikiHg4CxksuxQhkWbbpFt)_