### PR TITLE
Allow pinch-zoom while a modal or drawer is open

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import { MantineProvider, createTheme } from '@mantine/core';
+import { Drawer, MantineProvider, Modal, createTheme } from '@mantine/core';
 import '@mantine/core/styles.css';
 import '@mantine/dates/styles.css';
 import '@mantine/dropzone/styles.css';
@@ -61,6 +61,15 @@ const theme = createTheme({
       '#141517',
       '#101113',
     ],
+  },
+  components: {
+    // While a Modal or Drawer is open Mantine locks page scroll with
+    // react-remove-scroll, which by default also swallows pinch gestures
+    // (allowPinchZoom defaults to false). That left the page un-zoomable on
+    // mobile whenever e.g. the match details or edit-stage popup was open.
+    // Re-enable pinch zoom so accessibility zoom keeps working over modals.
+    Modal: Modal.extend({ defaultProps: { removeScrollProps: { allowPinchZoom: true } } }),
+    Drawer: Drawer.extend({ defaultProps: { removeScrollProps: { allowPinchZoom: true } } }),
   },
 });
 


### PR DESCRIPTION
## Problem

On mobile, once a Mantine `Modal` or `Drawer` was open (e.g. the match details popup or the edit-stage/edit-stage-item popup), the page could not be zoomed at all — pinch gestures did nothing.

## Cause

Mantine locks page scroll while a `Modal`/`Drawer` is open using [`react-remove-scroll`](https://github.com/theKashey/react-remove-scroll), whose `allowPinchZoom` prop defaults to `false`. With it disabled the scroll-lock intercepts and swallows multi-touch (pinch) gestures, so the browser's accessibility zoom is blocked for as long as the overlay is open.

## Fix

Re-enable `allowPinchZoom` via theme `defaultProps` for both `Modal` and `Drawer`, so it applies app-wide without touching each modal:

```ts
components: {
  Modal: Modal.extend({ defaultProps: { removeScrollProps: { allowPinchZoom: true } } }),
  Drawer: Drawer.extend({ defaultProps: { removeScrollProps: { allowPinchZoom: true } } }),
}
```

This is a follow-up to #217 (which stopped inputs auto-zooming on focus); that change is already merged, so this PR is scoped to just the pinch-zoom-over-modals behavior.

## Testing

- `pnpm run typecheck` ✅
- `pnpm run prettier:check` ✅
- `pnpm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk8cSmMbFtWKvuaQt6BdDu)_