### PR TITLE
Prevent mobile auto-zoom on input focus

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1,0 +1,16 @@
+/*
+ * Prevent mobile browsers (notably iOS Safari) from auto-zooming the page when
+ * a form control is focused. Safari zooms in whenever the focused field has a
+ * font-size below 16px, and because iOS ignores `user-scalable=no` the page can
+ * get stuck zoomed in. Mantine's default input size renders at 14px, so bumping
+ * form controls to 16px on small screens removes the trigger at the source while
+ * keeping normal pinch-to-zoom available. `!important` is needed to win over
+ * Mantine's class-based input styles.
+ */
+@media (max-width: 47.99em) {
+  input:not([type='checkbox']):not([type='radio']),
+  select,
+  textarea {
+    font-size: 16px !important;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { I18nextProvider } from 'react-i18next';
 import { BrowserRouter, Route, Routes } from 'react-router';
+import './global.css';
 
 import i18n from '../i18n';
 import { BracketSpotlight } from './components/modals/spotlight';


### PR DESCRIPTION
Mobile Safari zooms the page in whenever a focused form control has a
font-size below 16px, and since iOS ignores user-scalable=no the page can
get stuck zoomed in. Mantine's default input size renders text at 14px, so
every input triggered this. Bump form controls to 16px on small screens to
remove the trigger while keeping normal pinch-to-zoom available.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Sk8cSmMbFtWKvuaQt6BdDu