### PR TITLE
Fix flaky test_schedule_all_matches by selecting stage item by id

### DIFF
--- a/backend/tests/integration_tests/api/scheduling_matches_test.py
+++ b/backend/tests/integration_tests/api/scheduling_matches_test.py
@@ -140,7 +140,13 @@ async def test_schedule_all_matches(
 
     assert response == SUCCESS_RESPONSE
 
-    stage_item = stages[0].stage_items[0]
+    # Look the stage item up by id rather than indexing into stages[0].stage_items[0]:
+    # get_full_tournament_details aggregates stage items with array_agg, whose order is
+    # not guaranteed, so a positional index intermittently returned the sibling 1-round
+    # single-elimination item instead of this 3-round round-robin one (issue #182).
+    stage_item = next(
+        item for stage in stages for item in stage.stage_items if item.id == stage_item_1.id
+    )
     assert len(stage_item.rounds) == 3
     for round_ in stage_item.rounds:
         assert len(round_.matches) == 2


### PR DESCRIPTION
The test asserted against stages[0].stage_items[0], assuming a fixed
position. get_full_tournament_details collects stage items with
array_agg, whose ordering PostgreSQL does not guarantee (the inner
ORDER BY in the CTE is not preserved through the outer aggregate). The
test creates two sibling stage items in one stage -- a 3-round
round-robin ("Group A") and a 1-round single-elimination ("Bracket A").
When the aggregate occasionally returned them in a different order,
stage_items[0] was the 1-round item and the assertion failed with
1 == 3.

Look the stage item up by its id instead of by position, making the
assertion independent of aggregate ordering.

Fixes #182

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NGwuD65YFeFGFz319yq6uL