### PR TITLE
Fix Swiss planning: stable round/match ordering and round-1 resolution on slot-fill

### DIFF
--- a/backend/bracket/logic/scheduling/handle_stage_activation.py
+++ b/backend/bracket/logic/scheduling/handle_stage_activation.py
@@ -211,17 +211,17 @@ async def _resolve_round_1_for_swiss_stage_item(
     )
 
 
-async def try_resolve_first_swiss_round_in_active_stage(
+async def try_resolve_first_swiss_round_when_inputs_filled(
     tournament_id: TournamentId,
     stage_item_id: StageItemId,
 ) -> None:
-    """Resolve round 1 of a Swiss stage item without waiting for stage activation.
+    """Resolve round 1 of a Swiss stage item as soon as all of its slots are filled.
 
-    Round 1 of a Swiss stage item is normally resolved when its stage is activated. A Swiss
-    stage item created inside an already-active stage would never get that hook again, so this
-    resolves round 1 as soon as every input has a concrete team assigned. It is a no-op unless
-    round 1 is still a placeholder, which keeps it safe to call repeatedly (e.g. once per team
-    assignment). Callers must only invoke this for stage items in an active stage.
+    Round 1 is resolved once every input has a concrete team assigned — it does not wait for
+    the stage to be activated. So a resolved round 1 shows its real matchups (not TBD) even in a
+    stage that has not started yet. It is a no-op unless round 1 is still a placeholder and every
+    input is concrete, which keeps it safe to call repeatedly (e.g. once per team assignment) and
+    on stage items whose inputs are still tentative (those resolve on stage activation instead).
 
     The whole check-and-resolve runs under a transaction-scoped advisory lock keyed on the
     stage item, so concurrent team assignments (e.g. the parallel "auto-assign teams" feature)

--- a/backend/bracket/logic/scheduling/handle_stage_activation.py
+++ b/backend/bracket/logic/scheduling/handle_stage_activation.py
@@ -163,12 +163,16 @@ async def _resolve_round_1_for_swiss_stage_item(
     stage_item: StageItemWithRounds,
 ) -> None:
     """Fill in concrete team assignments for round 1 of a Swiss stage item."""
-    placeholder_round = next(
-        (r for r in stage_item.rounds if r.lifecycle_state == RoundLifecycleState.PLACEHOLDER),
-        None,
-    )
-    if placeholder_round is None:
+    # Round 1 is the lowest-id round. Resolve that specific round rather than the first
+    # placeholder in iteration order: the rounds can arrive in any order, so picking the first
+    # placeholder could resolve a later round (leaving the real round 1 a placeholder that shows
+    # TBD), and — once round 1 is resolved — could even mistake round 2 for round 1 and pair it
+    # with round-1 logic. If the first round is already resolved, there is nothing to do here.
+    first_round = min(stage_item.rounds, key=lambda round_: round_.id, default=None)
+    if first_round is None or first_round.lifecycle_state is not RoundLifecycleState.PLACEHOLDER:
         return
+
+    placeholder_round = first_round
 
     inputs = [i for i in stage_item.inputs if isinstance(i, StageItemInputFinal) and i.team.active]
     if not inputs:

--- a/backend/bracket/models/db/util.py
+++ b/backend/bracket/models/db/util.py
@@ -22,6 +22,16 @@ class RoundWithMatches(Round):
             return []
         return values
 
+    @field_validator("matches", mode="after")
+    @staticmethod
+    def sort_matches_by_id(
+        values: list[MatchWithDetailsDefinitive | MatchWithDetails],
+    ) -> list[MatchWithDetailsDefinitive | MatchWithDetails]:
+        # Guarantee a stable, deterministic match order (by id, i.e. creation order) regardless of
+        # how the database happened to aggregate them. The SQL already orders these, but this keeps
+        # the contract from silently regressing if that query is ever changed.
+        return sorted(values, key=lambda match: match.id)
+
 
 class StageItemWithRounds(StageItem):
     rounds: list[RoundWithMatches]
@@ -45,6 +55,15 @@ class StageItemWithRounds(StageItem):
         if values is None:
             return []
         return [value for value in values if value is not None]
+
+    @field_validator("rounds", mode="after")
+    @staticmethod
+    def sort_rounds_by_id(values: list[RoundWithMatches]) -> list[RoundWithMatches]:
+        # Guarantee a stable, deterministic round order (by id, i.e. round 1, 2, 3 …) regardless of
+        # how the database aggregated them. The SQL already orders these, but this keeps the
+        # contract from silently regressing if that query is ever changed, and ensures round-1
+        # logic (e.g. Swiss resolution) always sees the real round 1 first.
+        return sorted(values, key=lambda round_: round_.id)
 
 
 class StageWithStageItems(Stage):

--- a/backend/bracket/routes/stage_item_inputs.py
+++ b/backend/bracket/routes/stage_item_inputs.py
@@ -4,7 +4,7 @@ from starlette import status
 from bracket.config import config
 from bracket.database import database
 from bracket.logic.scheduling.handle_stage_activation import (
-    try_resolve_first_swiss_round_in_active_stage,
+    try_resolve_first_swiss_round_when_inputs_filled,
 )
 from bracket.models.db.stage_item_inputs import (
     StageItemInput,
@@ -131,9 +131,9 @@ async def update_stage_item_input(
             },
         )
 
-    # A Swiss stage item added to an already-active stage misses the stage-activation hook that
-    # resolves round 1, so resolve it here once all of its teams have been assigned.
-    if target_stage.is_active:
-        await try_resolve_first_swiss_round_in_active_stage(tournament_id, stage_item_id)
+    # Resolve round 1 of a Swiss stage item as soon as all of its slots are filled, regardless of
+    # whether the stage is active, so a resolved round 1 shows real matchups instead of TBD. It is
+    # a no-op while any input is still tentative (those resolve on stage activation instead).
+    await try_resolve_first_swiss_round_when_inputs_filled(tournament_id, stage_item_id)
 
     return SuccessResponse()

--- a/backend/bracket/sql/stages.py
+++ b/backend/bracket/sql/stages.py
@@ -55,7 +55,7 @@ async def get_full_tournament_details(
         ), rounds_with_matches AS (
             SELECT DISTINCT ON (rounds.id)
                 rounds.*,
-                to_json(array_agg(m.*)) AS matches
+                to_json(array_agg(m.* ORDER BY m.id)) AS matches
             FROM rounds
             LEFT JOIN matches_with_inputs m on m.round_id = rounds.id
             LEFT JOIN stage_items si on rounds.stage_item_id = si.id
@@ -66,7 +66,7 @@ async def get_full_tournament_details(
         ), stage_items_with_rounds AS (
             SELECT DISTINCT ON (stage_items.id)
                 stage_items.*,
-                to_json(array_agg(r.*)) AS rounds
+                to_json(array_agg(r.* ORDER BY r.id)) AS rounds
             FROM stage_items
             JOIN stages st on stage_items.stage_id = st.id
             LEFT JOIN rounds_with_matches r on r.stage_item_id = stage_items.id
@@ -76,7 +76,7 @@ async def get_full_tournament_details(
         ), stage_items_with_inputs AS (
             SELECT DISTINCT ON (stage_items.id)
                 stage_items.id,
-                to_json(array_agg(sii)) AS inputs
+                to_json(array_agg(sii ORDER BY sii.slot)) AS inputs
             FROM stage_items
             LEFT JOIN inputs_with_teams sii ON stage_items.id = sii.stage_item_id
             WHERE sii.tournament_id = :tournament_id
@@ -90,7 +90,7 @@ async def get_full_tournament_details(
             LEFT JOIN stage_items_with_inputs ON stage_items_with_inputs.id = stage_items.id
             ORDER BY stage_items.name
         )
-        SELECT stages.*, to_json(array_agg(r.*)) AS stage_items
+        SELECT stages.*, to_json(array_agg(r.* ORDER BY r.name)) AS stage_items
         FROM stages
         LEFT JOIN stage_items_with_rounds_and_inputs r on stages.id = r.stage_id
         {stage_item_filter_join}

--- a/backend/tests/integration_tests/api/test_swiss_round_ordering.py
+++ b/backend/tests/integration_tests/api/test_swiss_round_ordering.py
@@ -1,0 +1,220 @@
+"""Regression tests for two Swiss planning bugs that share a single root cause: the
+`array_agg(...)` calls in ``get_full_tournament_details`` had no ``ORDER BY``, so Postgres
+returned rounds and matches in physical heap order instead of id order.
+
+After tuples are deleted and their heap slots reused (which autovacuum does routinely once a
+tournament has been rescheduled / rebuilt a few times), that heap order diverges from id order:
+
+1. The planning page renders rounds/matches in the order the API returns them, so they would
+   suddenly flip into a scrambled (e.g. reversed) order on a background refetch.
+2. ``_resolve_round_1_for_swiss_stage_item`` resolved whichever placeholder round happened to be
+   first in that order rather than round 1, leaving the real round 1 a placeholder that shows TBD.
+"""
+
+import pytest
+from heliclockter import datetime_utc
+
+from bracket.database import database
+from bracket.logic.scheduling.handle_stage_activation import (
+    _resolve_round_1_for_swiss_stage_item,
+)
+from bracket.models.db.match import Match, MatchInsertable
+from bracket.models.db.round import RoundInsertable, RoundLifecycleState
+from bracket.models.db.stage_item import StageType
+from bracket.models.db.stage_item_inputs import StageItemInputFinal
+from bracket.schema import matches, rounds, stage_item_inputs, stage_items, stages
+from bracket.sql.rounds import sql_create_round
+from bracket.sql.stages import get_full_tournament_details
+from bracket.utils.db import insert_generic
+from bracket.utils.dummy_records import DUMMY_STAGE1, DUMMY_TEAM1
+from bracket.utils.http import HTTPMethod
+from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
+from tests.integration_tests.models import AuthContext
+from tests.integration_tests.sql import (
+    assert_row_count_and_clear,
+    inserted_stage,
+    inserted_team,
+)
+
+
+async def _get_swiss_stage_item(tournament_id, stage_id):  # type: ignore[no-untyped-def]
+    stages_in_tournament = await get_full_tournament_details(tournament_id)
+    return next(
+        si for stage in stages_in_tournament if stage.id == stage_id for si in stage.stage_items
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_rounds_and_matches_returned_in_id_order_after_heap_reuse(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """get_full_tournament_details must return rounds (and matches within a round) sorted by id,
+    even after deleted heap slots have been reused so heap order no longer matches id order."""
+    tournament_id = auth_context.tournament.id
+
+    async with inserted_stage(
+        DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id, "is_active": False})
+    ) as stage_inserted:
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                "stage_items",
+                auth_context,
+                json={
+                    "type": StageType.SWISS.value,
+                    "team_count": 4,
+                    "stage_id": stage_inserted.id,
+                    "games_per_player": 3,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        try:
+            stage_item = await _get_swiss_stage_item(tournament_id, stage_inserted.id)
+            rounds_sorted = sorted(stage_item.rounds, key=lambda round_: round_.id)
+            assert len(rounds_sorted) == 3
+
+            # Scramble the heap order of rounds: drop the lowest-id round, free its slot with a
+            # VACUUM, then create a fresh round that reuses that slot. The new round has the
+            # highest id but an earlier physical position than the surviving rounds.
+            first_round = rounds_sorted[0]
+            await database.execute(matches.delete().where(matches.c.round_id == first_round.id))
+            await database.execute(rounds.delete().where(rounds.c.id == first_round.id))
+            await database.execute("VACUUM rounds")
+            new_round_id = await sql_create_round(
+                RoundInsertable(
+                    created=datetime_utc.now(),
+                    stage_item_id=stage_item.id,
+                    name="Round 99",
+                    lifecycle_state=RoundLifecycleState.PLACEHOLDER,
+                    is_pinned=False,
+                )
+            )
+
+            # Scramble the heap order of matches: delete every other match across the surviving
+            # rounds, free those slots with a VACUUM, then reinsert fresh (higher-id) matches that
+            # land in the freed slots. Their physical order now diverges from id order, so an
+            # unordered array_agg returns them scrambled (e.g. {18,17,9,11}).
+            target_rounds = [rounds_sorted[1].id, rounds_sorted[2].id, new_round_id]
+            existing_match_ids = sorted(
+                match.id for round_ in rounds_sorted[1:] for match in round_.matches
+            )
+            await database.execute(
+                matches.delete().where(matches.c.id.in_(existing_match_ids[::2]))
+            )
+            await database.execute("VACUUM matches")
+            for round_id in target_rounds:
+                for _ in range(2):
+                    await insert_generic(
+                        database,
+                        MatchInsertable(
+                            created=datetime_utc.now(),
+                            round_id=round_id,
+                            duration_minutes=10,
+                            stage_item_input1_score=0,
+                            stage_item_input2_score=0,
+                        ),
+                        matches,
+                        Match,
+                    )
+
+            stage_item = await _get_swiss_stage_item(tournament_id, stage_inserted.id)
+
+            round_ids = [round_.id for round_ in stage_item.rounds]
+            assert round_ids == sorted(round_ids), (
+                f"Rounds were not returned in id order: {round_ids}"
+            )
+            for round_ in stage_item.rounds:
+                match_ids = [match.id for match in round_.matches]
+                assert match_ids == sorted(match_ids), (
+                    f"Matches in round {round_.id} were not returned in id order: {match_ids}"
+                )
+        finally:
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_resolve_round_1_targets_lowest_id_round_regardless_of_order(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Resolving round 1 must resolve the lowest-id round (the real round 1), even when the
+    stage item's rounds are handed over in a different order — as the non-deterministic SQL
+    ordering used to do. Otherwise a later round gets resolved and round 1 stays a placeholder
+    that displays TBD."""
+    tournament_id = auth_context.tournament.id
+
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id, "is_active": False})
+        ) as stage_inserted,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t1,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t3,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t4,
+    ):
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                "stage_items",
+                auth_context,
+                json={
+                    "type": StageType.SWISS.value,
+                    "team_count": 4,
+                    "stage_id": stage_inserted.id,
+                    "games_per_player": 3,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        try:
+            stage_item = await _get_swiss_stage_item(tournament_id, stage_inserted.id)
+            inputs_sorted = sorted(stage_item.inputs, key=lambda input_: input_.slot)
+
+            # Assign every team. The stage is inactive, so this does not auto-resolve round 1;
+            # every round stays a placeholder with concrete (Final) inputs.
+            for input_, team in zip(inputs_sorted, [t1, t2, t3, t4]):
+                assert (
+                    await send_tournament_request(
+                        HTTPMethod.PUT,
+                        f"stage_items/{stage_item.id}/inputs/{input_.id}",
+                        auth_context,
+                        json={"team_id": team.id},
+                    )
+                    == SUCCESS_RESPONSE
+                )
+
+            stage_item = await _get_swiss_stage_item(tournament_id, stage_inserted.id)
+            assert all(isinstance(input_, StageItemInputFinal) for input_ in stage_item.inputs)
+            assert all(
+                round_.lifecycle_state == RoundLifecycleState.PLACEHOLDER
+                for round_ in stage_item.rounds
+            )
+            assert len(stage_item.rounds) >= 2
+
+            # Mimic the scrambled order the buggy SQL returned: hand the rounds over reversed,
+            # so the first placeholder in iteration order is NOT round 1.
+            scrambled = stage_item.model_copy(update={"rounds": list(reversed(stage_item.rounds))})
+            await _resolve_round_1_for_swiss_stage_item(tournament_id, scrambled)
+
+            stage_item = await _get_swiss_stage_item(tournament_id, stage_inserted.id)
+            rounds_sorted = sorted(stage_item.rounds, key=lambda round_: round_.id)
+
+            # The real round 1 (lowest id) is the one that gets resolved, with concrete inputs.
+            assert rounds_sorted[0].lifecycle_state == RoundLifecycleState.RESOLVED
+            for match in rounds_sorted[0].matches:
+                assert match.stage_item_input1_id is not None
+                assert match.stage_item_input2_id is not None
+            for round_ in rounds_sorted[1:]:
+                assert round_.lifecycle_state == RoundLifecycleState.PLACEHOLDER
+        finally:
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)

--- a/backend/tests/integration_tests/api/test_swiss_round_ordering.py
+++ b/backend/tests/integration_tests/api/test_swiss_round_ordering.py
@@ -139,6 +139,89 @@ async def test_rounds_and_matches_returned_in_id_order_after_heap_reuse(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_inactive_stage_resolves_round_1_when_all_slots_filled(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Round 1 of a Swiss stage item resolves as soon as all of its slots are filled — it does
+    not wait for the stage to be activated. So a resolved round 1 shows its real matchups instead
+    of TBD even in a not-yet-activated stage."""
+    tournament_id = auth_context.tournament.id
+
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id, "is_active": False})
+        ) as stage_inserted,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t1,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t3,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t4,
+    ):
+        assert (
+            await send_tournament_request(
+                HTTPMethod.POST,
+                "stage_items",
+                auth_context,
+                json={
+                    "type": StageType.SWISS.value,
+                    "team_count": 4,
+                    "stage_id": stage_inserted.id,
+                    "games_per_player": 3,
+                },
+            )
+            == SUCCESS_RESPONSE
+        )
+
+        try:
+            stage_item = await _get_swiss_stage_item(tournament_id, stage_inserted.id)
+            inputs_sorted = sorted(stage_item.inputs, key=lambda input_: input_.slot)
+            teams = [t1, t2, t3, t4]
+
+            # While a slot is still empty, round 1 stays a placeholder.
+            for input_, team in zip(inputs_sorted[:-1], teams[:-1]):
+                assert (
+                    await send_tournament_request(
+                        HTTPMethod.PUT,
+                        f"stage_items/{stage_item.id}/inputs/{input_.id}",
+                        auth_context,
+                        json={"team_id": team.id},
+                    )
+                    == SUCCESS_RESPONSE
+                )
+
+            stage_item = await _get_swiss_stage_item(tournament_id, stage_inserted.id)
+            first_round = min(stage_item.rounds, key=lambda round_: round_.id)
+            assert first_round.lifecycle_state == RoundLifecycleState.PLACEHOLDER
+
+            # Filling the last slot resolves round 1 — even though the stage is still inactive.
+            assert (
+                await send_tournament_request(
+                    HTTPMethod.PUT,
+                    f"stage_items/{stage_item.id}/inputs/{inputs_sorted[-1].id}",
+                    auth_context,
+                    json={"team_id": teams[-1].id},
+                )
+                == SUCCESS_RESPONSE
+            )
+
+            stage_item = await _get_swiss_stage_item(tournament_id, stage_inserted.id)
+            rounds_sorted = sorted(stage_item.rounds, key=lambda round_: round_.id)
+
+            # The real round 1 (lowest id) is resolved with concrete inputs; later rounds wait.
+            assert rounds_sorted[0].lifecycle_state == RoundLifecycleState.RESOLVED
+            for match in rounds_sorted[0].matches:
+                assert match.stage_item_input1_id is not None
+                assert match.stage_item_input2_id is not None
+            for round_ in rounds_sorted[1:]:
+                assert round_.lifecycle_state == RoundLifecycleState.PLACEHOLDER
+        finally:
+            await assert_row_count_and_clear(matches, 0)
+            await assert_row_count_and_clear(rounds, 0)
+            await assert_row_count_and_clear(stage_item_inputs, 0)
+            await assert_row_count_and_clear(stage_items, 0)
+            await assert_row_count_and_clear(stages, 0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_resolve_round_1_targets_lowest_id_round_regardless_of_order(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:
@@ -176,17 +259,14 @@ async def test_resolve_round_1_targets_lowest_id_round_regardless_of_order(
             stage_item = await _get_swiss_stage_item(tournament_id, stage_inserted.id)
             inputs_sorted = sorted(stage_item.inputs, key=lambda input_: input_.slot)
 
-            # Assign every team. The stage is inactive, so this does not auto-resolve round 1;
-            # every round stays a placeholder with concrete (Final) inputs.
+            # Assign every team directly in SQL so the route's auto-resolve does not fire: this
+            # leaves every round a placeholder with concrete (Final) inputs, which is the state in
+            # which round-1 resolution then has to pick the right round.
             for input_, team in zip(inputs_sorted, [t1, t2, t3, t4]):
-                assert (
-                    await send_tournament_request(
-                        HTTPMethod.PUT,
-                        f"stage_items/{stage_item.id}/inputs/{input_.id}",
-                        auth_context,
-                        json={"team_id": team.id},
-                    )
-                    == SUCCESS_RESPONSE
+                await database.execute(
+                    stage_item_inputs.update()
+                    .where(stage_item_inputs.c.id == input_.id)
+                    .values(team_id=team.id)
                 )
 
             stage_item = await _get_swiss_stage_item(tournament_id, stage_inserted.id)

--- a/backend/tests/unit_tests/test_round_match_ordering.py
+++ b/backend/tests/unit_tests/test_round_match_ordering.py
@@ -1,0 +1,50 @@
+"""Unit guarantee that rounds and matches always come out in a stable, deterministic id order.
+
+The database query orders these explicitly, but the model layer enforces the same contract as
+defense-in-depth: it cannot silently regress the way a hand-edited SQL ``array_agg`` can, and it
+keeps round-1 logic (Swiss resolution) always seeing the real round 1 first.
+"""
+
+from bracket.models.db.util import RoundWithMatches, StageItemWithRounds
+from bracket.utils.dummy_records import (
+    DUMMY_MATCH1,
+    DUMMY_ROUND1,
+    DUMMY_STAGE_ITEM1,
+)
+
+
+def _match_dict(match_id: int) -> dict[str, object]:
+    return {**DUMMY_MATCH1.model_dump(), "id": match_id}
+
+
+def _round_dict(round_id: int, match_ids: list[int]) -> dict[str, object]:
+    return {
+        **DUMMY_ROUND1.model_dump(),
+        "id": round_id,
+        "matches": [_match_dict(match_id) for match_id in match_ids],
+    }
+
+
+def test_matches_are_sorted_by_id() -> None:
+    round_ = RoundWithMatches.model_validate(_round_dict(1, [30, 10, 20]))
+    assert [match.id for match in round_.matches] == [10, 20, 30]
+
+
+def test_rounds_are_sorted_by_id_and_so_are_their_matches() -> None:
+    stage_item = StageItemWithRounds.model_validate(
+        {
+            **DUMMY_STAGE_ITEM1.model_dump(),
+            "id": 1,
+            "inputs": [],
+            "rounds": [
+                _round_dict(3, [102, 101]),
+                _round_dict(1, [2, 1]),
+                _round_dict(2, [50, 40]),
+            ],
+        }
+    )
+
+    assert [round_.id for round_ in stage_item.rounds] == [1, 2, 3]
+    for round_ in stage_item.rounds:
+        match_ids = [match.id for match in round_.matches]
+        assert match_ids == sorted(match_ids)


### PR DESCRIPTION
## Problem

Two bugs on the planning page for Swiss stage items, both rooted in non-deterministic ordering:

1. **Rounds/matches invert a few seconds after the page loads** and flip back on reload.
2. **Round 1 shows TBD** even after it is resolved / its slots are filled.

## Root cause

`get_full_tournament_details` (`sql/stages.py`) built its nested JSON with `array_agg(...)` calls that had **no `ORDER BY`**, so Postgres returned rounds, matches and inputs in *physical heap order*. Once deleted tuple slots get reused — which autovacuum does routinely after a tournament has been rescheduled/rebuilt — that order diverges from id order and flips between refetches. Reproduced directly: after a `VACUUM` reclaims freed slots, `array_agg` returns e.g. `[1, 6, 3, 7, 5]` instead of `[1, 3, 5, 6, 7]`.

This caused:
- **Bug 1** — the planning page rendered rounds/matches in whatever scrambled order the API returned.
- **Bug 2 (part)** — `_resolve_round_1_for_swiss_stage_item` resolved whichever placeholder round came first in that scrambled order rather than round 1, leaving the real round 1 a placeholder showing TBD.

Separately, the input route still gated round‑1 resolution behind `if target_stage.is_active`, so a not‑yet‑activated stage with every slot filled also showed TBD — even though PR #186 intended round 1 to resolve on slot‑fill.

## Changes

- **`sql/stages.py`** — explicit `ORDER BY` on every `array_agg` (matches/rounds by id, inputs by slot, stage items by name).
- **`handle_stage_activation.py`** — resolve the **lowest‑id round explicitly** and no‑op if it is already resolved, so a later round can never be mistaken for round 1.
- **`models/db/util.py`** — enforce id ordering of rounds and matches in the Pydantic models as defense‑in‑depth, so the contract can't silently regress if the query is edited later.
- **`routes/stage_item_inputs.py`** — drop the active‑stage gate so round 1 resolves whenever all slots are filled, regardless of activation. The helper is already a no‑op while any input is tentative (those resolve on activation), so non‑first stages are unaffected. Renamed `try_resolve_first_swiss_round_in_active_stage` → `try_resolve_first_swiss_round_when_inputs_filled`.

## Tests (red → green; full suite 389 passing, lint/format/mypy clean)

- Integration test reproduces real heap‑reuse disorder and asserts id ordering (verified red without the SQL fix).
- Unit test guards the model‑level ordering (verified red without the model sort).
- Test asserts round 1 resolves on slot‑fill in an inactive stage (verified red with the gate restored).
- Test asserts round‑1 resolution targets the lowest‑id round regardless of the order rounds are supplied in.

## Note

The round‑order **conflict flag** was not affected by this bug — `setRoundOrderConflicts` already sorts rounds by id, so it computes correctly regardless of the scrambled API order. The inversion was display‑only; `start_time`s were untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Huz9MutLzU7ZT9gaNTJmPE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Huz9MutLzU7ZT9gaNTJmPE)_