### PR TITLE
Auto-resolve Swiss round 1 when teams are assigned in an active stage

### DIFF
--- a/backend/bracket/logic/scheduling/handle_stage_activation.py
+++ b/backend/bracket/logic/scheduling/handle_stage_activation.py
@@ -205,6 +205,38 @@ async def _resolve_round_1_for_swiss_stage_item(
     )
 
 
+async def try_resolve_first_swiss_round_in_active_stage(
+    tournament_id: TournamentId,
+    stage_item: StageItemWithRounds,
+) -> None:
+    """Resolve round 1 of a Swiss stage item without waiting for stage activation.
+
+    Round 1 of a Swiss stage item is normally resolved when its stage is activated. A Swiss
+    stage item created inside an already-active stage would never get that hook again, so this
+    resolves round 1 as soon as every input has a concrete team assigned. It is a no-op unless
+    round 1 is still a placeholder, which keeps it safe to call repeatedly (e.g. once per team
+    assignment). Callers must only invoke this for stage items in an active stage.
+
+    Only round 1 is pre-resolved today; later rounds are resolved sequentially as matches
+    complete. If we ever want to pre-resolve more than one round up front, this is the place to
+    extend (the skeleton already defines slot pairings for every round).
+    """
+    if stage_item.type is not StageType.SWISS:
+        return
+
+    # All inputs must reference concrete teams before we can pair round 1.
+    if not stage_item.inputs or not all(
+        isinstance(input_, StageItemInputFinal) for input_ in stage_item.inputs
+    ):
+        return
+
+    first_round = min(stage_item.rounds, key=lambda round_: round_.id, default=None)
+    if first_round is None or first_round.lifecycle_state is not RoundLifecycleState.PLACEHOLDER:
+        return
+
+    await _resolve_round_1_for_swiss_stage_item(tournament_id, stage_item)
+
+
 async def update_matches_in_activated_stage(tournament_id: TournamentId, stage_id: StageId) -> None:
     """
     Sets the team_id for stage item inputs of the newly activated stage.

--- a/backend/bracket/logic/scheduling/handle_stage_activation.py
+++ b/backend/bracket/logic/scheduling/handle_stage_activation.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException
 from pydantic import BaseModel
 from starlette import status
 
+from bracket.database import database
 from bracket.logic.ranking.calculation import (
     determine_team_ranking_for_stage_item,
 )
@@ -31,6 +32,7 @@ from bracket.sql.stage_item_inputs import (
     get_stage_item_input_by_id,
     sql_set_team_id_for_stage_item_input,
 )
+from bracket.sql.stage_items import get_stage_item
 from bracket.sql.stages import get_full_tournament_details
 from bracket.utils.id_types import (
     StageId,
@@ -207,7 +209,7 @@ async def _resolve_round_1_for_swiss_stage_item(
 
 async def try_resolve_first_swiss_round_in_active_stage(
     tournament_id: TournamentId,
-    stage_item: StageItemWithRounds,
+    stage_item_id: StageItemId,
 ) -> None:
     """Resolve round 1 of a Swiss stage item without waiting for stage activation.
 
