### PR TITLE
Implement SET_POINTS/SET_POINTS_WITH_MATCH_BONUS scoring types and set/point-diff tiebreakers

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_set_and_point_difference_to_stage_item_inputs.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_set_and_point_difference_to_stage_item_inputs.py
@@ -1,0 +1,32 @@
+"""Add set_difference and point_difference to stage_item_inputs
+
+Revision ID: a1b2c3d4e5f6
+Revises: f3a1b2c9d4e5
+Create Date: 2026-06-26 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str | None = "a1b2c3d4e5f6"
+down_revision: str | None = "f3a1b2c9d4e5"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "stage_item_inputs",
+        sa.Column("set_difference", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "stage_item_inputs",
+        sa.Column("point_difference", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("stage_item_inputs", "point_difference")
+    op.drop_column("stage_item_inputs", "set_difference")

--- a/backend/alembic/versions/b9d3e7f1a2c4_add_set_and_point_difference_to_stage_item_inputs.py
+++ b/backend/alembic/versions/b9d3e7f1a2c4_add_set_and_point_difference_to_stage_item_inputs.py
@@ -1,7 +1,7 @@
 """Add set_difference and point_difference to stage_item_inputs
 
-Revision ID: a1b2c3d4e5f6
-Revises: f3a1b2c9d4e5
+Revision ID: b9d3e7f1a2c4
+Revises: a7c2e9f1b3d8
 Create Date: 2026-06-26 00:00:00.000000
 
 """
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str | None = "a1b2c3d4e5f6"
-down_revision: str | None = "f3a1b2c9d4e5"
+revision: str | None = "b9d3e7f1a2c4"
+down_revision: str | None = "a7c2e9f1b3d8"
 branch_labels: str | None = None
 depends_on: str | None = None
 

--- a/backend/bracket/logic/ranking/calculation.py
+++ b/backend/bracket/logic/ranking/calculation.py
@@ -55,13 +55,13 @@ def set_statistics_for_stage_item_input(
         case StageType.ROUND_ROBIN | StageType.SINGLE_ELIMINATION:
             match ranking.scoring_type:
                 case ScoringType.MATCH_POINTS:
-                    assert ranking.match_points is not None
+                    mp = ranking.match_points
                     if has_won:
-                        stats[stage_item_input_id].points += ranking.match_points.win_points
+                        stats[stage_item_input_id].points += mp.win_points if mp else Decimal("1.0")
                     elif was_draw:
-                        stats[stage_item_input_id].points += ranking.match_points.draw_points
+                        stats[stage_item_input_id].points += mp.draw_points if mp else Decimal("0.5")
                     else:
-                        stats[stage_item_input_id].points += ranking.match_points.loss_points
+                        stats[stage_item_input_id].points += mp.loss_points if mp else Decimal("0.0")
 
                 case ScoringType.SET_POINTS:
                     stats[stage_item_input_id].points += Decimal(team_sets)

--- a/backend/bracket/logic/ranking/calculation.py
+++ b/backend/bracket/logic/ranking/calculation.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 from bracket.logic.ranking.statistics import START_ELO, TeamStatistics
 from bracket.models.db.match import MatchState, MatchWithDetailsDefinitive
-from bracket.models.db.ranking import Ranking
+from bracket.models.db.ranking import Ranking, ScoringType
 from bracket.models.db.stage_item import StageType
 from bracket.models.db.util import StageItemWithRounds
 from bracket.sql.rankings import get_ranking_for_stage_item
@@ -29,41 +29,69 @@ def set_statistics_for_stage_item_input(
     sets1 = match.sets_won_by_input1
     sets2 = match.sets_won_by_input2
     team_sets = sets1 if is_team1 else sets2
+    opp_sets = sets2 if is_team1 else sets1
     was_draw = sets1 == sets2
     has_won = not was_draw and team_sets == max(sets1, sets2)
 
+    completed_sets = [s for s in match.match_sets if s.state.value == "COMPLETED"]
+    if is_team1:
+        total_points_for = sum(s.stage_item_input1_score for s in completed_sets)
+        total_points_against = sum(s.stage_item_input2_score for s in completed_sets)
+    else:
+        total_points_for = sum(s.stage_item_input2_score for s in completed_sets)
+        total_points_against = sum(s.stage_item_input1_score for s in completed_sets)
+
+    stats[stage_item_input_id].set_difference += team_sets - opp_sets
+    stats[stage_item_input_id].point_difference += total_points_for - total_points_against
+
     if has_won:
         stats[stage_item_input_id].wins += 1
-        if ranking.match_points is not None:
-            swiss_score_diff = ranking.match_points.win_points
-        else:
-            # TODO: Issue 5 — implement set-points win logic
-            swiss_score_diff = Decimal("1.0")
     elif was_draw:
         stats[stage_item_input_id].draws += 1
-        if ranking.match_points is not None:
-            swiss_score_diff = ranking.match_points.draw_points
-        else:
-            # TODO: Issue 5 — implement set-points draw logic
-            swiss_score_diff = Decimal("0.5")
     else:
         stats[stage_item_input_id].losses += 1
-        if ranking.match_points is not None:
-            swiss_score_diff = ranking.match_points.loss_points
-        else:
-            # TODO: Issue 5 — implement set-points loss logic
-            swiss_score_diff = Decimal("0.0")
 
     match stage_item.type:
         case StageType.ROUND_ROBIN | StageType.SINGLE_ELIMINATION:
-            stats[stage_item_input_id].points += swiss_score_diff
+            match ranking.scoring_type:
+                case ScoringType.MATCH_POINTS:
+                    assert ranking.match_points is not None
+                    if has_won:
+                        stats[stage_item_input_id].points += ranking.match_points.win_points
+                    elif was_draw:
+                        stats[stage_item_input_id].points += ranking.match_points.draw_points
+                    else:
+                        stats[stage_item_input_id].points += ranking.match_points.loss_points
+
+                case ScoringType.SET_POINTS:
+                    stats[stage_item_input_id].points += Decimal(team_sets)
+
+                case ScoringType.SET_POINTS_WITH_MATCH_BONUS:
+                    stats[stage_item_input_id].points += Decimal(team_sets)
+                    if has_won:
+                        assert ranking.set_points_with_bonus is not None
+                        stats[
+                            stage_item_input_id
+                        ].points += ranking.set_points_with_bonus.match_bonus_points
 
         case StageType.SWISS:
+            # Swiss ELO uses match_points.win/draw/loss or standard 1.0/0.5/0.0 for set-based types
+            if ranking.match_points is not None:
+                if has_won:
+                    elo_score = ranking.match_points.win_points
+                elif was_draw:
+                    elo_score = ranking.match_points.draw_points
+                else:
+                    elo_score = ranking.match_points.loss_points
+            else:
+                elo_score = (
+                    Decimal("1.0") if has_won else Decimal("0.5") if was_draw else Decimal("0.0")
+                )
             rating_diff = (match.stage_item_input2.elo - match.stage_item_input1.elo) * (
                 1 if is_team1 else -1
             )
             expected_score = Decimal(1.0 / (1.0 + math.pow(10.0, rating_diff / D)))
-            stats[stage_item_input_id].points += int(K * (swiss_score_diff - expected_score))
+            stats[stage_item_input_id].points += int(K * (elo_score - expected_score))
 
         case _:
             raise ValueError(f"Unsupported stage type: {stage_item.type}")
@@ -105,7 +133,11 @@ def determine_team_ranking_for_stage_item(
     ranking: Ranking,
 ) -> list[tuple[StageItemInputId, TeamStatistics]]:
     team_ranking = determine_ranking_for_stage_item(stage_item, ranking)
-    return sorted(team_ranking.items(), key=lambda x: x[1].points, reverse=True)
+    return sorted(
+        team_ranking.items(),
+        key=lambda x: (x[1].points, x[1].set_difference, x[1].point_difference),
+        reverse=True,
+    )
 
 
 async def recalculate_ranking_for_stage_item(

--- a/backend/bracket/logic/ranking/statistics.py
+++ b/backend/bracket/logic/ranking/statistics.py
@@ -10,3 +10,5 @@ class TeamStatistics(BaseModel):
     draws: int = 0
     losses: int = 0
     points: Decimal = Decimal("0.00")
+    set_difference: int = 0
+    point_difference: int = 0

--- a/backend/bracket/models/db/stage_item_inputs.py
+++ b/backend/bracket/models/db/stage_item_inputs.py
@@ -21,6 +21,8 @@ class StageItemInputGeneric(BaseModel):
     wins: int = 0
     draws: int = 0
     losses: int = 0
+    set_difference: int = 0
+    point_difference: int = 0
 
     @property
     def elo(self) -> Decimal:

--- a/backend/bracket/schema.py
+++ b/backend/bracket/schema.py
@@ -138,6 +138,8 @@ stage_item_inputs = Table(
     Column("wins", Integer, nullable=False, server_default="0"),
     Column("draws", Integer, nullable=False, server_default="0"),
     Column("losses", Integer, nullable=False, server_default="0"),
+    Column("set_difference", Integer, nullable=False, server_default="0"),
+    Column("point_difference", Integer, nullable=False, server_default="0"),
     UniqueConstraint("stage_item_id", "team_id"),
     UniqueConstraint("stage_item_id", "winner_from_stage_item_id", "winner_position"),
 )

--- a/backend/bracket/sql/teams.py
+++ b/backend/bracket/sql/teams.py
@@ -108,7 +108,9 @@ async def update_team_stats(
             wins = :wins,
             draws = :draws,
             losses = :losses,
-            points = :points
+            points = :points,
+            set_difference = :set_difference,
+            point_difference = :point_difference
         WHERE stage_item_inputs.tournament_id = :tournament_id
         AND stage_item_inputs.id = :stage_item_input_id
         """
