### PR TITLE
fix: per-set state labels and score reset in match details modal

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -333,6 +333,7 @@
     "set_label": "Satz {{number}}",
     "set_number_label": "Satz {{current}} von {{total}}",
     "set_ranking_for_stage_items_label": "Rangliste für alle Gruppen/Brackets festlegen",
+    "set_state_label": "Status von Satz {{number}}",
     "set_to_new_button": "Jetzt setzen",
     "sets_won_label": "Sätze gewonnen",
     "sign_in_title": "Anmelden",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -333,6 +333,7 @@
     "set_label": "Set {{number}}",
     "set_number_label": "Set {{current}} of {{total}}",
     "set_ranking_for_stage_items_label": "Set ranking for all stage items",
+    "set_state_label": "Set {{number}} state",
     "set_to_new_button": "Set To Now",
     "sets_won_label": "Sets Won",
     "sign_in_title": "Sign in",

--- a/frontend/src/components/modals/match_modal.tsx
+++ b/frontend/src/components/modals/match_modal.tsx
@@ -466,7 +466,11 @@ function MatchModalForm({
                 />
               </Group>
               <Select
-                label={t('match_state_label')}
+                label={
+                  form.values.sets.length > 1
+                    ? t('set_state_label', { number: set.set_number })
+                    : t('match_state_label')
+                }
                 data={[
                   { value: 'NOT_STARTED', label: t('match_state_not_started') },
                   { value: 'IN_PROGRESS', label: t('match_state_in_progress') },
@@ -476,6 +480,10 @@ function MatchModalForm({
                 onChange={(value) => {
                   if (value != null) {
                     form.setFieldValue(`sets.${index}.state`, value as SetFormValue['state']);
+                    if (value === 'NOT_STARTED') {
+                      form.setFieldValue(`sets.${index}.stage_item_input1_score`, 0);
+                      form.setFieldValue(`sets.${index}.stage_item_input2_score`, 0);
+                    }
                   }
                 }}
               />


### PR DESCRIPTION
When a match has multiple sets, the set state Select now reads
"Set N state" instead of the generic "Match state".

Restore the behaviour where switching a set back to "Not started"
resets that set's scores to 0:0, which was lost in the per-set refactor.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C9vj8FUyM76CJYKM97pboH