### PR TITLE
Code-review cleanups for PRD 189 multi-set/scoring redesign

### DIFF
--- a/backend/bracket/logic/ranking/calculation.py
+++ b/backend/bracket/logic/ranking/calculation.py
@@ -33,7 +33,7 @@ def set_statistics_for_stage_item_input(
     was_draw = sets1 == sets2
     has_won = not was_draw and team_sets == max(sets1, sets2)
 
-    completed_sets = [s for s in match.match_sets if s.state.value == "COMPLETED"]
+    completed_sets = match.completed_sets
     if is_team1:
         total_points_for = sum(s.stage_item_input1_score for s in completed_sets)
         total_points_against = sum(s.stage_item_input2_score for s in completed_sets)
@@ -59,9 +59,13 @@ def set_statistics_for_stage_item_input(
                     if has_won:
                         stats[stage_item_input_id].points += mp.win_points if mp else Decimal("1.0")
                     elif was_draw:
-                        stats[stage_item_input_id].points += mp.draw_points if mp else Decimal("0.5")
+                        stats[stage_item_input_id].points += (
+                            mp.draw_points if mp else Decimal("0.5")
+                        )
                     else:
-                        stats[stage_item_input_id].points += mp.loss_points if mp else Decimal("0.0")
+                        stats[stage_item_input_id].points += (
+                            mp.loss_points if mp else Decimal("0.0")
+                        )
 
                 case ScoringType.SET_POINTS:
                     stats[stage_item_input_id].points += Decimal(team_sets)
@@ -69,10 +73,12 @@ def set_statistics_for_stage_item_input(
                 case ScoringType.SET_POINTS_WITH_MATCH_BONUS:
                     stats[stage_item_input_id].points += Decimal(team_sets)
                     if has_won:
-                        assert ranking.set_points_with_bonus is not None
-                        stats[
-                            stage_item_input_id
-                        ].points += ranking.set_points_with_bonus.match_bonus_points
+                        # Subtype row should always exist for this scoring type, but fall back to
+                        # the model default bonus rather than crashing if it is ever missing.
+                        bonus = ranking.set_points_with_bonus
+                        stats[stage_item_input_id].points += (
+                            bonus.match_bonus_points if bonus is not None else Decimal("1.0")
+                        )
 
         case StageType.SWISS:
             # Swiss ELO uses match_points.win/draw/loss or standard 1.0/0.5/0.0 for set-based types

--- a/backend/bracket/models/db/match.py
+++ b/backend/bracket/models/db/match.py
@@ -106,15 +106,19 @@ class Match(MatchInsertable):
         return derive_match_state(self.match_sets)
 
     @property
+    def completed_sets(self) -> list["MatchSet"]:
+        return [s for s in self.match_sets if s.state is MatchSetState.COMPLETED]
+
+    @property
     def sets_won_by_input1(self) -> int:
         return sum(
-            1 for s in self.match_sets if s.stage_item_input1_score > s.stage_item_input2_score
+            1 for s in self.completed_sets if s.stage_item_input1_score > s.stage_item_input2_score
         )
 
     @property
     def sets_won_by_input2(self) -> int:
         return sum(
-            1 for s in self.match_sets if s.stage_item_input2_score > s.stage_item_input1_score
+            1 for s in self.completed_sets if s.stage_item_input2_score > s.stage_item_input1_score
         )
 
     def get_winner(self) -> StageItemInput | None:

--- a/backend/bracket/routes/rankings.py
+++ b/backend/bracket/routes/rankings.py
@@ -31,7 +31,7 @@ from bracket.sql.rankings import (
     sql_delete_ranking,
     sql_update_ranking,
 )
-from bracket.sql.stage_item_inputs import get_stage_item_input_ids_by_ranking_id
+from bracket.sql.stage_item_inputs import get_stage_item_ids_by_ranking_id
 from bracket.sql.stage_items import get_stage_item, get_stage_items_for_ranking
 from bracket.utils.id_types import RankingId, TournamentId
 
@@ -93,7 +93,7 @@ async def update_ranking_by_id(
         if ranking_body.num_sets != old_num_sets:
             await sql_resize_sets_for_ranking(ranking_id, old_num_sets, ranking_body.num_sets)
 
-        stage_item_ids = await get_stage_item_input_ids_by_ranking_id(ranking_id)
+        stage_item_ids = await get_stage_item_ids_by_ranking_id(ranking_id)
         for stage_item_id in stage_item_ids:
             stage_item = await get_stage_item(tournament_id, stage_item_id)
             await recalculate_ranking_for_stage_item(tournament_id, stage_item)

--- a/backend/bracket/sql/match_sets.py
+++ b/backend/bracket/sql/match_sets.py
@@ -67,15 +67,21 @@ async def sql_update_match_set(match_set_id: MatchSetId, body: MatchSetBody) -> 
 async def sql_add_trailing_sets(
     match_id: MatchId, from_set_number: int, to_set_number: int
 ) -> None:
-    for set_number in range(from_set_number, to_set_number + 1):
-        await database.execute(
-            query="""
-                INSERT INTO match_sets (match_id, set_number, state)
-                VALUES (:match_id, :set_number, 'NOT_STARTED')
-                ON CONFLICT (match_id, set_number) DO NOTHING
-            """,
-            values={"match_id": match_id, "set_number": set_number},
-        )
+    # Single multi-row insert (via generate_series) so a resize stays one round-trip per match,
+    # matching how sql_create_match_sets pre-populates sets at match creation.
+    await database.execute(
+        query="""
+            INSERT INTO match_sets (match_id, set_number, state)
+            SELECT :match_id, set_number, 'NOT_STARTED'
+            FROM generate_series(:from_set_number, :to_set_number) AS set_number
+            ON CONFLICT (match_id, set_number) DO NOTHING
+        """,
+        values={
+            "match_id": match_id,
+            "from_set_number": from_set_number,
+            "to_set_number": to_set_number,
+        },
+    )
 
 
 async def sql_delete_trailing_sets(match_id: MatchId, keep_up_to_set_number: int) -> None:

--- a/backend/bracket/sql/stage_item_inputs.py
+++ b/backend/bracket/sql/stage_item_inputs.py
@@ -37,7 +37,7 @@ async def get_stage_item_input_by_id(
     return TypeAdapter(StageItemInput).validate_python(result)
 
 
-async def get_stage_item_input_ids_by_ranking_id(ranking_id: RankingId) -> list[StageItemId]:
+async def get_stage_item_ids_by_ranking_id(ranking_id: RankingId) -> list[StageItemId]:
     query = """
         SELECT id
         FROM stage_items

--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -440,9 +440,6 @@ export function ScoreTrackingMatchView({
     const isLastSet = set.set_number === numSets;
     const endDisabled = isSaving || isEndSetDisabled(set, match, isSwapped);
 
-    const setScore1 = isSwapped ? set.stage_item_input2_score : set.stage_item_input1_score;
-    const setScore2 = isSwapped ? set.stage_item_input1_score : set.stage_item_input2_score;
-
     const teamDisplayScores = displayedTeams.map((team) =>
       team.slot === 1
         ? isSwapped


### PR DESCRIPTION
- Compare match-set state by enum identity (MatchSetState.COMPLETED) instead
  of a stringly `.state.value == "COMPLETED"` check, via a shared
  `Match.completed_sets` property.
- Base `sets_won_by_input1/2` on completed sets only, so set-difference and
  point-difference are derived from the same set basis.
- Replace the `assert` on the SET_POINTS_WITH_MATCH_BONUS subtype row with a
  graceful fallback to the model default bonus.
- Rename `get_stage_item_input_ids_by_ranking_id` to
  `get_stage_item_ids_by_ranking_id` (it returns stage item ids).
- Resize set rows with a single bulk insert (generate_series) instead of one
  insert per set, matching match-creation pre-population.
- Remove dead `setScore1`/`setScore2` locals in the score-tracking view.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CL9tXNE35NFv4hqZ6FuecC