@@ -121,6 +123,8 @@ async def update_team_stats(
             "draws": team_statistics.draws,
             "losses": team_statistics.losses,
             "points": float(team_statistics.points),
+            "set_difference": team_statistics.set_difference,
+            "point_difference": team_statistics.point_difference,
         },
     )
 

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -2924,11 +2924,21 @@
             "title": "Losses",
             "type": "integer"
           },
+          "point_difference": {
+            "default": 0,
+            "title": "Point Difference",
+            "type": "integer"
+          },
           "points": {
             "default": "0.0",
             "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
             "title": "Points",
             "type": "string"
+          },
+          "set_difference": {
+            "default": 0,
+            "title": "Set Difference",
+            "type": "integer"
           },
           "slot": {
             "title": "Slot",
@@ -2972,6 +2982,8 @@
           "wins",
           "draws",
           "losses",
+          "set_difference",
+          "point_difference",
           "id",
           "slot",
           "tournament_id",
@@ -2999,11 +3011,21 @@
             "title": "Losses",
             "type": "integer"
           },
+          "point_difference": {
+            "default": 0,
+            "title": "Point Difference",
+            "type": "integer"
+          },
           "points": {
             "default": "0.0",
             "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
             "title": "Points",
             "type": "string"
+          },
+          "set_difference": {
+            "default": 0,
+            "title": "Set Difference",
+            "type": "integer"
           },
           "slot": {
             "title": "Slot",
@@ -3064,6 +3086,8 @@
           "wins",
           "draws",
           "losses",
+          "set_difference",
+          "point_difference",
           "id",
           "slot",
           "tournament_id",
@@ -3159,11 +3183,21 @@
             "title": "Losses",
             "type": "integer"
           },
