### PR TITLE
Honor referees_enabled in client-side conflict detection (#181)

### DIFF
--- a/frontend/src/components/modals/match_modal.tsx
+++ b/frontend/src/components/modals/match_modal.tsx
@@ -287,8 +287,9 @@ function MatchModalForm({
   // an optimistic move — instead of reading the backend-persisted columns.
   const marginMinutes = swrTournamentResponse.data?.data.margin_minutes ?? 0;
   const conflictFlags = useMemo(
-    () => computeConflictFlags(swrStagesResponse.data?.data ?? [], marginMinutes),
-    [swrStagesResponse.data?.data, marginMinutes]
+    () =>
+      computeConflictFlags(swrStagesResponse.data?.data ?? [], marginMinutes, { refereesEnabled }),
+    [swrStagesResponse.data?.data, marginMinutes, refereesEnabled]
   );
   const conflicts = conflictFlags.get(match.id);
 

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -996,8 +996,8 @@ export default function ScheduleGrid({
   // they update the instant a drag/swap repacks the grid — no server round-trip. The
   // backend still persists the conflict columns, but they are ignored here.
   const conflictFlags = useMemo(
-    () => computeConflictFlags(stages, layout.defaultBreakMinutes),
-    [stages, layout.defaultBreakMinutes]
+    () => computeConflictFlags(stages, layout.defaultBreakMinutes, { refereesEnabled }),
+    [stages, layout.defaultBreakMinutes, refereesEnabled]
   );
   const gridHeight = layout.totalMinutes * pxPerMinute;
   // On phones an anchored break popover can open off-screen, so the editor

--- a/frontend/src/logic/planning/conflict_preview.test.ts
+++ b/frontend/src/logic/planning/conflict_preview.test.ts
@@ -87,6 +87,7 @@ describe('computeConflictPreview', () => {
         match: { matchId: 1, courtId: 1, position: 0 },
       },
       tournamentStartTime: START,
+      refereesEnabled: true,
     });
 
     expect([...preview.insertionLines]).toContain(insertionLineKey(2, 0));
@@ -113,6 +114,7 @@ describe('computeConflictPreview', () => {
       layout,
       selection: { kind: 'tray-match-selected', matchId: 1 },
       tournamentStartTime: START,
+      refereesEnabled: true,
     });
 
     expect([...preview.insertionLines]).toContain(insertionLineKey(1, 0));
@@ -150,6 +152,7 @@ describe('computeConflictPreview', () => {
       layout,
       selection: { kind: 'tray-match-selected', matchId: 1 },
       tournamentStartTime: START,
+      refereesEnabled: true,
     });
 
     expect([...preview.insertionLines]).toContain(insertionLineKey(1, 0));
@@ -188,6 +191,7 @@ describe('computeConflictPreview', () => {
       layout,
       selection: { kind: 'tray-match-selected', matchId: 2 },
       tournamentStartTime: START,
+      refereesEnabled: true,
     });
 
     expect([...preview.insertionLines]).toContain(insertionLineKey(2, 0));
@@ -214,6 +218,7 @@ describe('computeConflictPreview', () => {
       layout,
       selection: { kind: 'tray-match-selected', matchId: 1 },
       tournamentStartTime: START,
+      refereesEnabled: true,
     });
 
     expect([...preview.swapTargets]).toContain(2);
@@ -247,6 +252,7 @@ describe('computeConflictPreview', () => {
         match: { matchId: 1, courtId: 1, position: 0 },
       },
       tournamentStartTime: START,
+      refereesEnabled: true,
     });
 
     expect([...preview.swapTargets]).toContain(2);
@@ -284,6 +290,7 @@ describe('computeConflictPreview', () => {
         match: { matchId: 1, courtId: 1, position: 0 },
       },
       tournamentStartTime: START,
+      refereesEnabled: true,
     });
 
     expect([...preview.swapTargets]).toContain(4);
@@ -318,6 +325,7 @@ describe('computeConflictPreview', () => {
         match: { matchId: 1, courtId: 1, position: 0 },
       },
       tournamentStartTime: START,
+      refereesEnabled: true,
     });
 
     expect([...preview.swapTargets]).toContain(2);
@@ -347,6 +355,7 @@ describe('computeConflictPreview', () => {
       layout,
       selection: { kind: 'tray-match-selected', matchId: 1 },
       tournamentStartTime: START,
+      refereesEnabled: true,
     });
 
     expect([...preview.swapTargets]).toContain(2);

--- a/frontend/src/logic/planning/conflict_preview.ts
+++ b/frontend/src/logic/planning/conflict_preview.ts
@@ -71,12 +71,13 @@ function actionsIntroduceConflict(
   baseline: Map<number, ConflictFlags>,
   defaultBreakMinutes: number,
   tournamentStartTime: string | Date,
+  refereesEnabled: boolean,
   actions: PlanningAction[]
 ): boolean {
   if (actions.length === 0) return false;
 
   const simulated = applyPlanningActions(stages, actions, tournamentStartTime, defaultBreakMinutes);
-  const postFlags = computeConflictFlags(simulated, defaultBreakMinutes);
+  const postFlags = computeConflictFlags(simulated, defaultBreakMinutes, { refereesEnabled });
 
   for (const [matchId, flags] of postFlags) {
     const before = baseline.get(matchId);
@@ -94,20 +95,29 @@ export function computeConflictPreview({
   layout,
   selection,
   tournamentStartTime,
+  refereesEnabled,
 }: {
   stages: ConflictStage[];
   layout: ScheduleGridLayout;
   selection: SelectionState;
   tournamentStartTime: string | Date;
+  refereesEnabled: boolean;
 }): ConflictPreview {
   if (getSelectedMatchId(selection) == null) return emptyPreview();
 
   const defaultBreakMinutes = layout.defaultBreakMinutes;
-  const baseline = computeConflictFlags(stages, defaultBreakMinutes);
+  const baseline = computeConflictFlags(stages, defaultBreakMinutes, { refereesEnabled });
   const preview = emptyPreview();
 
   const introducesConflict = (actions: PlanningAction[]): boolean =>
-    actionsIntroduceConflict(stages, baseline, defaultBreakMinutes, tournamentStartTime, actions);
+    actionsIntroduceConflict(
+      stages,
+      baseline,
+      defaultBreakMinutes,
+      tournamentStartTime,
+      refereesEnabled,
+      actions
+    );
 
   for (const { court, blocks } of layout.courts) {
     for (const line of computeInsertionLines(blocks)) {

--- a/frontend/src/logic/planning/conflicts.test.ts
+++ b/frontend/src/logic/planning/conflicts.test.ts
@@ -686,6 +686,156 @@ describe('computeConflictFlags — placeholder slot overlap', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Referees disabled (tournament.referees_enabled === false, issue #181)
+// ---------------------------------------------------------------------------
+
+describe('computeConflictFlags — referees disabled', () => {
+  it('does not flag a team that plays and referees overlapping matches', () => {
+    // Same fixture as the "team plays and referees" case above, which DOES flag when
+    // referees are enabled; with referees disabled the referee slot is not a resource.
+    const team20 = teamInput(-20);
+    const playingMatch = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: team20,
+      input2: teamInput(-21),
+    });
+    const refereeingMatch = makeMatch({
+      id: -21,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-22),
+      input2: teamInput(-23),
+      referee: teamInput(-20),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(playingMatch, refereeingMatch)], 0, {
+      refereesEnabled: false,
+    });
+
+    expect(flags.get(-21)!.referee_conflict).toBe(false);
+    expect(flags.get(-20)!.stage_item_input1_conflict).toBe(false);
+  });
+
+  it('does not flag a team refereeing two overlapping matches', () => {
+    const team20 = teamInput(-20);
+    const refMatch1 = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: teamInput(-21),
+      input2: teamInput(-22),
+      referee: team20,
+    });
+    const refMatch2 = makeMatch({
+      id: -21,
+      startMinutes: 30,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-23),
+      input2: teamInput(-24),
+      referee: teamInput(-20),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(refMatch1, refMatch2)], 0, {
+      refereesEnabled: false,
+    });
+
+    expect(flags.get(-20)!.referee_conflict).toBe(false);
+    expect(flags.get(-21)!.referee_conflict).toBe(false);
+  });
+
+  it('does not flag a placeholder slot refereeing two overlapping matches', () => {
+    // The slot-id (placeholder) referee pass must also be gated off.
+    const refMatch1 = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: teamInput(-20),
+      input2: teamInput(-21),
+      referee: tentativeInput(null, -30),
+    });
+    const refMatch2 = makeMatch({
+      id: -21,
+      startMinutes: 30,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-22),
+      input2: teamInput(-23),
+      referee: tentativeInput(null, -30),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(refMatch1, refMatch2)], 0, {
+      refereesEnabled: false,
+    });
+
+    expect(flags.get(-20)!.referee_conflict).toBe(false);
+    expect(flags.get(-21)!.referee_conflict).toBe(false);
+  });
+
+  it('still flags overlapping playing slots when referees are disabled', () => {
+    // Disabling referees must not suppress genuine team double-booking.
+    const team20 = teamInput(-20);
+    const match1 = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: team20,
+      input2: teamInput(-21),
+    });
+    const match2 = makeMatch({
+      id: -21,
+      startMinutes: 30,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-20),
+      input2: teamInput(-22),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0, {
+      refereesEnabled: false,
+    });
+
+    expect(flags.get(-20)!.stage_item_input1_conflict).toBe(true);
+    expect(flags.get(-21)!.stage_item_input1_conflict).toBe(true);
+  });
+
+  it('flags referee conflicts when refereesEnabled is true (explicit option)', () => {
+    const team20 = teamInput(-20);
+    const playingMatch = makeMatch({
+      id: -20,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -1,
+      input1: team20,
+      input2: teamInput(-21),
+    });
+    const refereeingMatch = makeMatch({
+      id: -21,
+      startMinutes: 0,
+      durationMinutes: 60,
+      courtId: -2,
+      input1: teamInput(-22),
+      input2: teamInput(-23),
+      referee: teamInput(-20),
+    });
+
+    const flags = computeConflictFlags([twoMatchStage(playingMatch, refereeingMatch)], 0, {
+      refereesEnabled: true,
+    });
+
+    expect(flags.get(-21)!.referee_conflict).toBe(true);
+    expect(flags.get(-20)!.stage_item_input1_conflict).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Round order conflicts
 // ---------------------------------------------------------------------------
 
@@ -774,7 +924,9 @@ describe('computeConflictFlags — matches of interest', () => {
       input2: teamInput(-4),
     });
 
-    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0, 'all');
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0, {
+      matchesOfInterest: 'all',
+    });
 
     expect(new Set(flags.keys())).toEqual(new Set([-1, -2]));
   });
