### PR TITLE
Use a single default ranking for all levels

### DIFF
--- a/backend/bracket/routes/stage_items.py
+++ b/backend/bracket/routes/stage_items.py
@@ -55,7 +55,7 @@ from bracket.sql.stage_items import (
     get_stage_item,
     sql_create_stage_item_with_empty_inputs,
 )
-from bracket.sql.rankings import get_default_ranking_for_stage, get_ranking_by_id
+from bracket.sql.rankings import get_default_ranking, get_ranking_by_id
 from bracket.sql.stages import get_full_tournament_details
 from bracket.sql.tournaments import sql_get_tournament
 from bracket.sql.validation import check_foreign_keys_belong_to_tournament
@@ -488,7 +488,7 @@ async def create_stage_item(
         if stage_body.ranking_id is not None:
             ranking = await get_ranking_by_id(tournament_id, stage_body.ranking_id)
         else:
-            ranking = await get_default_ranking_for_stage(tournament_id, stage_body.stage_id)
+            ranking = await get_default_ranking(tournament_id)
         if ranking is not None and ranking.num_sets % 2 == 0:
             raise HTTPException(
                 status_code=422,

--- a/backend/bracket/routes/tournaments.py
+++ b/backend/bracket/routes/tournaments.py
@@ -213,12 +213,9 @@ async def create_tournament(
 
         if tournament_to_insert.levels:
             for position, level_name in enumerate(tournament_to_insert.levels):
-                level = await sql_create_level(tournament_id, level_name, position)
-                await sql_create_ranking(
-                    tournament_id, RankingMatchPointsBody(), position=0, level_id=level.id
-                )
-        else:
-            await sql_create_ranking(tournament_id, RankingMatchPointsBody(), position=0)
+                await sql_create_level(tournament_id, level_name, position)
+
+        await sql_create_ranking(tournament_id, RankingMatchPointsBody(), position=0)
 
     return SuccessResponse()
 

--- a/backend/bracket/sql/rankings.py
+++ b/backend/bracket/sql/rankings.py
@@ -13,7 +13,7 @@ from bracket.models.db.ranking import (
     RankingSetPointsWithMatchBonusData,
     ScoringType,
 )
-from bracket.utils.id_types import LevelId, RankingId, StageId, StageItemId, TournamentId
+from bracket.utils.id_types import LevelId, RankingId, StageItemId, TournamentId
 
 # Common SELECT fragment that LEFT JOINs all three subtype tables
 _RANKING_SELECT = """
@@ -66,21 +66,17 @@ async def get_all_rankings_in_tournament(tournament_id: TournamentId) -> list[Ra
     return [_row_to_ranking(row) for row in rows]
 
 
-async def get_default_ranking_for_stage(tournament_id: TournamentId, stage_id: StageId) -> Ranking:
+async def get_default_ranking(tournament_id: TournamentId) -> Ranking:
     query = (
         _RANKING_SELECT
         + """
-        JOIN stages ON stages.id = :stage_id
         WHERE r.tournament_id = :tournament_id
-          AND r.level_id IS NOT DISTINCT FROM stages.level_id
         ORDER BY r.position
         LIMIT 1
         """
     )
-    result = await database.fetch_one(
-        query=query, values={"tournament_id": tournament_id, "stage_id": stage_id}
-    )
-    assert result is not None, "No default ranking found for stage"
+    result = await database.fetch_one(query=query, values={"tournament_id": tournament_id})
+    assert result is not None, "No default ranking found for tournament"
     return _row_to_ranking(result)
 
 

--- a/backend/bracket/sql/stage_items.py
+++ b/backend/bracket/sql/stage_items.py
@@ -5,7 +5,7 @@ from bracket.database import database
 from bracket.models.db.stage_item import StageItem, StageItemCreateBody, StageItemWithInputsCreate
 from bracket.models.db.stage_item_inputs import StageItemInputCreateBodyEmpty
 from bracket.models.db.util import StageItemWithRounds
-from bracket.sql.rankings import get_default_ranking_for_stage
+from bracket.sql.rankings import get_default_ranking
 from bracket.sql.stage_item_inputs import sql_create_stage_item_input
 from bracket.sql.stages import get_full_tournament_details
 from bracket.utils.id_types import RankingId, StageItemId, TournamentId
@@ -28,7 +28,7 @@ async def sql_create_stage_item(
             "team_count": stage_item.team_count,
             "ranking_id": stage_item.ranking_id
             if stage_item.ranking_id
-            else (await get_default_ranking_for_stage(tournament_id, stage_item.stage_id)).id,
+            else (await get_default_ranking(tournament_id)).id,
             "games_per_player": stage_item.games_per_player,
         },
     )

--- a/backend/tests/integration_tests/api/per_level_rankings_test.py
+++ b/backend/tests/integration_tests/api/per_level_rankings_test.py
@@ -39,7 +39,7 @@ def _create_body(endpoint: str, club_id: int, levels: list[str] | None = None) -
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_tournament_with_levels_creates_one_default_ranking_per_level(
+async def test_tournament_with_levels_creates_a_single_default_ranking(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:
     endpoint = "per-level-rankings-create"
@@ -50,53 +50,18 @@ async def test_tournament_with_levels_creates_one_default_ranking_per_level(
     )
 
     tournament = assert_some(await sql_get_tournament_by_endpoint_name(endpoint))
-    tournament_response = await send_auth_request(
-        HTTPMethod.GET, f"tournaments/{tournament.id}", auth_context
-    )
-    levels_by_name = {lvl["name"]: lvl for lvl in tournament_response["data"]["levels"]}
 
     rankings = await get_all_rankings_in_tournament(tournament.id)
-    assert len(rankings) == 2
-
-    rankings_by_level = {r.level_id: r for r in rankings}
-    assert rankings_by_level.keys() == {
-        levels_by_name["Beginners"]["id"],
-        levels_by_name["Advanced"]["id"],
-    }
-    for ranking in rankings:
-        assert ranking.position == 0
+    assert len(rankings) == 1
+    [ranking] = rankings
+    assert ranking.position == 0
+    assert ranking.level_id is None
 
     await sql_delete_tournament_completely(tournament.id)
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_rankings_api_response_includes_level_id(
-    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
-) -> None:
-    endpoint = "per-level-rankings-api"
-    body = _create_body(endpoint, auth_context.club.id, levels=["Beginners", "Advanced"])
-    assert (
-        await send_auth_request(HTTPMethod.POST, "tournaments", auth_context, json=body)
-        == SUCCESS_RESPONSE
-    )
-
-    tournament = assert_some(await sql_get_tournament_by_endpoint_name(endpoint))
-    tournament_response = await send_auth_request(
-        HTTPMethod.GET, f"tournaments/{tournament.id}", auth_context
-    )
-    level_ids = {lvl["id"] for lvl in tournament_response["data"]["levels"]}
-
-    temp_context = auth_context.model_copy(update={"tournament": tournament})
-    rankings_response = await send_tournament_request(HTTPMethod.GET, "rankings", temp_context)
-
-    response_level_ids = {r["level_id"] for r in rankings_response["data"]}
-    assert response_level_ids == level_ids
-
-    await sql_delete_tournament_completely(tournament.id)
-
-
-@pytest.mark.asyncio(loop_scope="session")
-async def test_stage_item_defaults_to_its_levels_ranking(
+async def test_stage_item_defaults_to_the_single_default_ranking(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:
     endpoint = "per-level-rankings-stageitem-default"
@@ -114,7 +79,7 @@ async def test_stage_item_defaults_to_its_levels_ranking(
     advanced_level_id = next(lvl["id"] for lvl in levels if lvl["name"] == "Advanced")
 
     rankings = await get_all_rankings_in_tournament(tournament.id)
-    advanced_ranking = next(r for r in rankings if r.level_id == advanced_level_id)
+    [default_ranking] = rankings
 
     temp_context = auth_context.model_copy(update={"tournament": tournament})
     assert (
@@ -144,7 +109,7 @@ async def test_stage_item_defaults_to_its_levels_ranking(
 
     [stage_after] = await get_full_tournament_details(tournament.id)
     [stage_item] = stage_after.stage_items
-    assert stage_item.ranking_id == advanced_ranking.id
+    assert stage_item.ranking_id == default_ranking.id
 
     await sql_delete_tournament_completely(tournament.id)
 

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -93,7 +93,6 @@
     "default_label": "Standard",
     "default_pause_duration_button": "Standard-Pausendauer",
     "default_ranking_badge": "Standard Rangliste",
-    "default_ranking_badge_with_level": "Level {{name}} Standard",
     "details_button": "Details",
     "delete_button": "Löschen",
     "delete_club_button": "Verein löschen",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -93,7 +93,6 @@
     "default_label": "Default",
     "default_pause_duration_button": "Default pause duration",
     "default_ranking_badge": "Default Ranking",
-    "default_ranking_badge_with_level": "Level {{name}} Default",
     "details_button": "Details",
     "delete_button": "Delete",
     "delete_club_button": "Delete Club",

--- a/frontend/src/pages/tournaments/[id]/rankings.tsx
+++ b/frontend/src/pages/tournaments/[id]/rankings.tsx
@@ -42,14 +42,9 @@ function RankingDeleteButton({
   swrRankingsResponse: SWRResponse<RankingsResponse>;
 }) {
   if (ranking.position === 0) {
-    const level = tournament.levels.find((l) => l.id === ranking.level_id);
     return (
       <Center ml="1rem" miw="10rem">
-        <Badge color="indigo">
-          {level != null
-            ? t('default_ranking_badge_with_level', { name: level.name })
-            : t('default_ranking_badge')}
-        </Badge>
+        <Badge color="indigo">{t('default_ranking_badge')}</Badge>
       </Center>
     );
   }


### PR DESCRIPTION
Previously a separate default ranking was created for each tournament
level. Now tournaments always start with one default ranking that is
used as the default for stage items regardless of level.

- create_tournament always creates a single default ranking
- get_default_ranking_for_stage -> get_default_ranking (no level match)
- rankings page badge now always reads "default ranking"
- drop the per-level "Level X Default" badge translation

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UnPuA2CXf623RZnboKhxEW