+          "point_difference": {
+            "default": 0,
+            "title": "Point Difference",
+            "type": "integer"
+          },
           "points": {
             "default": "0.0",
             "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
             "title": "Points",
             "type": "string"
+          },
+          "set_difference": {
+            "default": 0,
+            "title": "Set Difference",
+            "type": "integer"
           },
           "slot": {
             "title": "Slot",
@@ -3208,6 +3242,8 @@
           "wins",
           "draws",
           "losses",
+          "set_difference",
+          "point_difference",
           "id",
           "slot",
           "tournament_id",

--- a/backend/tests/unit_tests/ranking_calculation_test.py
+++ b/backend/tests/unit_tests/ranking_calculation_test.py
@@ -112,8 +112,17 @@ def test_determine_ranking_for_stage_item_elimination() -> None:
     )
 
     assert ranking == {
-        -2: TeamStatistics(wins=0, draws=1, losses=1, points=Decimal("1.25")),
-        -1: TeamStatistics(wins=1, draws=1, losses=0, points=Decimal("4.75")),
+        -2: TeamStatistics(
+            wins=0,
+            draws=1,
+            losses=1,
+            points=Decimal("1.25"),
+            set_difference=-1,
+            point_difference=-2,
+        ),
+        -1: TeamStatistics(
+            wins=1, draws=1, losses=0, points=Decimal("4.75"), set_difference=1, point_difference=2
+        ),
     }
 
 
@@ -189,9 +198,586 @@ def test_determine_ranking_for_stage_item_swiss() -> None:
     )
 
     assert ranking == {
-        -2: TeamStatistics(wins=0, draws=1, losses=1, points=Decimal("1208")),
-        -1: TeamStatistics(wins=1, draws=1, losses=0, points=Decimal("1320")),
+        -2: TeamStatistics(
+            wins=0,
+            draws=1,
+            losses=1,
+            points=Decimal("1208"),
+            set_difference=-1,
+            point_difference=-2,
+        ),
+        -1: TeamStatistics(
+            wins=1, draws=1, losses=0, points=Decimal("1320"), set_difference=1, point_difference=2
+        ),
     }