@@ -793,7 +945,9 @@ describe('computeConflictFlags — matches of interest', () => {
       input2: teamInput(-4),
     });
 
-    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0, new Set([-1]));
+    const flags = computeConflictFlags([twoMatchStage(match1, match2)], 0, {
+      matchesOfInterest: new Set([-1]),
+    });
 
     expect(new Set(flags.keys())).toEqual(new Set([-1]));
     // The conflict is still detected using the full schedule, only the output is filtered.

--- a/frontend/src/logic/planning/conflicts.ts
+++ b/frontend/src/logic/planning/conflicts.ts
@@ -2,7 +2,7 @@
  * Client-side conflict engine: a faithful 1:1 port of the backend
  * `bracket/logic/planning/conflicts.py`.
  *
- * `computeConflictFlags(stages, defaultBreakMinutes, matchesOfInterest)` returns a
+ * `computeConflictFlags(stages, defaultBreakMinutes, options)` returns a
  * `Map<matchId, ConflictFlags>` covering every conflict type the backend persists:
  *
  *   - team double-booking (`stage_item_input{1,2}_conflict`), flagged two ways: a
@@ -521,7 +521,11 @@ function flagSlotOccupancy(occupancy: SlotOccupancy, flags: Map<number, Conflict
  * slots too — a slot that isn't yet resolved to a concrete team is still a resource
  * that cannot play and/or referee two overlapping matches.
  */
-function setSlotOverlapConflicts(stages: ConflictStage[], flags: Map<number, ConflictFlags>): void {
+function setSlotOverlapConflicts(
+  stages: ConflictStage[],
+  flags: Map<number, ConflictFlags>,
+  refereesEnabled: boolean
+): void {
   const occupanciesBySlot = new Map<number, SlotOccupancy[]>();
   for (const match of getAllMatches(stages)) {
     const start = startMillis(match);
@@ -531,8 +535,12 @@ function setSlotOverlapConflicts(stages: ConflictStage[], flags: Map<number, Con
     const slots: [number | null, 1 | 2 | null][] = [
       [match.stage_item_input1_id, 1],
       [match.stage_item_input2_id, 2],
-      [match.referee_stage_item_input_id, null],
     ];
+    // When referees are disabled for the tournament, the referee slot is not a conflict
+    // resource, so it is excluded from the overlap pass (matching the team-backed pass).
+    if (refereesEnabled) {
+      slots.push([match.referee_stage_item_input_id, null]);
+    }
     for (const [slotId, playingSide] of slots) {
       if (slotId == null) {
         continue;
@@ -612,17 +620,36 @@ function setRoundOrderConflicts(stages: ConflictStage[], flags: Map<number, Conf
   }
 }
 
+export interface ComputeConflictFlagsOptions {
+  /**
+   * Restrict the returned map to these match ids. Conflicts are relational, so they are
+   * always computed over the whole schedule; only the returned map is narrowed. Defaults
+   * to every match.
+   */
+  matchesOfInterest?: 'all' | ReadonlySet<number>;
+  /**
+   * Mirrors the tournament's `referees_enabled` toggle. When false, referee slots are not
+   * treated as a conflict resource: referee double-booking is skipped in both the
+   * team-backed pass (`setRefereeOverlapConflicts`) and the referee-slot pass
+   * (`setSlotOverlapConflicts`). Defaults to true.
+   */
+  refereesEnabled?: boolean;
+}
+
 export function computeConflictFlags(
   stages: ConflictStage[],
   defaultBreakMinutes: number,
-  matchesOfInterest: 'all' | ReadonlySet<number> = 'all'
+  options: ComputeConflictFlagsOptions = {}
 ): Map<number, ConflictFlags> {
+  const { matchesOfInterest = 'all', refereesEnabled = true } = options;
   const matches = getAllMatches(stages);
   const flags = new Map<number, ConflictFlags>(matches.map((match) => [match.id, emptyFlags()]));
 
   setTeamOverlapConflicts(stages, flags);
-  setRefereeOverlapConflicts(stages, flags);
-  setSlotOverlapConflicts(stages, flags);
+  if (refereesEnabled) {
+    setRefereeOverlapConflicts(stages, flags);
+  }
+  setSlotOverlapConflicts(stages, flags, refereesEnabled);
   setWinnerOfPrecedenceConflicts(matches, flags);
   setCrossStagePrecedenceConflicts(stages, flags);
   setCrossStageFeederPrecedenceConflicts(stages, flags);

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -274,6 +274,7 @@ export default function SchedulePage() {
       layout: previewLayout,
       selection: planner.selection,
       tournamentStartTime: tournamentValue.start_time,
+      refereesEnabled: tournamentValue.referees_enabled,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [


### PR DESCRIPTION
Thread the tournament's referees_enabled flag into the shared conflict
engine. computeConflictFlags now takes an options object with a
refereesEnabled flag (default true); when false it skips referee
double-booking detection in both the team-backed pass
(setRefereeOverlapConflicts) and the referee-slot pass
(setSlotOverlapConflicts), so referee slots are not treated as a
conflict resource.

The flag is passed through at the three call sites: the planner preview
(conflict_preview.ts / schedule.tsx), the grid conflict icons
(schedule_grid.tsx), and the match modal (match_modal.tsx).

This mirrors the backend scheduler, which only assigns referee slots when
referees_enabled is true, so disabled tournaments never populate
referee_stage_item_input_id in the first place.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016RtZ1twjnbbiZRZYdb1wfL