### PR TITLE
Fix planning tray overlapping mobile side nav by raising navbar z-index

### DIFF
--- a/frontend/src/pages/_layout.tsx
+++ b/frontend/src/pages/_layout.tsx
@@ -110,7 +110,7 @@ export function HeaderAction({ links, navbarState, breadcrumbs }: HeaderActionPr
 
 function NavBar({ links }: any) {
   return (
-    <AppShell.Navbar p="md">
+    <AppShell.Navbar p="md" zIndex={200}>
       {links == null ? (
         <AppShell.Section grow>
           <div />


### PR DESCRIPTION
AppShell.Navbar defaulted to z-index 101 (Mantine's base 100 + 1), while
the fixed bottom tray (UnscheduledSheet) uses z-index 150. On mobile the
navbar slides in as an overlay, so it was rendered beneath the tray.

Setting zIndex={200} on AppShell.Navbar causes Mantine to compute
--app-shell-navbar-z-index as calc(200 + 1) = 201, which is above the
tray and ensures the nav renders on top when opened.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQ8hK4U57CBfPegpEZVq3M