+
+
+def test_team_statistics_has_set_and_point_difference() -> None:
+    stats = TeamStatistics()
+    assert stats.set_difference == 0
+    assert stats.point_difference == 0
+
+
+def test_match_points_sort_by_set_difference_tiebreaker() -> None:
+    """Teams tied on match points are ordered by set_difference (higher = better rank)."""
+    tournament_id = TournamentId(-1)
+    now = datetime_utc.now()
+    ranking = _ranking(tournament_id, now, win="1.0", draw="0.5")
+
+    # match 1: team1 beats team2 in 2 sets (team1 set_diff +2, team2 -2)
+    # match 2: team2 beats team1 in 3 sets - 2 wins to 1 (team2 set_diff +1, team1 -1)
+    # team1 net set_diff: +2 - 1 = +1, points = 1 (1 win, 1 loss)
+    # team2 net set_diff: -2 + 1 = -1, points = 1 (1 win, 1 loss)
+    # team1 should rank above team2 due to better set_difference
+    input1 = StageItemInputFinal(
+        id=StageItemInputId(-1),
+        team_id=TeamId(-1),
+        slot=1,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(-1)),
+    )
+    input2 = StageItemInputFinal(
+        id=StageItemInputId(-2),
+        team_id=TeamId(-2),
+        slot=2,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM2.model_dump(), id=TeamId(-2)),
+    )
+
+    from bracket.logic.ranking.calculation import determine_team_ranking_for_stage_item
+    from bracket.models.db.match import MatchSet, MatchSetState
+
+    def make_sets(match_id: MatchId, scores: list[tuple[int, int]]) -> list[MatchSet]:
+        from bracket.utils.id_types import MatchSetId
+
+        return [
+            MatchSet(
+                id=MatchSetId(match_id * 10 + i),
+                match_id=match_id,
+                set_number=i + 1,
+                stage_item_input1_score=s1,
+                stage_item_input2_score=s2,
+                state=MatchSetState.COMPLETED,
+            )
+            for i, (s1, s2) in enumerate(scores)
+        ]
+
+    stage_item = StageItemWithRounds(
+        rounds=[
+            RoundWithMatches(
+                id=RoundId(-1),
+                matches=[
+                    MatchWithDetailsDefinitive(
+                        id=MatchId(-1),
+                        stage_item_input1=input1,
+                        stage_item_input2=input2,
+                        created=now,
+                        duration_minutes=90,
+                        round_id=RoundId(-1),
+                        match_sets=make_sets(MatchId(-1), [(21, 5), (21, 5)]),  # team1 wins 2-0
+                    ),
+                    MatchWithDetailsDefinitive(
+                        id=MatchId(-2),
+                        stage_item_input1=input2,
+                        stage_item_input2=input1,
+                        created=now,
+                        duration_minutes=90,
+                        round_id=RoundId(-1),
+                        match_sets=make_sets(
+                            MatchId(-2), [(21, 5), (5, 21), (21, 5)]
+                        ),  # team2 wins 2-1
+                    ),
+                ],
+                stage_item_id=StageItemId(-1),
+                created=now,
+                lifecycle_state=RoundLifecycleState.ACTIVE,
+                name="",
+            )
+        ],
+        inputs=[input1, input2],
+        type_name="Round Robin",
+        team_count=2,
+        ranking_id=None,
+        id=StageItemId(-1),
+        stage_id=StageId(-1),
+        name="",
+        created=now,
+        type=StageType.ROUND_ROBIN,
+    )
+
+    ranked = determine_team_ranking_for_stage_item(stage_item, ranking)
+    # Both teams have 1 win (1 point each)
+    assert ranked[0][0] == StageItemInputId(-1), "team1 should rank first (set_diff +2 vs 0)"
+    assert ranked[1][0] == StageItemInputId(-2)
+
+
+def _set_points_ranking(tournament_id: TournamentId, now: datetime_utc) -> Ranking:
+
+    return Ranking(
+        id=RankingId(-1),
+        tournament_id=tournament_id,
+        created=now,
+        position=0,
+        scoring_type=ScoringType.SET_POINTS,
+        match_points=None,
+        set_points_with_bonus=None,
+    )
+
+
+def _set_points_with_bonus_ranking(
+    tournament_id: TournamentId, now: datetime_utc, bonus: str = "1.0"
+) -> Ranking:
+    from bracket.models.db.ranking import RankingSetPointsWithMatchBonusData
+
+    return Ranking(
+        id=RankingId(-1),
+        tournament_id=tournament_id,
+        created=now,
+        position=0,
+        scoring_type=ScoringType.SET_POINTS_WITH_MATCH_BONUS,
+        match_points=None,
+        set_points_with_bonus=RankingSetPointsWithMatchBonusData(match_bonus_points=Decimal(bonus)),
+    )
+
+
+def _make_stage_item(
+    tournament_id: TournamentId,
+    now: datetime_utc,
+    input1: StageItemInputFinal,
+    input2: StageItemInputFinal,
+    matches: list[MatchWithDetailsDefinitive],
+) -> StageItemWithRounds:
+    return StageItemWithRounds(
+        rounds=[
+            RoundWithMatches(
+                id=RoundId(-1),
+                matches=matches,
+                stage_item_id=StageItemId(-1),
+                created=now,
+                lifecycle_state=RoundLifecycleState.ACTIVE,
+                name="",
+            )
+        ],
+        inputs=[input1, input2],
+        type_name="Round Robin",
+        team_count=2,
+        ranking_id=None,
+        id=StageItemId(-1),
+        stage_id=StageId(-1),
+        name="",
+        created=now,
+        type=StageType.ROUND_ROBIN,
+    )
+
+
+def test_set_points_scoring_awards_one_point_per_set_won() -> None:
+    """SET_POINTS: stats.points equals the number of sets won across all matches."""
+    tournament_id = TournamentId(-1)
+    now = datetime_utc.now()
+    input1 = StageItemInputFinal(
+        id=StageItemInputId(-1),
+        team_id=TeamId(-1),
+        slot=1,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(-1)),
+    )
+    input2 = StageItemInputFinal(
+        id=StageItemInputId(-2),
+        team_id=TeamId(-2),
+        slot=2,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM2.model_dump(), id=TeamId(-2)),
+    )
+    ranking = _set_points_ranking(tournament_id, now)
+
+    from bracket.models.db.match import MatchSet, MatchSetState
+    from bracket.utils.id_types import MatchSetId
+
+    # Match: team1 wins 3-1 (4 sets total)
+    match = MatchWithDetailsDefinitive(
+        id=MatchId(-1),
+        stage_item_input1=input1,
+        stage_item_input2=input2,
+        created=now,
+        duration_minutes=90,
+        round_id=RoundId(-1),
+        match_sets=[
+            MatchSet(
+                id=MatchSetId(1),
+                match_id=MatchId(-1),
+                set_number=1,
+                stage_item_input1_score=21,
+                stage_item_input2_score=10,
+                state=MatchSetState.COMPLETED,
+            ),
+            MatchSet(
+                id=MatchSetId(2),
+                match_id=MatchId(-1),
+                set_number=2,
+                stage_item_input1_score=10,
+                stage_item_input2_score=21,
+                state=MatchSetState.COMPLETED,
+            ),
+            MatchSet(
+                id=MatchSetId(3),
+                match_id=MatchId(-1),
+                set_number=3,
+                stage_item_input1_score=21,
+                stage_item_input2_score=10,
+                state=MatchSetState.COMPLETED,
+            ),
+            MatchSet(
+                id=MatchSetId(4),
+                match_id=MatchId(-1),
+                set_number=4,
+                stage_item_input1_score=21,
+                stage_item_input2_score=10,
+                state=MatchSetState.COMPLETED,
+            ),
+        ],
+    )
+
+    result = determine_ranking_for_stage_item(
+        _make_stage_item(tournament_id, now, input1, input2, [match]), ranking
+    )
+    assert result[StageItemInputId(-1)].points == Decimal("3")  # 3 sets won
+    assert result[StageItemInputId(-2)].points == Decimal("1")  # 1 set won
+    assert result[StageItemInputId(-1)].wins == 1
+    assert result[StageItemInputId(-2)].losses == 1
+
+
+def test_set_points_with_match_bonus_awards_bonus_for_win() -> None:
+    """SET_POINTS_WITH_MATCH_BONUS: winner gets sets_won + match_bonus; draw gets sets_won only."""
+    tournament_id = TournamentId(-1)
+    now = datetime_utc.now()
+    input1 = StageItemInputFinal(
+        id=StageItemInputId(-1),
+        team_id=TeamId(-1),
+        slot=1,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(-1)),
+    )
+    input2 = StageItemInputFinal(
+        id=StageItemInputId(-2),
+        team_id=TeamId(-2),
+        slot=2,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM2.model_dump(), id=TeamId(-2)),
+    )
+    ranking = _set_points_with_bonus_ranking(tournament_id, now, bonus="2.0")
+
+    from bracket.models.db.match import MatchSet, MatchSetState
+    from bracket.utils.id_types import MatchSetId
+
+    # Match: team1 wins 2-1; bonus=2 → team1 gets 2(sets)+2(bonus)=4, team2 gets 1(set)
+    match = MatchWithDetailsDefinitive(
+        id=MatchId(-1),
+        stage_item_input1=input1,
+        stage_item_input2=input2,
+        created=now,
+        duration_minutes=90,
+        round_id=RoundId(-1),
+        match_sets=[
+            MatchSet(
+                id=MatchSetId(1),
+                match_id=MatchId(-1),
+                set_number=1,
+                stage_item_input1_score=21,
+                stage_item_input2_score=10,
+                state=MatchSetState.COMPLETED,
+            ),
+            MatchSet(
+                id=MatchSetId(2),
+                match_id=MatchId(-1),
+                set_number=2,
+                stage_item_input1_score=10,
+                stage_item_input2_score=21,
+                state=MatchSetState.COMPLETED,
+            ),
+            MatchSet(
+                id=MatchSetId(3),
+                match_id=MatchId(-1),
+                set_number=3,
+                stage_item_input1_score=21,
+                stage_item_input2_score=10,
+                state=MatchSetState.COMPLETED,
+            ),
+        ],
+    )
+
+    result = determine_ranking_for_stage_item(
+        _make_stage_item(tournament_id, now, input1, input2, [match]), ranking
+    )
+    assert result[StageItemInputId(-1)].points == Decimal("4")  # 2 sets won + 2 bonus
+    assert result[StageItemInputId(-2)].points == Decimal("1")  # 1 set won, no bonus
+    assert result[StageItemInputId(-1)].wins == 1
+    assert result[StageItemInputId(-2)].losses == 1
+
+
+def test_set_points_with_match_bonus_draw_gives_no_bonus() -> None:
+    """SET_POINTS_WITH_MATCH_BONUS: draws give 1 point per set each, no match bonus."""
+    tournament_id = TournamentId(-1)
+    now = datetime_utc.now()
+    input1 = StageItemInputFinal(
+        id=StageItemInputId(-1),
+        team_id=TeamId(-1),
+        slot=1,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(-1)),
+    )
+    input2 = StageItemInputFinal(
+        id=StageItemInputId(-2),
+        team_id=TeamId(-2),
+        slot=2,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM2.model_dump(), id=TeamId(-2)),
+    )
+    ranking = _set_points_with_bonus_ranking(tournament_id, now, bonus="3.0")
+
+    from bracket.models.db.match import MatchSet, MatchSetState
+    from bracket.utils.id_types import MatchSetId
+
+    # num_sets=2 match, 1-1 draw: each team wins 1 set, no match bonus
+    match = MatchWithDetailsDefinitive(
+        id=MatchId(-1),
+        stage_item_input1=input1,
+        stage_item_input2=input2,
+        created=now,
+        duration_minutes=90,
+        round_id=RoundId(-1),
+        match_sets=[
+            MatchSet(
+                id=MatchSetId(1),
+                match_id=MatchId(-1),
+                set_number=1,
+                stage_item_input1_score=21,
+                stage_item_input2_score=10,
+                state=MatchSetState.COMPLETED,
+            ),
+            MatchSet(
+                id=MatchSetId(2),
+                match_id=MatchId(-1),
+                set_number=2,
+                stage_item_input1_score=10,
+                stage_item_input2_score=21,
+                state=MatchSetState.COMPLETED,
+            ),
+        ],
+    )
+
+    result = determine_ranking_for_stage_item(
+        _make_stage_item(tournament_id, now, input1, input2, [match]), ranking
+    )
+    assert result[StageItemInputId(-1)].points == Decimal("1")  # 1 set won, no bonus
+    assert result[StageItemInputId(-2)].points == Decimal("1")  # 1 set won, no bonus
+    assert result[StageItemInputId(-1)].draws == 1
+    assert result[StageItemInputId(-2)].draws == 1
+
+
+def test_match_points_sort_by_point_difference_when_set_difference_tied() -> None:
+    """When points and set_difference are equal, point_difference breaks the tie."""
+    tournament_id = TournamentId(-1)
+    now = datetime_utc.now()
+    ranking = _ranking(tournament_id, now, win="1.0", draw="0.5")
+
+    # Both teams: 1 win, 1 loss → 1 point each
+    # Both teams: win one set, lose one set → set_diff = 0 for both
+    # team1 wins the set 21-5, team2 wins the set 21-19 → point_diff team1 = (21-5)+(5-21)=0
+    # Wait, that's symmetric. Let me try:
+    # Match 1 (team1 vs team2): team1 wins 1 set 21-5, team2 wins 1 set 21-19 → draw? No, wait...
+    # For a 1-set match: team1 wins with 21-5, so sets1=1, sets2=0 → team1 wins.
+    # Let's do this: 2-set match format (num_sets=2 is unusual but valid)
+    # Match 1: team1 wins set1 (21-5), team2 wins set2 (21-19). Draw (sets_won: 1-1).
+    # Match 2 (reversed): team2 wins set1 (21-15), team1 wins set2 (21-5). Draw (1-1).
+    # But then both have 0 wins, 2 draws → same points.
+    # team1 point_diff: (21-5)+(19-21)+(15-21)+(21-5) = 16-2-6+16 = 24?
+    # Actually let me think of a cleaner scenario with SINGLE-set matches:
+    # Match 1: team1 wins single set 21-5 (sets won: team1=1, team2=0) → team1 wins match
+    # Match 2: team2 wins single set 21-15 (sets won: team2=1, team1=0) → team2 wins match
+    # Both have 1 win, 1 loss → equal points (1.0 each)
+    # Both have set_diff: team1 = +1-1 = 0, team2 = -1+1 = 0
+    # point_diff: team1 = (21-5)+(15-21) = 16-6 = +10, team2 = (5-21)+(21-15) = -16+6 = -10
+    # team1 should rank first due to better point_difference
+
+    from bracket.models.db.match import MatchSet, MatchSetState
+    from bracket.utils.id_types import MatchSetId
+
+    input1 = StageItemInputFinal(
+        id=StageItemInputId(-1),
+        team_id=TeamId(-1),
+        slot=1,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(-1)),
+    )
+    input2 = StageItemInputFinal(
+        id=StageItemInputId(-2),
+        team_id=TeamId(-2),
+        slot=2,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM2.model_dump(), id=TeamId(-2)),
+    )
+
+    match1 = MatchWithDetailsDefinitive(
+        id=MatchId(-1),
+        stage_item_input1=input1,
+        stage_item_input2=input2,
+        created=now,
+        duration_minutes=90,
+        round_id=RoundId(-1),
+        match_sets=[
+            MatchSet(
+                id=MatchSetId(1),
+                match_id=MatchId(-1),
+                set_number=1,
+                stage_item_input1_score=21,
+                stage_item_input2_score=5,
+                state=MatchSetState.COMPLETED,
+            )
+        ],
+    )
+    match2 = MatchWithDetailsDefinitive(
+        id=MatchId(-2),
+        stage_item_input1=input2,
+        stage_item_input2=input1,
+        created=now,
+        duration_minutes=90,
+        round_id=RoundId(-1),
+        match_sets=[
+            MatchSet(
+                id=MatchSetId(2),
+                match_id=MatchId(-2),
+                set_number=1,
+                stage_item_input1_score=21,
+                stage_item_input2_score=15,
+                state=MatchSetState.COMPLETED,
+            )
+        ],
+    )
+
+    from bracket.logic.ranking.calculation import determine_team_ranking_for_stage_item
+
+    ranked = determine_team_ranking_for_stage_item(
+        _make_stage_item(tournament_id, now, input1, input2, [match1, match2]), ranking
+    )
+    assert ranked[0][0] == StageItemInputId(-1), "team1 should rank first (point_diff +10 vs -10)"
+    assert ranked[1][0] == StageItemInputId(-2)
+
+
+def test_set_points_draw_gives_one_point_per_set() -> None:
+    """SET_POINTS: a 1-1 draw gives each team 1 point (their sets won)."""
+    tournament_id = TournamentId(-1)
+    now = datetime_utc.now()
+    input1 = StageItemInputFinal(
+        id=StageItemInputId(-1),
+        team_id=TeamId(-1),
+        slot=1,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(-1)),
+    )
+    input2 = StageItemInputFinal(
+        id=StageItemInputId(-2),
+        team_id=TeamId(-2),
+        slot=2,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM2.model_dump(), id=TeamId(-2)),
+    )
+    ranking = _set_points_ranking(tournament_id, now)
+
+    from bracket.models.db.match import MatchSet, MatchSetState
+    from bracket.utils.id_types import MatchSetId
+
+    # 2-set match ending 1-1 draw
+    match = MatchWithDetailsDefinitive(
+        id=MatchId(-1),
+        stage_item_input1=input1,
+        stage_item_input2=input2,
+        created=now,
+        duration_minutes=90,
+        round_id=RoundId(-1),
+        match_sets=[
+            MatchSet(
+                id=MatchSetId(1),
+                match_id=MatchId(-1),
+                set_number=1,
+                stage_item_input1_score=21,
+                stage_item_input2_score=10,
+                state=MatchSetState.COMPLETED,
+            ),
+            MatchSet(
+                id=MatchSetId(2),
+                match_id=MatchId(-1),
+                set_number=2,
+                stage_item_input1_score=10,
+                stage_item_input2_score=21,
+                state=MatchSetState.COMPLETED,
+            ),
+        ],
+    )
+    result = determine_ranking_for_stage_item(
+        _make_stage_item(tournament_id, now, input1, input2, [match]), ranking
+    )
+    assert result[StageItemInputId(-1)].points == Decimal("1")
+    assert result[StageItemInputId(-2)].points == Decimal("1")
+    assert result[StageItemInputId(-1)].draws == 1
+    assert result[StageItemInputId(-2)].draws == 1
+
+
+def test_match_points_draw_gives_draw_points() -> None:
+    """MATCH_POINTS: a draw gives each team draw_points."""
+    tournament_id = TournamentId(-1)
+    now = datetime_utc.now()
+    input1 = StageItemInputFinal(
+        id=StageItemInputId(-1),
+        team_id=TeamId(-1),
+        slot=1,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(-1)),
+    )
+    input2 = StageItemInputFinal(
+        id=StageItemInputId(-2),
+        team_id=TeamId(-2),
+        slot=2,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM2.model_dump(), id=TeamId(-2)),
+    )
+    ranking = _ranking(tournament_id, now, win="3.0", draw="1.0")
+
+    from bracket.models.db.match import MatchSet, MatchSetState
+    from bracket.utils.id_types import MatchSetId
+
+    # 2-set match ending 1-1 draw
+    match = MatchWithDetailsDefinitive(
+        id=MatchId(-1),
+        stage_item_input1=input1,
+        stage_item_input2=input2,
+        created=now,
+        duration_minutes=90,
+        round_id=RoundId(-1),
+        match_sets=[
+            MatchSet(
+                id=MatchSetId(1),
+                match_id=MatchId(-1),
+                set_number=1,
+                stage_item_input1_score=21,
+                stage_item_input2_score=10,
+                state=MatchSetState.COMPLETED,
+            ),
+            MatchSet(
+                id=MatchSetId(2),
+                match_id=MatchId(-1),
+                set_number=2,
+                stage_item_input1_score=10,
+                stage_item_input2_score=21,
+                state=MatchSetState.COMPLETED,
+            ),
+        ],
+    )
+    result = determine_ranking_for_stage_item(
+        _make_stage_item(tournament_id, now, input1, input2, [match]), ranking
+    )
+    assert result[StageItemInputId(-1)].points == Decimal("1.0")  # draw_points
+    assert result[StageItemInputId(-2)].points == Decimal("1.0")  # draw_points
+    assert result[StageItemInputId(-1)].draws == 1
 
 
 def test_determine_ranking_for_stage_item_swiss_no_matches() -> None:

