### PR TITLE
Planning view: Edit mode

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -234,6 +234,7 @@
     "placement_conflict_preview_label": "Würde ein Team doppelt belegen",
     "plan_next_round_button": "Nächste Runde planen",
     "planner_mode_aria_label": "Planungsmodus",
+    "planner_mode_edit": "Bearbeiten",
     "planner_mode_move": "Verschieben",
     "planner_mode_unschedule": "Ausplanen",
     "planner_tools_title": "Planungswerkzeuge",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -234,6 +234,7 @@
     "placement_conflict_preview_label": "Would double-book a team",
     "plan_next_round_button": "Plan next round",
     "planner_mode_aria_label": "Planning mode",
+    "planner_mode_edit": "Edit",
     "planner_mode_move": "Move",
     "planner_mode_unschedule": "Unschedule",
     "planner_tools_title": "Planner tools",

--- a/frontend/src/logic/planning/selection.test.ts
+++ b/frontend/src/logic/planning/selection.test.ts
@@ -573,6 +573,38 @@ describe('plannerReducer', () => {
       expect(actions).toEqual([]);
     });
 
+    it('edit mode opens details for a planned match on tap', () => {
+      const { state, actions } = plannerReducer(planner('compact', IDLE_SELECTION, 'edit'), {
+        type: 'tap-match',
+        match: ref(10, 1, 0),
+      });
+
+      expect(state).toEqual(planner('compact', IDLE_SELECTION, 'edit'));
+      expect(actions).toEqual([{ type: 'open-details', matchId: 10 }]);
+    });
+
+    it('edit mode opens details for a tray match on tap', () => {
+      const { state, actions } = plannerReducer(planner('compact', IDLE_SELECTION, 'edit'), {
+        type: 'tap-tray-match',
+        matchId: 30,
+      });
+
+      expect(state).toEqual(planner('compact', IDLE_SELECTION, 'edit'));
+      expect(actions).toEqual([{ type: 'open-details', matchId: 30 }]);
+    });
+
+    it('edit mode opens details for played and locked planned matches', () => {
+      for (const match of [startedRef(10, 1, 0), playedRef(11, 1, 1), lockedRef(12, 1, 2)]) {
+        const { state, actions } = plannerReducer(planner('compact', IDLE_SELECTION, 'edit'), {
+          type: 'tap-match',
+          match,
+        });
+
+        expect(state).toEqual(planner('compact', IDLE_SELECTION, 'edit'));
+        expect(actions).toEqual([{ type: 'open-details', matchId: match.matchId }]);
+      }
+    });
+
     it('deselects on a second tap of the selected match', () => {
       const { state, actions } = plannerReducer(planner('agenda', selected(ref(10, 1, 2))), {
         type: 'tap-match',

--- a/frontend/src/logic/planning/selection.ts
+++ b/frontend/src/logic/planning/selection.ts
@@ -72,7 +72,8 @@ export type PlanningAction =
     }
   | { type: 'swap'; matchId1: number; matchId2: number }
   | { type: 'unschedule'; matchId: number }
-  | { type: 'resize-break'; matchId: number; newDurationMinutes: number };
+  | { type: 'resize-break'; matchId: number; newDurationMinutes: number }
+  | { type: 'open-details'; matchId: number };
 
 export interface SelectionTransition {
   state: SelectionState;
@@ -175,8 +176,20 @@ export function selectionReducer(
               actions: [{ type: 'unschedule', matchId: event.match.matchId }],
             };
           }
+          if (mode === 'edit') {
+            return {
+              state: IDLE_SELECTION,
+              actions: [{ type: 'open-details', matchId: event.match.matchId }],
+            };
+          }
           return stay({ kind: 'match-selected', match: event.match });
         case 'tap-tray-match':
+          if (mode === 'edit') {
+            return {
+              state: IDLE_SELECTION,
+              actions: [{ type: 'open-details', matchId: event.matchId }],
+            };
+          }
           return stay({ kind: 'tray-match-selected', matchId: event.matchId });
         default:
           return stay(state);
@@ -259,7 +272,7 @@ export interface PlannerState {
   selection: SelectionState;
 }
 
-const PLANNER_MODES = ['move', 'unschedule'] as const;
+const PLANNER_MODES = ['move', 'unschedule', 'edit'] as const;
 export type PlannerMode = (typeof PLANNER_MODES)[number];
 export function isPlannerMode(value: string): value is PlannerMode {
   return (PLANNER_MODES as readonly string[]).includes(value);

--- a/frontend/src/pages/tournaments/[id]/schedule.tsx
+++ b/frontend/src/pages/tournaments/[id]/schedule.tsx
@@ -386,6 +386,14 @@ export default function SchedulePage() {
       setFocus((previous) => ({ ...focusTarget, nonce: (previous?.nonce ?? 0) + 1 }));
     }
 
+    for (const action of actions) {
+      if (action.type === 'open-details') {
+        setDetailsMatchId(action.matchId);
+      }
+    }
+
+    const backendActions = actions.filter((action) => action.type !== 'open-details');
+
     const updateTrayOpened = () =>
       setTrayOpened((opened) =>
         nextTrayOpenedAfterPlannerEvent({
@@ -397,13 +405,13 @@ export default function SchedulePage() {
         })
       );
 
-    if (actions.length > 0) {
+    if (backendActions.length > 0) {
       try {
         // Show the predicted outcome immediately; the revalidation that follows the
         // request replaces it with the backend's authoritative schedule.
         await swrStagesResponse.mutate(
           async (current) => {
-            for (const action of actions) {
+            for (const action of backendActions) {
               await performAction(action);
             }
             return current;
@@ -416,7 +424,7 @@ export default function SchedulePage() {
                     ...current,
                     data: applyPlanningActions(
                       current.data,
-                      actions,
+                      backendActions,
                       tournament.start_time,
                       tournament.margin_minutes
                     ),
@@ -540,6 +548,23 @@ export default function SchedulePage() {
                 ) : (
                   <Text span size="sm">
                     {t('planner_mode_unschedule')}
+                  </Text>
+                )}
+              </Group>
+            </Tooltip>
+          ),
+        },
+        {
+          value: 'edit',
+          label: (
+            <Tooltip label={t('planner_mode_edit')} disabled={!isMobile}>
+              <Group gap={4} wrap="nowrap" justify="center" miw={isMobile ? 26 : undefined}>
+                <IconListDetails size={16} aria-hidden />
+                {isMobile ? (
+                  <VisuallyHidden>{t('planner_mode_edit')}</VisuallyHidden>
+                ) : (
+                  <Text span size="sm">
+                    {t('planner_mode_edit')}
                   </Text>
                 )}
               </Group>


### PR DESCRIPTION
## Summary

- Adds **Edit** as the third planning mode: tapping any match (grid or unscheduled tray) emits an `open-details` side effect that opens the existing match detail modal.
- Edit mode is ungated — played, in-progress, and locked matches open directly for score entry and referee assignment.
- Adds reducer tests and en/de i18n for the new segment.

Closes #232

## Test plan

- [x] `pnpm exec vitest run src/logic/planning/selection.test.ts` — 66 tests pass
- [x] `pnpm run typecheck`
- [ ] On the planning page, select **Edit** in the mode control
- [ ] Tap a scheduled match → match detail modal opens (no selection pill)
- [ ] Tap an unscheduled tray match → same modal opens
- [ ] Tap a completed/in-progress match → modal still opens


Made with [Cursor](https://cursor.com)