@@ -217,24 +219,39 @@ async def try_resolve_first_swiss_round_in_active_stage(
     round 1 is still a placeholder, which keeps it safe to call repeatedly (e.g. once per team
     assignment). Callers must only invoke this for stage items in an active stage.
 
+    The whole check-and-resolve runs under a transaction-scoped advisory lock keyed on the
+    stage item, so concurrent team assignments (e.g. the parallel "auto-assign teams" feature)
+    serialize: the first caller resolves round 1, the rest observe it is no longer a placeholder
+    and return. This prevents two callers from interleaving their slot writes.
+
     Only round 1 is pre-resolved today; later rounds are resolved sequentially as matches
     complete. If we ever want to pre-resolve more than one round up front, this is the place to
     extend (the skeleton already defines slot pairings for every round).
     """
-    if stage_item.type is not StageType.SWISS:
-        return
+    async with database.transaction():
+        await database.execute(
+            query="SELECT pg_advisory_xact_lock(:lock_key)",
+            values={"lock_key": int(stage_item_id)},
+        )
 
-    # All inputs must reference concrete teams before we can pair round 1.
-    if not stage_item.inputs or not all(
-        isinstance(input_, StageItemInputFinal) for input_ in stage_item.inputs
-    ):
-        return
+        stage_item = await get_stage_item(tournament_id, stage_item_id)
+        if stage_item.type is not StageType.SWISS:
+            return
 
-    first_round = min(stage_item.rounds, key=lambda round_: round_.id, default=None)
-    if first_round is None or first_round.lifecycle_state is not RoundLifecycleState.PLACEHOLDER:
-        return
+        # All inputs must reference concrete teams before we can pair round 1.
+        if not stage_item.inputs or not all(
+            isinstance(input_, StageItemInputFinal) for input_ in stage_item.inputs
+        ):
+            return
 
-    await _resolve_round_1_for_swiss_stage_item(tournament_id, stage_item)
+        first_round = min(stage_item.rounds, key=lambda round_: round_.id, default=None)
+        if (
+            first_round is None
+            or first_round.lifecycle_state is not RoundLifecycleState.PLACEHOLDER
+        ):
+            return
+
+        await _resolve_round_1_for_swiss_stage_item(tournament_id, stage_item)
 
 
 async def update_matches_in_activated_stage(tournament_id: TournamentId, stage_id: StageId) -> None:

--- a/backend/bracket/routes/stage_item_inputs.py
+++ b/backend/bracket/routes/stage_item_inputs.py
@@ -21,7 +21,6 @@ from bracket.routes.auth import (
 from bracket.routes.models import SuccessResponse
 from bracket.routes.util import disallow_archived_tournament, stage_item_dependency
 from bracket.sql.stage_item_inputs import get_stage_item_input_by_id
-from bracket.sql.stage_items import get_stage_item
 from bracket.sql.stages import get_full_tournament_details
 from bracket.sql.teams import get_team_by_id
 from bracket.utils.errors import (
@@ -135,7 +134,6 @@ async def update_stage_item_input(
     # A Swiss stage item added to an already-active stage misses the stage-activation hook that
     # resolves round 1, so resolve it here once all of its teams have been assigned.
     if target_stage.is_active:
-        updated_stage_item = await get_stage_item(tournament_id, stage_item_id)
-        await try_resolve_first_swiss_round_in_active_stage(tournament_id, updated_stage_item)
+        await try_resolve_first_swiss_round_in_active_stage(tournament_id, stage_item_id)
 
     return SuccessResponse()

--- a/backend/bracket/routes/stage_item_inputs.py
+++ b/backend/bracket/routes/stage_item_inputs.py
@@ -3,6 +3,9 @@ from starlette import status
 
 from bracket.config import config
 from bracket.database import database
+from bracket.logic.scheduling.handle_stage_activation import (
+    try_resolve_first_swiss_round_in_active_stage,
+)
 from bracket.models.db.stage_item_inputs import (
     StageItemInput,
     StageItemInputUpdateBody,
@@ -18,6 +21,7 @@ from bracket.routes.auth import (
 from bracket.routes.models import SuccessResponse
 from bracket.routes.util import disallow_archived_tournament, stage_item_dependency
 from bracket.sql.stage_item_inputs import get_stage_item_input_by_id
+from bracket.sql.stage_items import get_stage_item
 from bracket.sql.stages import get_full_tournament_details
 from bracket.sql.teams import get_team_by_id
 from bracket.utils.errors import (
@@ -127,4 +131,11 @@ async def update_stage_item_input(
                 else None,
             },
         )
+
+    # A Swiss stage item added to an already-active stage misses the stage-activation hook that
+    # resolves round 1, so resolve it here once all of its teams have been assigned.
+    if target_stage.is_active:
+        updated_stage_item = await get_stage_item(tournament_id, stage_item_id)
+        await try_resolve_first_swiss_round_in_active_stage(tournament_id, updated_stage_item)
+
     return SuccessResponse()

--- a/backend/tests/integration_tests/api/test_swiss_active_stage_resolution.py
+++ b/backend/tests/integration_tests/api/test_swiss_active_stage_resolution.py
@@ -1,6 +1,8 @@
 """Integration test: a Swiss stage item created inside an already-active stage resolves round 1
 once all of its teams are assigned, without needing the stage to be (re)activated."""
 
+import asyncio
+
 import pytest
 
 from bracket.models.db.round import RoundLifecycleState
@@ -110,6 +112,90 @@ async def test_swiss_round1_resolves_when_assigned_in_active_stage(
                 assert match.stage_item_input2_id is not None
             for round_ in rounds_sorted[1:]:
                 assert round_.lifecycle_state == RoundLifecycleState.PLACEHOLDER
+        finally:
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_swiss_round1_resolves_with_parallel_auto_assign(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """The frontend "auto-assign teams" feature fires all input assignments in parallel; round 1
+    must still resolve exactly once, with every slot filled by a distinct team."""
+    tournament_id = auth_context.tournament.id
+
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id, "is_active": True})
+        ) as stage_inserted,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t1,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t3,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t4,
+    ):
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                "stage_items",
+                auth_context,
+                json={
+                    "type": StageType.SWISS.value,
+                    "team_count": 4,
+                    "stage_id": stage_inserted.id,
+                    "games_per_player": 2,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        stages_in_tournament = await get_full_tournament_details(tournament_id)
+        stage_item = next(
+            si
+            for stage in stages_in_tournament
+            if stage.id == stage_inserted.id
+            for si in stage.stage_items
+        )
+
+        try:
+            inputs_sorted = sorted(stage_item.inputs, key=lambda input_: input_.slot)
+            teams = [t1, t2, t3, t4]
+
+            # Fire every assignment concurrently, mirroring the frontend's Promise.all auto-assign.
+            results = await asyncio.gather(
+                *[
+                    send_tournament_request(
+                        HTTPMethod.PUT,
+                        f"stage_items/{stage_item.id}/inputs/{input_.id}",
+                        auth_context,
+                        json={"team_id": team.id},
+                    )
+                    for input_, team in zip(inputs_sorted, teams)
+                ]
+            )
+            assert all(result == SUCCESS_RESPONSE for result in results)
+
+            stages_in_tournament = await get_full_tournament_details(tournament_id)
+            stage_item = next(
+                si
+                for stage in stages_in_tournament
+                if stage.id == stage_inserted.id
+                for si in stage.stage_items
+            )
+            first_round = min(stage_item.rounds, key=lambda round_: round_.id)
+            assert first_round.lifecycle_state == RoundLifecycleState.RESOLVED
+
+            assigned_input_ids = [
+                input_id
+                for match in first_round.matches
+                for input_id in (match.stage_item_input1_id, match.stage_item_input2_id)
+            ]
+            # Every playing slot is filled and no team is double-booked across matches.
+            assert all(input_id is not None for input_id in assigned_input_ids)
+            assert len(set(assigned_input_ids)) == 4
         finally:
             await assert_row_count_and_clear(matches, 0)
             await assert_row_count_and_clear(rounds, 0)

--- a/backend/tests/integration_tests/api/test_swiss_active_stage_resolution.py
+++ b/backend/tests/integration_tests/api/test_swiss_active_stage_resolution.py
@@ -1,0 +1,118 @@
+"""Integration test: a Swiss stage item created inside an already-active stage resolves round 1
+once all of its teams are assigned, without needing the stage to be (re)activated."""
+
+import pytest
+
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.stage_item import StageType
+from bracket.schema import matches, rounds, stage_item_inputs, stage_items, stages
+from bracket.sql.stages import get_full_tournament_details
+from bracket.utils.dummy_records import DUMMY_STAGE1, DUMMY_TEAM1
+from bracket.utils.http import HTTPMethod
+from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
+from tests.integration_tests.models import AuthContext
+from tests.integration_tests.sql import (
+    assert_row_count_and_clear,
+    inserted_stage,
+    inserted_team,
+)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_swiss_round1_resolves_when_assigned_in_active_stage(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Assigning all teams to a Swiss stage item in an active stage auto-resolves round 1."""
+    tournament_id = auth_context.tournament.id
+
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id, "is_active": True})
+        ) as stage_inserted,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t1,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t3,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t4,
+    ):
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                "stage_items",
+                auth_context,
+                json={
+                    "type": StageType.SWISS.value,
+                    "team_count": 4,
+                    "stage_id": stage_inserted.id,
+                    "games_per_player": 2,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        stages_in_tournament = await get_full_tournament_details(tournament_id)
+        stage_item = next(
+            si
+            for stage in stages_in_tournament
+            if stage.id == stage_inserted.id
+            for si in stage.stage_items
+        )
+
+        try:
+            inputs_sorted = sorted(stage_item.inputs, key=lambda input_: input_.slot)
+            teams = [t1, t2, t3, t4]
+
+            # Assign all but the last team; round 1 must stay a placeholder until complete.
+            for input_, team in zip(inputs_sorted[:-1], teams[:-1]):
+                assert (
+                    await send_tournament_request(
+                        HTTPMethod.PUT,
+                        f"stage_items/{stage_item.id}/inputs/{input_.id}",
+                        auth_context,
+                        json={"team_id": team.id},
+                    )
+                    == SUCCESS_RESPONSE
+                )
+
+            stages_in_tournament = await get_full_tournament_details(tournament_id)
+            stage_item = next(
+                si
+                for stage in stages_in_tournament
+                if stage.id == stage_inserted.id
+                for si in stage.stage_items
+            )
+            first_round = min(stage_item.rounds, key=lambda round_: round_.id)
+            assert first_round.lifecycle_state == RoundLifecycleState.PLACEHOLDER
+
+            # Assign the final team — this completes the inputs and resolves round 1.
+            assert (
+                await send_tournament_request(
+                    HTTPMethod.PUT,
+                    f"stage_items/{stage_item.id}/inputs/{inputs_sorted[-1].id}",
+                    auth_context,
+                    json={"team_id": teams[-1].id},
+                )
+                == SUCCESS_RESPONSE
+            )
+
+            stages_in_tournament = await get_full_tournament_details(tournament_id)
+            stage_item = next(
+                si
+                for stage in stages_in_tournament
+                if stage.id == stage_inserted.id
+                for si in stage.stage_items
+            )
+            rounds_sorted = sorted(stage_item.rounds, key=lambda round_: round_.id)
+
+            # Round 1 is resolved with concrete teams; later rounds stay placeholders.
+            assert rounds_sorted[0].lifecycle_state == RoundLifecycleState.RESOLVED
+            for match in rounds_sorted[0].matches:
+                assert match.stage_item_input1_id is not None
+                assert match.stage_item_input2_id is not None
+            for round_ in rounds_sorted[1:]:
+                assert round_.lifecycle_state == RoundLifecycleState.PLACEHOLDER
+        finally:
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)


### PR DESCRIPTION
A Swiss stage item's first round is normally resolved (placeholder slots
filled with concrete teams) when its stage is activated. A Swiss stage
item created inside an already-active stage never gets that hook again, so
its first round stayed a placeholder with no way to resolve it.

Resolve round 1 as soon as every input of a Swiss stage item in an active
stage has a concrete team assigned, mirroring what stage activation does.
The resolution is a no-op unless round 1 is still a placeholder, so it is
safe to call once per team assignment.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01URQyvmGs8nVMiESB8E4nxD