--- a/frontend/src/components/tables/standings.tsx
+++ b/frontend/src/components/tables/standings.tsx
@@ -7,7 +7,7 @@ import { EmptyTableInfo } from '@components/no_content/empty_table_info';
 import { formatStageItemInput } from '@components/utils/stage_item_input';
 import { StageItemInputFinal, StageItemWithRounds } from '@openapi';
 import { WinDistributionTitle } from './players';
-import { ThNotSortable, ThSortable, getTableState, sortTableEntries } from './table';
+import { ThNotSortable, ThSortable, getTableState } from './table';
 import TableLayoutLarge from './table_large';
 
 export function StandingsTableForStageItem({
@@ -30,10 +30,17 @@ export function StandingsTableForStageItem({
   const maxPoints = Math.max(...teams_with_inputs.map((input) => parseFloat(input.points)));
 
   const rows = teams_with_inputs
-    .sort((p1: StageItemInputFinal, p2: StageItemInputFinal) => (p1.points > p2.points ? 1 : -1))
-    .sort((p1: StageItemInputFinal, p2: StageItemInputFinal) =>
-      sortTableEntries(p1, p2, tableState)
-    )
+    .sort((p1: StageItemInputFinal, p2: StageItemInputFinal) => {
+      const pts1 = parseFloat(p1.points);
+      const pts2 = parseFloat(p2.points);
+      if (pts1 !== pts2) return pts2 - pts1;
+      const sd1 = p1.set_difference ?? 0;
+      const sd2 = p2.set_difference ?? 0;
+      if (sd1 !== sd2) return sd2 - sd1;
+      const pd1 = p1.point_difference ?? 0;
+      const pd2 = p2.point_difference ?? 0;
+      return pd2 - pd1;
+    })
     .slice(0, maxTeamsToDisplay)
     .map((team_with_input, index) => (
       <Table.Tr key={team_with_input.id}>

--- a/frontend/src/openapi/types.gen.ts
+++ b/frontend/src/openapi/types.gen.ts
@@ -1482,9 +1482,17 @@ export type StageItemInputEmpty = {
    */
   losses: number;
   /**
+   * Point Difference
+   */
+  point_difference: number;
+  /**
    * Points
    */
   points: string;
+  /**
+   * Set Difference
+   */
+  set_difference: number;
   /**
    * Slot
    */
@@ -1532,9 +1540,17 @@ export type StageItemInputFinal = {
    */
   losses: number;
   /**
+   * Point Difference
+   */
+  point_difference: number;
+  /**
    * Points
    */
   points: string;
+  /**
+   * Set Difference
+   */
+  set_difference: number;
   /**
    * Slot
    */
@@ -1627,9 +1643,17 @@ export type StageItemInputTentative = {
    */
   losses: number;
   /**
+   * Point Difference
+   */
+  point_difference: number;
+  /**
    * Points
    */
   points: string;
+  /**
+   * Set Difference
+   */
+  set_difference: number;
   /**
    * Slot
    */


### PR DESCRIPTION
- Add `set_difference` and `point_difference` fields to `TeamStatistics`
- Implement SET_POINTS scoring: 1 point per set won per match
- Implement SET_POINTS_WITH_MATCH_BONUS: sets won + bonus for match winner
- Add set_difference → point_difference tiebreakers to ranking sort for all round-robin types
- Accumulate set_difference and point_difference for every completed match
- Add Alembic migration to add set_difference/point_difference columns to stage_item_inputs
- Persist set_difference and point_difference in update_team_stats SQL
- Swiss ELO path unchanged (uses match_points win/draw/loss or 1.0/0.5/0.0 fallback)
- 8 new unit tests covering all scoring types, tiebreakers, and draw handling

Closes #194

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018fu3Da2eQNT9GLV3G1ZjRt