### PR TITLE
feat: even-set validation for single elimination and draw-safe winner propagation

### DIFF
--- a/backend/bracket/logic/ranking/elimination.py
+++ b/backend/bracket/logic/ranking/elimination.py
@@ -1,3 +1,5 @@
+import logging
+
 from bracket.models.db.match import Match, MatchState
 from bracket.models.db.stage_item_inputs import StageItemInput
 from bracket.models.db.util import StageItemWithRounds
@@ -8,6 +10,8 @@ from bracket.utils.id_types import (
     MatchId,
     RoundId,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def get_inputs_to_update_in_subsequent_elimination_rounds(
@@ -44,14 +48,28 @@ def get_inputs_to_update_in_subsequent_elimination_rounds(
                 subsequent_match.stage_item_input1_winner_from_match_id
             )
         ):
-            updated_inputs[0] = affected_match1.get_winner()
+            winner1 = affected_match1.get_winner()
+            if winner1 is None:
+                logger.warning(
+                    "Match %s has no winner yet or is a draw — skipping elimination propagation",
+                    affected_match1.id,
+                )
+            else:
+                updated_inputs[0] = winner1
 
         if subsequent_match.stage_item_input2_winner_from_match_id is not None and (
             affected_match2 := affected_matches.get(
                 subsequent_match.stage_item_input2_winner_from_match_id
             )
         ):
-            updated_inputs[1] = affected_match2.get_winner()
+            winner2 = affected_match2.get_winner()
+            if winner2 is None:
+                logger.warning(
+                    "Match %s has no winner yet or is a draw — skipping elimination propagation",
+                    affected_match2.id,
+                )
+            else:
+                updated_inputs[1] = winner2
 
         if original_inputs != updated_inputs:
             input_ids = [input_.id if input_ else None for input_ in updated_inputs]

--- a/backend/bracket/routes/rankings.py
+++ b/backend/bracket/routes/rankings.py
@@ -32,7 +32,7 @@ from bracket.sql.rankings import (
     sql_update_ranking,
 )
 from bracket.sql.stage_item_inputs import get_stage_item_input_ids_by_ranking_id
-from bracket.sql.stage_items import get_stage_item
+from bracket.sql.stage_items import get_stage_item, get_stage_items_for_ranking
 from bracket.utils.id_types import RankingId, TournamentId
 
 router = APIRouter(prefix=config.api_prefix)
@@ -55,6 +55,14 @@ async def update_ranking_by_id(
     _: UserPublic = Depends(user_authenticated_for_tournament),
     __: Tournament = Depends(disallow_archived_tournament),
 ) -> SuccessResponse:
+    if ranking_body.num_sets % 2 == 0:
+        stage_items_for_ranking = await get_stage_items_for_ranking(tournament_id, ranking_id)
+        if any(si.type == StageType.SINGLE_ELIMINATION for si in stage_items_for_ranking):
+            raise HTTPException(
+                status_code=422,
+                detail="Even number of sets is not supported for single elimination brackets.",
+            )
+
     # Detect a change in the configured number of sets so existing matches' set rows can be
     # resized. When matches already have in-progress or completed sets this is destructive, so
     # it is refused with a 409 unless explicitly forced.

--- a/backend/bracket/routes/stage_items.py
+++ b/backend/bracket/routes/stage_items.py
@@ -55,6 +55,7 @@ from bracket.sql.stage_items import (
     get_stage_item,
     sql_create_stage_item_with_empty_inputs,
 )
+from bracket.sql.rankings import get_ranking_by_id
 from bracket.sql.stages import get_full_tournament_details
 from bracket.sql.tournaments import sql_get_tournament
 from bracket.sql.validation import check_foreign_keys_belong_to_tournament
@@ -483,6 +484,14 @@ async def create_stage_item(
     existing_stage_items = [stage_item for stage in stages for stage_item in stage.stage_items]
     check_requirement(existing_stage_items, user, "max_stage_items")
 
+    if stage_body.type is StageType.SINGLE_ELIMINATION and stage_body.ranking_id is not None:
+        ranking = await get_ranking_by_id(tournament_id, stage_body.ranking_id)
+        if ranking is not None and ranking.num_sets % 2 == 0:
+            raise HTTPException(
+                status_code=422,
+                detail="Even number of sets is not supported for single elimination brackets.",
+            )
+
     stage_item = await sql_create_stage_item_with_empty_inputs(tournament_id, stage_body)
     await build_matches_for_stage_item(stage_item, tournament_id)
     return SuccessResponse()
@@ -507,6 +516,14 @@ async def update_stage_item(
 
     await check_foreign_keys_belong_to_tournament(stage_item_body, tournament_id)
     team_count_changed = stage_item_body.team_count != stage_item.team_count
+
+    if stage_item.type is StageType.SINGLE_ELIMINATION and stage_item_body.ranking_id != stage_item.ranking_id:
+        ranking = await get_ranking_by_id(tournament_id, stage_item_body.ranking_id)
+        if ranking is not None and ranking.num_sets % 2 == 0:
+            raise HTTPException(
+                status_code=422,
+                detail="Even number of sets is not supported for single elimination brackets.",
+            )
 
     async with database.transaction():
         if stage_item_body.games_per_player is not None and stage_item.type is StageType.SWISS:

--- a/backend/bracket/routes/stage_items.py
+++ b/backend/bracket/routes/stage_items.py
@@ -55,7 +55,7 @@ from bracket.sql.stage_items import (
     get_stage_item,
     sql_create_stage_item_with_empty_inputs,
 )
-from bracket.sql.rankings import get_ranking_by_id
+from bracket.sql.rankings import get_default_ranking_for_stage, get_ranking_by_id
 from bracket.sql.stages import get_full_tournament_details
 from bracket.sql.tournaments import sql_get_tournament
 from bracket.sql.validation import check_foreign_keys_belong_to_tournament
@@ -484,8 +484,11 @@ async def create_stage_item(
     existing_stage_items = [stage_item for stage in stages for stage_item in stage.stage_items]
     check_requirement(existing_stage_items, user, "max_stage_items")
 
-    if stage_body.type is StageType.SINGLE_ELIMINATION and stage_body.ranking_id is not None:
-        ranking = await get_ranking_by_id(tournament_id, stage_body.ranking_id)
+    if stage_body.type is StageType.SINGLE_ELIMINATION:
+        if stage_body.ranking_id is not None:
+            ranking = await get_ranking_by_id(tournament_id, stage_body.ranking_id)
+        else:
+            ranking = await get_default_ranking_for_stage(tournament_id, stage_body.stage_id)
         if ranking is not None and ranking.num_sets % 2 == 0:
             raise HTTPException(
                 status_code=422,

--- a/backend/bracket/sql/rankings.py
+++ b/backend/bracket/sql/rankings.py
@@ -84,6 +84,14 @@ async def get_default_ranking_for_stage(tournament_id: TournamentId, stage_id: S
     return _row_to_ranking(result)
 
 
+async def get_ranking_by_id(tournament_id: TournamentId, ranking_id: RankingId) -> Ranking | None:
+    query = _RANKING_SELECT + " WHERE r.tournament_id = :tournament_id AND r.id = :ranking_id"
+    result = await database.fetch_one(
+        query=query, values={"tournament_id": tournament_id, "ranking_id": ranking_id}
+    )
+    return _row_to_ranking(result) if result else None
+
+
 async def get_ranking_for_stage_item(
     tournament_id: TournamentId, stage_item_id: StageItemId
 ) -> Ranking | None:

--- a/backend/bracket/sql/stage_items.py
+++ b/backend/bracket/sql/stage_items.py
@@ -8,7 +8,7 @@ from bracket.models.db.util import StageItemWithRounds
 from bracket.sql.rankings import get_default_ranking_for_stage
 from bracket.sql.stage_item_inputs import sql_create_stage_item_input
 from bracket.sql.stages import get_full_tournament_details
-from bracket.utils.id_types import StageItemId, TournamentId
+from bracket.utils.id_types import RankingId, StageItemId, TournamentId
 
 
 async def sql_create_stage_item(
@@ -70,6 +70,23 @@ async def sql_delete_stage_item(stage_item_id: StageItemId) -> None:
         WHERE stage_items.id = :stage_item_id
         """
     await database.execute(query=query, values={"stage_item_id": stage_item_id})
+
+
+async def get_stage_items_for_ranking(
+    tournament_id: TournamentId, ranking_id: RankingId
+) -> list[StageItem]:
+    query = """
+        SELECT si.*
+        FROM stage_items si
+        JOIN stages s ON s.id = si.stage_id
+        WHERE s.tournament_id = :tournament_id
+          AND si.ranking_id = :ranking_id
+    """
+    results = await database.fetch_all(
+        query=query,
+        values={"tournament_id": tournament_id, "ranking_id": ranking_id},
+    )
+    return [StageItem.model_validate(dict(result._mapping)) for result in results]
 
 
 async def get_stage_item(

--- a/backend/tests/integration_tests/api/rankings_test.py
+++ b/backend/tests/integration_tests/api/rankings_test.py
@@ -4,15 +4,16 @@ from unittest.mock import ANY
 import pytest
 
 from bracket.models.db.ranking import ScoringType
+from bracket.models.db.stage_item import StageType
 from bracket.sql.rankings import (
     get_all_rankings_in_tournament,
     sql_delete_ranking,
 )
-from bracket.utils.dummy_records import DUMMY_RANKING1, DUMMY_TEAM1
+from bracket.utils.dummy_records import DUMMY_RANKING1, DUMMY_STAGE1, DUMMY_STAGE_ITEM1, DUMMY_STAGE_ITEM3, DUMMY_TEAM1
 from bracket.utils.http import HTTPMethod
 from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
 from tests.integration_tests.models import AuthContext
-from tests.integration_tests.sql import inserted_ranking, inserted_team
+from tests.integration_tests.sql import inserted_ranking, inserted_stage, inserted_stage_item, inserted_team
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -235,3 +236,85 @@ async def test_update_ranking_side_switch(
             updated_rankings = await get_all_rankings_in_tournament(auth_context.tournament.id)
             updated = next(r for r in updated_rankings if r.id == ranking_inserted.id)
             assert updated.side_switch_every_n_points == 7
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_ranking_even_sets_single_elimination_returns_422(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """PUT with even num_sets returns 422 when the ranking is used by a SINGLE_ELIMINATION stage item."""
+    body = {"scoring_type": "MATCH_POINTS", "num_sets": 2}
+    tournament_id = auth_context.tournament.id
+    async with inserted_ranking(
+        DUMMY_RANKING1.model_copy(update={"tournament_id": tournament_id})
+    ) as test_ranking:
+        async with inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
+        ) as stage:
+            async with inserted_stage_item(
+                DUMMY_STAGE_ITEM3.model_copy(
+                    update={"stage_id": stage.id, "ranking_id": test_ranking.id}
+                )
+            ):
+                response = await send_tournament_request(
+                    HTTPMethod.PUT,
+                    f"rankings/{test_ranking.id}",
+                    auth_context,
+                    json=body,
+                )
+                assert "detail" in response
+                assert "Even number of sets" in response["detail"]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_ranking_odd_sets_single_elimination_succeeds(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """PUT with odd num_sets succeeds even when the ranking is used by a SINGLE_ELIMINATION stage item."""
+    body = {"scoring_type": "MATCH_POINTS", "num_sets": 3}
+    tournament_id = auth_context.tournament.id
+    async with inserted_ranking(
+        DUMMY_RANKING1.model_copy(update={"tournament_id": tournament_id})
+    ) as test_ranking:
+        async with inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
+        ) as stage:
+            async with inserted_stage_item(
+                DUMMY_STAGE_ITEM3.model_copy(
+                    update={"stage_id": stage.id, "ranking_id": test_ranking.id}
+                )
+            ):
+                response = await send_tournament_request(
+                    HTTPMethod.PUT,
+                    f"rankings/{test_ranking.id}",
+                    auth_context,
+                    json=body,
+                )
+                assert response.get("success") is True, response
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_ranking_even_sets_round_robin_succeeds(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """PUT with even num_sets is allowed when all associated stage items are ROUND_ROBIN."""
+    body = {"scoring_type": "MATCH_POINTS", "num_sets": 2}
+    tournament_id = auth_context.tournament.id
+    async with inserted_ranking(
+        DUMMY_RANKING1.model_copy(update={"tournament_id": tournament_id})
+    ) as test_ranking:
+        async with inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
+        ) as stage:
+            async with inserted_stage_item(
+                DUMMY_STAGE_ITEM1.model_copy(
+                    update={"stage_id": stage.id, "ranking_id": test_ranking.id}
+                )
+            ):
+                response = await send_tournament_request(
+                    HTTPMethod.PUT,
+                    f"rankings/{test_ranking.id}",
+                    auth_context,
+                    json=body,
+                )
+                assert response.get("success") is True, response

--- a/backend/tests/integration_tests/api/stage_items_test.py
+++ b/backend/tests/integration_tests/api/stage_items_test.py
@@ -12,9 +12,11 @@ from bracket.schema import match_sets, matches, rounds, stage_item_inputs, stage
 from bracket.sql.stage_items import get_stage_item, sql_create_stage_item_with_inputs
 from bracket.sql.stages import get_full_tournament_details
 from bracket.utils.dummy_records import (
+    DUMMY_RANKING1,
     DUMMY_STAGE1,
     DUMMY_STAGE2,
     DUMMY_STAGE_ITEM1,
+    DUMMY_STAGE_ITEM3,
     DUMMY_TEAM1,
     DUMMY_TEAM2,
     DUMMY_TEAM3,
@@ -28,6 +30,7 @@ from tests.integration_tests.api.shared import (
 from tests.integration_tests.models import AuthContext
 from tests.integration_tests.sql import (
     assert_row_count_and_clear,
+    inserted_ranking,
     inserted_stage,
     inserted_stage_item,
     inserted_team,
@@ -464,3 +467,61 @@ async def test_update_single_elimination_stage_item_fails_after_games_started(
         await assert_row_count_and_clear(stage_item_inputs, 4)
         await assert_row_count_and_clear(stage_items, 1)
         await assert_row_count_and_clear(stages, 1)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_create_single_elimination_stage_item_with_even_set_ranking_returns_422(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """POST stage_items with SINGLE_ELIMINATION type and a ranking with even num_sets returns 422."""
+    tournament_id = auth_context.tournament.id
+    async with inserted_ranking(
+        DUMMY_RANKING1.model_copy(update={"tournament_id": tournament_id, "num_sets": 2})
+    ) as ranking_even:
+        async with inserted_stage(
+            DUMMY_STAGE2.model_copy(update={"tournament_id": tournament_id})
+        ) as stage:
+            response = await send_tournament_request(
+                HTTPMethod.POST,
+                "stage_items",
+                auth_context,
+                json={
+                    "type": StageType.SINGLE_ELIMINATION.value,
+                    "team_count": 2,
+                    "stage_id": stage.id,
+                    "ranking_id": ranking_even.id,
+                },
+            )
+            assert "detail" in response
+            assert "Even number of sets" in response["detail"]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_stage_item_ranking_to_even_sets_single_elimination_returns_422(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """PUT stage_items changing ranking_id to a ranking with even num_sets returns 422 for SINGLE_ELIMINATION."""
+    tournament_id = auth_context.tournament.id
+    async with inserted_ranking(
+        DUMMY_RANKING1.model_copy(update={"tournament_id": tournament_id, "num_sets": 2})
+    ) as ranking_even:
+        async with inserted_stage(
+            DUMMY_STAGE2.model_copy(update={"tournament_id": tournament_id})
+        ) as stage:
+            async with inserted_stage_item(
+                DUMMY_STAGE_ITEM3.model_copy(
+                    update={"stage_id": stage.id, "ranking_id": auth_context.ranking.id}
+                )
+            ) as stage_item:
+                response = await send_tournament_request(
+                    HTTPMethod.PUT,
+                    f"stage_items/{stage_item.id}",
+                    auth_context,
+                    json={
+                        "name": "Bracket A",
+                        "ranking_id": ranking_even.id,
+                        "team_count": stage_item.team_count,
+                    },
+                )
+                assert "detail" in response
+                assert "Even number of sets" in response["detail"]

--- a/backend/tests/unit_tests/elimination_test.py
+++ b/backend/tests/unit_tests/elimination_test.py
@@ -1,9 +1,17 @@
 from bracket.logic.ranking.elimination import get_inputs_to_update_in_subsequent_elimination_rounds
+from bracket.models.db.match import MatchSet, MatchSetState, MatchWithDetails, MatchWithDetailsDefinitive
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.util import RoundWithMatches
+from bracket.utils.dummy_records import DUMMY_MOCK_TIME
 from bracket.utils.id_types import (
+    MatchId,
+    MatchSetId,
     RoundId,
+    StageItemId,
     TournamentId,
 )
 from tests.unit_tests.mocks import (
+    _single_set,
     get_2_definitive_and_2_tentative_matches_mock,
     get_one_round_with_two_definitive_matches,
     get_stage_item_inputs_mock,
@@ -45,3 +53,100 @@ def test_elimination_input_updates() -> None:
             }
         ),
     }
+
+
+def test_elimination_propagation_skips_none_winner() -> None:
+    """When get_winner() returns None (draw), the previously-set downstream input is preserved."""
+    tournament_id = TournamentId(-1)
+    stage_item_inputs = get_stage_item_inputs_mock(tournament_id)
+
+    # A drawn match: 2 sets, each player wins one → get_winner() = None
+    drawn_match = MatchWithDetailsDefinitive(
+        id=MatchId(-1),
+        stage_item_input1=stage_item_inputs[0],
+        stage_item_input2=stage_item_inputs[1],
+        stage_item_input1_id=stage_item_inputs[0].id,
+        stage_item_input2_id=stage_item_inputs[1].id,
+        created=DUMMY_MOCK_TIME,
+        duration_minutes=90,
+        round_id=RoundId(-3),
+        match_sets=[
+            MatchSet(
+                id=MatchSetId(-10),
+                match_id=MatchId(-1),
+                set_number=1,
+                stage_item_input1_score=21,
+                stage_item_input2_score=10,
+                state=MatchSetState.COMPLETED,
+            ),
+            MatchSet(
+                id=MatchSetId(-11),
+                match_id=MatchId(-1),
+                set_number=2,
+                stage_item_input1_score=10,
+                stage_item_input2_score=21,
+                state=MatchSetState.COMPLETED,
+            ),
+        ],
+        completed_at=DUMMY_MOCK_TIME,
+    )
+
+    # A normal match: input2 wins
+    normal_match = MatchWithDetailsDefinitive(
+        id=MatchId(-2),
+        stage_item_input1=stage_item_inputs[2],
+        stage_item_input2=stage_item_inputs[3],
+        stage_item_input1_id=stage_item_inputs[2].id,
+        stage_item_input2_id=stage_item_inputs[3].id,
+        created=DUMMY_MOCK_TIME,
+        duration_minutes=90,
+        round_id=RoundId(-3),
+        match_sets=[_single_set(MatchId(-2), 2, 3, MatchSetState.COMPLETED)],
+        completed_at=DUMMY_MOCK_TIME,
+    )
+
+    # Subsequent match: input1 was previously propagated from drawn_match, input2 from normal_match.
+    # Since drawn_match has no winner, input1 must NOT be cleared.
+    subsequent_match = MatchWithDetails(
+        id=MatchId(-3),
+        created=DUMMY_MOCK_TIME,
+        duration_minutes=90,
+        round_id=RoundId(-2),
+        match_sets=[],
+        stage_item_input1=stage_item_inputs[0],
+        stage_item_input1_id=stage_item_inputs[0].id,
+        stage_item_input1_winner_from_match_id=drawn_match.id,
+        stage_item_input2_winner_from_match_id=normal_match.id,
+    )
+
+    round1 = RoundWithMatches(
+        id=RoundId(-3),
+        matches=[drawn_match, normal_match],
+        stage_item_id=StageItemId(-1),
+        created=DUMMY_MOCK_TIME,
+        lifecycle_state=RoundLifecycleState.ACTIVE,
+        name="",
+    )
+    round2 = RoundWithMatches(
+        id=RoundId(-2),
+        matches=[subsequent_match],
+        stage_item_id=StageItemId(-1),
+        created=DUMMY_MOCK_TIME,
+        lifecycle_state=RoundLifecycleState.ACTIVE,
+        name="",
+    )
+
+    updates = get_inputs_to_update_in_subsequent_elimination_rounds(
+        RoundId(-3),
+        get_stage_item_mock(stage_item_inputs, [round1, round2]),
+        {drawn_match.id, normal_match.id},
+    )
+
+    # Only input2 should be updated (from normal_match winner = stage_item_inputs[3]).
+    # input1 must be preserved as stage_item_inputs[0] — draw must NOT clear it.
+    assert subsequent_match.id in updates
+    updated = updates[subsequent_match.id]
+    assert updated.stage_item_input1 == stage_item_inputs[0]
+    assert updated.stage_item_input1_id == stage_item_inputs[0].id
+    assert updated.stage_item_input2 == stage_item_inputs[3]
+    assert updated.stage_item_input2_id == stage_item_inputs[3].id

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -141,6 +141,7 @@
     "empty_password_validation": "Passwort darf nicht leer sein",
     "empty_slot": "Leerer Slot",
     "end_set_label": "Satz beenden",
+    "even_sets_single_elim_error": "Eine gerade Anzahl von Sätzen wird für Single-Elimination-Brackets nicht unterstützt.",
     "example_label": "Beispiel:",
     "filter_stage_item_label": "Nach Stufenelement filtern",
     "filter_stage_item_placeholder": "Kein Filter",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -141,6 +141,7 @@
     "empty_password_validation": "Password cannot be empty",
     "empty_slot": "Empty slot",
     "end_set_label": "End Set",
+    "even_sets_single_elim_error": "Even number of sets is not supported for single elimination brackets.",
     "example_label": "Example:",
     "filter_stage_item_label": "Filter on stage item",
     "filter_stage_item_placeholder": "No filter",

--- a/frontend/src/components/builder/builder.tsx
+++ b/frontend/src/components/builder/builder.tsx
@@ -538,6 +538,7 @@ function StageColumn({
         key={-1}
         tournament={tournament}
         stage={stage}
+        rankings={rankings}
         swrStagesResponse={swrStagesResponse}
         swrAvailableInputsResponse={swrAvailableInputsResponse}
       />

--- a/frontend/src/components/modals/create_stage_item.tsx
+++ b/frontend/src/components/modals/create_stage_item.tsx
@@ -16,8 +16,10 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SWRResponse } from 'swr';
 
+import { RankingSelect } from '@components/select/ranking_select';
 import { Translator } from '@components/utils/types';
 import {
+  Ranking,
   StageItemInputOptionsResponse,
   StageWithStageItems,
   StagesWithStageItemsResponse,
@@ -190,20 +192,25 @@ interface FormValues {
   team_count_round_robin: number;
   team_count_elimination: number;
   games_per_player: number;
+  ranking_id: string;
 }
 export function CreateStageItemModal({
   tournament,
   stage,
+  rankings,
   swrStagesResponse,
   swrAvailableInputsResponse,
 }: {
   tournament: TournamentWithLevels;
   stage: StageWithStageItems;
+  rankings: Ranking[];
   swrStagesResponse: SWRResponse<StagesWithStageItemsResponse>;
   swrAvailableInputsResponse: SWRResponse<StageItemInputOptionsResponse>;
 }) {
   const { t } = useTranslation();
   const [opened, setOpened] = useState(false);
+
+  const defaultRanking = rankings.find((r) => r.level_id === stage.level_id) ?? rankings[0];
 
   const form = useForm<FormValues>({
     initialValues: {
@@ -211,6 +218,7 @@ export function CreateStageItemModal({
       team_count_round_robin: 4,
       team_count_elimination: 2,
       games_per_player: 3,
+      ranking_id: defaultRanking?.id.toString() ?? '',
     },
     validate: {
       team_count_round_robin: (value) => (value >= 2 ? null : t('at_least_two_team_validation')),
@@ -243,6 +251,7 @@ export function CreateStageItemModal({
               stage.id,
               values.type,
               getTeamCount(values),
+              Number(values.ranking_id),
               values.type === 'SWISS' ? values.games_per_player : null
             );
             await swrStagesResponse.mutate();
@@ -260,6 +269,7 @@ export function CreateStageItemModal({
           <Divider mt="1rem" />
           <TeamCountInput form={form} />
           <GamesPerPlayerInput form={form} />
+          <RankingSelect form={form} rankings={rankings} />
 
           <Button fullWidth mt="1.5rem" color="green" type="submit">
             {t('create_stage_item_button')}

--- a/frontend/src/pages/tournaments/[id]/rankings.tsx
+++ b/frontend/src/pages/tournaments/[id]/rankings.tsx
@@ -7,6 +7,7 @@ import {
   Container,
   NumberInput,
   Select,
+  Text,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useTranslation } from 'react-i18next';
@@ -18,9 +19,15 @@ import RequestErrorAlert from '@components/utils/error_alert';
 import { TableSkeletonSingleColumn } from '@components/utils/skeletons';
 import { Translator } from '@components/utils/types';
 import { getTournamentIdFromRouter } from '@components/utils/util';
-import { Ranking, RankingsResponse, ScoringType, TournamentWithLevels } from '@openapi';
+import {
+  Ranking,
+  RankingsResponse,
+  ScoringType,
+  StageItemWithRounds,
+  TournamentWithLevels,
+} from '@openapi';
 import TournamentLayout from '@pages/tournaments/_tournament_layout';
-import { getRankings, getTournamentById } from '@services/adapter';
+import { getRankings, getStages, getTournamentById } from '@services/adapter';
 import { createRanking, deleteRanking, editRanking } from '@services/ranking';
 
 function RankingDeleteButton({
@@ -64,13 +71,16 @@ function EditRankingForm({
   t,
   tournament,
   ranking,
+  stageItems,
   swrRankingsResponse,
 }: {
   t: Translator;
   tournament: TournamentWithLevels;
   ranking: Ranking;
+  stageItems: StageItemWithRounds[];
   swrRankingsResponse: SWRResponse<RankingsResponse>;
 }) {
+  const stageItemsForRanking = stageItems.filter((si) => si.ranking_id === ranking.id);
   const form = useForm({
     initialValues: {
       scoring_type: ranking.scoring_type as ScoringType,
@@ -88,6 +98,9 @@ function EditRankingForm({
     },
     validate: {},
   });
+  const hasEvenSetsError =
+    form.values.num_sets % 2 === 0 &&
+    stageItemsForRanking.some((si) => si.type === 'SINGLE_ELIMINATION');
   const rankingTitle = `${t('ranking_title')} ${ranking.position + 1}`;
 
   return (
@@ -173,6 +186,11 @@ function EditRankingForm({
             label={t('num_sets_label')}
             {...form.getInputProps('num_sets')}
           />
+          {hasEvenSetsError && (
+            <Text c="red" size="sm" mt="xs">
+              {t('even_sets_single_elim_error')}
+            </Text>
+          )}
           <NumberInput
             mt="1rem"
             withAsterisk
@@ -208,7 +226,13 @@ function EditRankingForm({
               {...form.getInputProps('side_switch_every_n_points')}
             />
           )}
-          <Button fullWidth style={{ marginTop: 16 }} color="green" type="submit">
+          <Button
+            fullWidth
+            style={{ marginTop: 16 }}
+            color="green"
+            type="submit"
+            disabled={hasEvenSetsError}
+          >
             {`${t('save_button')} ${rankingTitle}`}
           </Button>
         </Accordion.Panel>
@@ -220,10 +244,12 @@ function EditRankingForm({
 function RankingForm({
   t,
   tournament,
+  stageItems,
   swrRankingsResponse,
 }: {
   t: Translator;
   tournament: TournamentWithLevels;
+  stageItems: StageItemWithRounds[];
   swrRankingsResponse: SWRResponse<RankingsResponse>;
 }) {
   const rankings: Ranking[] = swrRankingsResponse.data != null ? swrRankingsResponse.data.data : [];
@@ -235,6 +261,7 @@ function RankingForm({
         t={t}
         tournament={tournament}
         ranking={ranking}
+        stageItems={stageItems}
         swrRankingsResponse={swrRankingsResponse}
       />
     ));
@@ -257,9 +284,11 @@ function RankingForm({
 export default function RankingsPage() {
   const { tournamentData } = getTournamentIdFromRouter();
   const swrRankingsResponse = getRankings(tournamentData.id);
+  const swrStagesResponse = getStages(tournamentData.id);
 
   const swrTournamentResponse = getTournamentById(tournamentData.id);
   const tournamentDataFull = swrTournamentResponse.data?.data;
+  const stageItems = (swrStagesResponse.data?.data ?? []).flatMap((s) => s.stage_items);
   const { t } = useTranslation();
 
   // TODO: show loading icon.
@@ -273,6 +302,7 @@ export default function RankingsPage() {
         <RankingForm
           t={t}
           tournament={tournamentDataFull}
+          stageItems={stageItems}
           swrRankingsResponse={swrRankingsResponse}
         />
         <Button

--- a/frontend/src/services/stage_item.tsx
+++ b/frontend/src/services/stage_item.tsx
@@ -5,6 +5,7 @@ export async function createStageItem(
   stage_id: number,
   type: string,
   team_count: number,
+  ranking_id: number,
   games_per_player: number | null = null
 ) {
   return createAxios()
@@ -12,6 +13,7 @@ export async function createStageItem(
       stage_id,
       type,
       team_count,
+      ranking_id,
       games_per_player,
     })
     .catch((response: any) => handleRequestError(response));


### PR DESCRIPTION
- Block even num_sets on PUT /rankings/{id} when any associated stage item
  is SINGLE_ELIMINATION (returns HTTP 422)
- Add get_stage_items_for_ranking() SQL helper used by the validation
- Fix elimination propagation to skip (not clear) downstream inputs when
  get_winner() returns None (drawn/incomplete match)
- Show inline error and disable save in rankings UI when even sets + single
  elimination combination is detected
- Add i18n keys (en/de) for the even-sets error message
- Add unit test covering draw-safe propagation
- Add integration tests for even-set validation (422, odd-OK, round-robin-OK)
  using isolated inserted_ranking fixtures to prevent session fixture pollution

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TtzUKbeNZ5whQkDTmynZo5