### PR TITLE
Resize match sets when a stage item's ranking changes

### DIFF
--- a/backend/bracket/routes/stage_items.py
+++ b/backend/bracket/routes/stage_items.py
@@ -37,10 +37,12 @@ from bracket.routes.auth import (
 )
 from bracket.routes.models import SuccessResponse
 from bracket.routes.util import disallow_archived_tournament, stage_item_dependency
+from bracket.sql.match_sets import sql_resize_sets_for_stage_item
 from bracket.sql.matches import (
     sql_create_match,
     sql_delete_matches,
 )
+from bracket.sql.rankings import get_default_ranking, get_ranking_by_id
 from bracket.sql.rounds import (
     get_next_round_name,
     sql_create_round,
@@ -55,7 +57,6 @@ from bracket.sql.stage_items import (
     get_stage_item,
     sql_create_stage_item_with_empty_inputs,
 )
-from bracket.sql.rankings import get_default_ranking, get_ranking_by_id
 from bracket.sql.stages import get_full_tournament_details
 from bracket.sql.tournaments import sql_get_tournament
 from bracket.sql.validation import check_foreign_keys_belong_to_tournament
@@ -519,16 +520,33 @@ async def update_stage_item(
 
     await check_foreign_keys_belong_to_tournament(stage_item_body, tournament_id)
     team_count_changed = stage_item_body.team_count != stage_item.team_count
+    ranking_changed = stage_item_body.ranking_id != stage_item.ranking_id
 
-    if stage_item.type is StageType.SINGLE_ELIMINATION and stage_item_body.ranking_id != stage_item.ranking_id:
-        ranking = await get_ranking_by_id(tournament_id, stage_item_body.ranking_id)
-        if ranking is not None and ranking.num_sets % 2 == 0:
+    new_ranking = (
+        await get_ranking_by_id(tournament_id, stage_item_body.ranking_id)
+        if stage_item_body.ranking_id is not None
+        else None
+    )
+
+    if stage_item.type is StageType.SINGLE_ELIMINATION and ranking_changed:
+        if new_ranking is not None and new_ranking.num_sets % 2 == 0:
             raise HTTPException(
                 status_code=422,
                 detail="Even number of sets is not supported for single elimination brackets.",
             )
 
     async with database.transaction():
+        # Reassigning a stage item to a ranking with a different set count must resize the set
+        # rows of its existing matches, mirroring how editing a ranking's num_sets resizes them.
+        if ranking_changed and new_ranking is not None:
+            old_ranking = (
+                await get_ranking_by_id(tournament_id, stage_item.ranking_id)
+                if stage_item.ranking_id is not None
+                else None
+            )
+            old_num_sets = old_ranking.num_sets if old_ranking is not None else 1
+            await sql_resize_sets_for_stage_item(stage_item_id, old_num_sets, new_ranking.num_sets)
+
         if stage_item_body.games_per_player is not None and stage_item.type is StageType.SWISS:
             await adjust_swiss_games_per_player(
                 tournament_id, stage_item_id, stage_item, stage_item_body.games_per_player

--- a/backend/bracket/sql/match_sets.py
+++ b/backend/bracket/sql/match_sets.py
@@ -1,6 +1,6 @@
 from bracket.database import database
 from bracket.models.db.match import MatchSet, MatchSetBody
-from bracket.utils.id_types import MatchId, MatchSetId, RankingId
+from bracket.utils.id_types import MatchId, MatchSetId, RankingId, StageItemId
 
 # SQL fragment that aggregates a match's sets into a JSON array, ordered by set number.
 # Correlates on the outer ``matches`` row, so callers must alias the matches table as ``matches``.
@@ -73,7 +73,9 @@ async def sql_add_trailing_sets(
         query="""
             INSERT INTO match_sets (match_id, set_number, state)
             SELECT :match_id, set_number, 'NOT_STARTED'
-            FROM generate_series(:from_set_number, :to_set_number) AS set_number
+            FROM generate_series(
+                CAST(:from_set_number AS integer), CAST(:to_set_number AS integer)
+            ) AS set_number
             ON CONFLICT (match_id, set_number) DO NOTHING
         """,
         values={
@@ -123,6 +125,28 @@ async def sql_ranking_has_active_sets(ranking_id: RankingId) -> bool:
     return bool(row._mapping["has_active"]) if row is not None else False
 
 
+async def sql_get_match_ids_for_stage_item(stage_item_id: StageItemId) -> list[MatchId]:
+    query = """
+        SELECT matches.id
+        FROM matches
+        JOIN rounds ON rounds.id = matches.round_id
+        WHERE rounds.stage_item_id = :stage_item_id
+        """
+    rows = await database.fetch_all(query=query, values={"stage_item_id": stage_item_id})
+    return [MatchId(row._mapping["id"]) for row in rows]
+
+
+async def _resize_sets_for_matches(
+    match_ids: list[MatchId], old_num_sets: int, new_num_sets: int
+) -> None:
+    """Add trailing NOT_STARTED sets or delete trailing sets for the given matches."""
+    for match_id in match_ids:
+        if new_num_sets > old_num_sets:
+            await sql_add_trailing_sets(match_id, old_num_sets + 1, new_num_sets)
+        else:
+            await sql_delete_trailing_sets(match_id, new_num_sets)
+
+
 async def sql_resize_sets_for_ranking(
     ranking_id: RankingId, old_num_sets: int, new_num_sets: int
 ) -> None:
@@ -131,8 +155,15 @@ async def sql_resize_sets_for_ranking(
         return
 
     match_ids = await sql_get_match_ids_for_ranking(ranking_id)
-    for match_id in match_ids:
-        if new_num_sets > old_num_sets:
-            await sql_add_trailing_sets(match_id, old_num_sets + 1, new_num_sets)
-        else:
-            await sql_delete_trailing_sets(match_id, new_num_sets)
+    await _resize_sets_for_matches(match_ids, old_num_sets, new_num_sets)
+
+
+async def sql_resize_sets_for_stage_item(
+    stage_item_id: StageItemId, old_num_sets: int, new_num_sets: int
+) -> None:
+    """Add trailing NOT_STARTED sets or delete trailing sets for every match of a stage item."""
+    if new_num_sets == old_num_sets:
+        return
+
+    match_ids = await sql_get_match_ids_for_stage_item(stage_item_id)
+    await _resize_sets_for_matches(match_ids, old_num_sets, new_num_sets)

--- a/backend/tests/integration_tests/api/stage_items_test.py
+++ b/backend/tests/integration_tests/api/stage_items_test.py
@@ -11,8 +11,12 @@ from bracket.models.db.stage_item_inputs import (
 from bracket.schema import match_sets, matches, rounds, stage_item_inputs, stage_items, stages
 from bracket.sql.stage_items import get_stage_item, sql_create_stage_item_with_inputs
 from bracket.sql.stages import get_full_tournament_details
+from bracket.sql.match_sets import get_sets_for_match
 from bracket.utils.dummy_records import (
+    DUMMY_COURT1,
+    DUMMY_MATCH1,
     DUMMY_RANKING1,
+    DUMMY_ROUND1,
     DUMMY_STAGE1,
     DUMMY_STAGE2,
     DUMMY_STAGE_ITEM1,
@@ -30,7 +34,10 @@ from tests.integration_tests.api.shared import (
 from tests.integration_tests.models import AuthContext
 from tests.integration_tests.sql import (
     assert_row_count_and_clear,
+    inserted_court,
+    inserted_match,
     inserted_ranking,
+    inserted_round,
     inserted_stage,
     inserted_stage_item,
     inserted_team,
@@ -525,3 +532,58 @@ async def test_update_stage_item_ranking_to_even_sets_single_elimination_returns
                 )
                 assert "detail" in response
                 assert "Even number of sets" in response["detail"]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_stage_item_ranking_resizes_match_sets(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Changing a stage item's ranking to one with a different num_sets resizes its match sets."""
+    tournament_id = auth_context.tournament.id
+    async with (
+        inserted_ranking(
+            DUMMY_RANKING1.model_copy(update={"tournament_id": tournament_id, "num_sets": 3})
+        ) as ranking_three_sets,
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
+        ) as stage,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item.id})
+        ) as round_inserted,
+        inserted_court(
+            DUMMY_COURT1.model_copy(update={"tournament_id": tournament_id})
+        ) as court_inserted,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_inserted.id,
+                    "court_id": court_inserted.id,
+                    "stage_item_input1_id": None,
+                    "stage_item_input2_id": None,
+                    "completed_at": None,
+                }
+            )
+        ) as match_inserted,
+    ):
+        # The match starts with a single set (matching the default ranking's num_sets=1).
+        assert len(await get_sets_for_match(match_inserted.id)) == 1
+
+        response = await send_tournament_request(
+            HTTPMethod.PUT,
+            f"stage_items/{stage_item.id}",
+            auth_context,
+            json={
+                "name": stage_item.name,
+                "ranking_id": ranking_three_sets.id,
+                "team_count": stage_item.team_count,
+            },
+        )
+        assert response == SUCCESS_RESPONSE
+
+        # The match should now carry three sets to match the newly assigned ranking.
+        assert len(await get_sets_for_match(match_inserted.id)) == 3

--- a/backend/tests/integration_tests/api/stage_items_test.py
+++ b/backend/tests/integration_tests/api/stage_items_test.py
@@ -9,9 +9,9 @@ from bracket.models.db.stage_item_inputs import (
     StageItemInputCreateBodyTentative,
 )
 from bracket.schema import match_sets, matches, rounds, stage_item_inputs, stage_items, stages
+from bracket.sql.match_sets import get_sets_for_match
 from bracket.sql.stage_items import get_stage_item, sql_create_stage_item_with_inputs
 from bracket.sql.stages import get_full_tournament_details
-from bracket.sql.match_sets import get_sets_for_match
 from bracket.utils.dummy_records import (
     DUMMY_COURT1,
     DUMMY_MATCH1,
@@ -544,9 +544,7 @@ async def test_update_stage_item_ranking_resizes_match_sets(
         inserted_ranking(
             DUMMY_RANKING1.model_copy(update={"tournament_id": tournament_id, "num_sets": 3})
         ) as ranking_three_sets,
-        inserted_stage(
-            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
-        ) as stage,
+        inserted_stage(DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})) as stage,
         inserted_stage_item(
             DUMMY_STAGE_ITEM1.model_copy(
                 update={"stage_id": stage.id, "ranking_id": auth_context.ranking.id}


### PR DESCRIPTION
## Problem

Editing a ranking's `num_sets` resizes the set rows of all affected matches (via `sql_resize_sets_for_ranking`). But reassigning a **stage item** to a *different* ranking whose set count differs never touched the matches' set rows — they stayed at the old ranking's set count. The mismatch only got corrected when the ranking itself was edited.

## Fix

- Extracted the per-match resize loop in `sql/match_sets.py` into a shared `_resize_sets_for_matches` helper, now used by both:
  - the existing `sql_resize_sets_for_ranking`, and
  - a new `sql_resize_sets_for_stage_item` (scopes matches via `rounds.stage_item_id`).
- Wired it into the `update_stage_item` route: when `ranking_id` changes, it looks up the old and new rankings' `num_sets` and resizes the stage item's match sets inside the existing transaction, mirroring the ranking-edit path.
- Added explicit `CAST(... AS integer)` to the `generate_series` call in `sql_add_trailing_sets` — without it PostgreSQL raised `function generate_series(unknown, unknown) is not unique` because the named parameters were bound as unknown types. This also unblocked the pre-existing ranking-resize test that hit the same error.

## Testing

- New integration test `test_update_stage_item_ranking_resizes_match_sets`: assigns a match's stage item to a ranking with a different set count and verifies the match's set rows are resized accordingly (written red-first via TDD).
- Full backend suite passes (427 tests).

## Notes

Unlike the ranking-edit endpoint, the stage-item update endpoint has no `force` flag, so shrinking the set count here drops trailing sets without a 409 guard even if they contain scores. Happy to add the same destructive-change protection if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAt5zvZuzmqRKkykwSuv1p)_