### PR TITLE
Show level name in default ranking badge

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -93,6 +93,7 @@
     "default_label": "Standard",
     "default_pause_duration_button": "Standard-Pausendauer",
     "default_ranking_badge": "Standard Rangliste",
+    "default_ranking_badge_with_level": "Level {{name}} Standard",
     "details_button": "Details",
     "delete_button": "Löschen",
     "delete_club_button": "Verein löschen",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -93,6 +93,7 @@
     "default_label": "Default",
     "default_pause_duration_button": "Default pause duration",
     "default_ranking_badge": "Default Ranking",
+    "default_ranking_badge_with_level": "Level {{name}} Default",
     "details_button": "Details",
     "delete_button": "Delete",
     "delete_club_button": "Delete Club",

--- a/frontend/src/pages/tournaments/[id]/rankings.tsx
+++ b/frontend/src/pages/tournaments/[id]/rankings.tsx
@@ -26,9 +26,14 @@ function RankingDeleteButton({
   swrRankingsResponse: SWRResponse<RankingsResponse>;
 }) {
   if (ranking.position === 0) {
+    const level = tournament.levels.find((l) => l.id === ranking.level_id);
     return (
       <Center ml="1rem" miw="10rem">
-        <Badge color="indigo">{t('default_ranking_badge')}</Badge>
+        <Badge color="indigo">
+          {level != null
+            ? t('default_ranking_badge_with_level', { name: level.name })
+            : t('default_ranking_badge')}
+        </Badge>
       </Center>
     );
   }


### PR DESCRIPTION
On the rankings page, the "Default Ranking" badge now displays the
associated level name, e.g. a level named "A" shows "Level A Default".
Falls back to the previous "Default Ranking" label when a ranking has no
associated level.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xuz77xdtiJW8sVcVLpPH9d