### PR TITLE
Make invalid set ordering unrepresentable: pointer model behind existing API

### DIFF
--- a/backend/alembic/versions/b4e8f2a1c9d7_match_set_pointer.py
+++ b/backend/alembic/versions/b4e8f2a1c9d7_match_set_pointer.py
@@ -1,0 +1,105 @@
+"""Match set progress pointer on matches
+
+Revision ID: b4e8f2a1c9d7
+Revises: 1f6b8c9d2e4a
+Create Date: 2026-06-29 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str | None = "b4e8f2a1c9d7"
+down_revision: str | None = "1f6b8c9d2e4a"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "matches",
+        sa.Column("completed_set_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "matches",
+        sa.Column(
+            "current_set_in_progress",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.create_check_constraint(
+        "matches_completed_set_count_non_negative",
+        "matches",
+        "completed_set_count >= 0",
+    )
+
+    op.execute(
+        """
+        UPDATE matches m
+        SET
+            completed_set_count = stats.completed_count,
+            current_set_in_progress = stats.in_progress
+        FROM (
+            SELECT
+                ms.match_id,
+                COALESCE(
+                    MAX(ms.set_number) FILTER (WHERE ms.state = 'COMPLETED'),
+                    0
+                ) AS completed_count,
+                EXISTS (
+                    SELECT 1
+                    FROM match_sets ms2
+                    WHERE ms2.match_id = ms.match_id
+                      AND ms2.state = 'IN_PROGRESS'
+                      AND ms2.set_number > COALESCE(
+                          MAX(ms.set_number) FILTER (WHERE ms.state = 'COMPLETED'),
+                          0
+                      )
+                ) AS in_progress
+            FROM match_sets ms
+            GROUP BY ms.match_id
+        ) stats
+        WHERE m.id = stats.match_id
+        """
+    )
+
+    op.drop_column("match_sets", "state")
+    op.execute("DROP TYPE IF EXISTS match_set_state")
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "CREATE TYPE match_set_state AS ENUM ('NOT_STARTED', 'IN_PROGRESS', 'COMPLETED')"
+        )
+    )
+    op.add_column(
+        "match_sets",
+        sa.Column(
+            "state",
+            sa.Enum("NOT_STARTED", "IN_PROGRESS", "COMPLETED", name="match_set_state"),
+            nullable=False,
+            server_default="NOT_STARTED",
+        ),
+    )
+
+    op.execute(
+        """
+        UPDATE match_sets ms
+        SET state = CASE
+            WHEN ms.set_number <= m.completed_set_count THEN 'COMPLETED'
+            WHEN ms.set_number = m.completed_set_count + 1
+                 AND m.current_set_in_progress THEN 'IN_PROGRESS'
+            ELSE 'NOT_STARTED'
+        END::match_set_state
+        FROM matches m
+        WHERE ms.match_id = m.id
+        """
+    )
+
+    op.drop_constraint("matches_completed_set_count_non_negative", "matches", type_="check")
+    op.drop_column("matches", "current_set_in_progress")
+    op.drop_column("matches", "completed_set_count")

--- a/backend/bracket/logic/match_sets/pointer.py
+++ b/backend/bracket/logic/match_sets/pointer.py
@@ -1,0 +1,62 @@
+from bracket.models.db.match import MatchSetState, MatchState
+
+
+class IllegalSetTransitionError(ValueError):
+    pass
+
+
+def derive_set_state(
+    set_number: int, completed_set_count: int, current_set_in_progress: bool
+) -> MatchSetState:
+    if set_number <= completed_set_count:
+        return MatchSetState.COMPLETED
+    if set_number == completed_set_count + 1 and current_set_in_progress:
+        return MatchSetState.IN_PROGRESS
+    return MatchSetState.NOT_STARTED
+
+
+def derive_match_state_from_pointer(
+    completed_set_count: int, num_sets: int, current_set_in_progress: bool
+) -> MatchState:
+    if completed_set_count == 0 and not current_set_in_progress:
+        return MatchState.NOT_STARTED
+    if completed_set_count >= num_sets:
+        return MatchState.COMPLETED
+    return MatchState.IN_PROGRESS
+
+
+def apply_pointer_transition(
+    completed_set_count: int,
+    current_set_in_progress: bool,
+    set_number: int,
+    target_state: MatchSetState,
+) -> tuple[int, bool]:
+    """Return updated (completed_set_count, current_set_in_progress) for a set state change."""
+    current_state = derive_set_state(set_number, completed_set_count, current_set_in_progress)
+    if target_state == current_state:
+        return completed_set_count, current_set_in_progress
+
+    if target_state == MatchSetState.IN_PROGRESS:
+        if set_number == completed_set_count and not current_set_in_progress:
+            return completed_set_count - 1, True
+        if set_number == completed_set_count + 1 and not current_set_in_progress:
+            return completed_set_count, True
+        raise IllegalSetTransitionError(
+            "Cannot update set state: sets must be completed in order"
+        )
+
+    if target_state == MatchSetState.COMPLETED:
+        if set_number == completed_set_count + 1:
+            return completed_set_count + 1, False
+        raise IllegalSetTransitionError(
+            "Cannot update set state: sets must be completed in order"
+        )
+
+    if target_state == MatchSetState.NOT_STARTED:
+        if set_number == completed_set_count + 1 and current_set_in_progress:
+            return completed_set_count, False
+        raise IllegalSetTransitionError(
+            "Cannot update set state: sets must be completed in order"
+        )
+
+    raise IllegalSetTransitionError("Cannot update set state: sets must be completed in order")

--- a/backend/bracket/models/db/match.py
+++ b/backend/bracket/models/db/match.py
@@ -44,6 +44,10 @@ class MatchSet(BaseModelORM):
 def derive_match_state(sets: list["MatchSet"]) -> MatchState:
     """Derive a match's overall state from the states of its sets.
 
+    Set states are derived positionally from the match progress pointer at read time,
+    so this reflects the pointer invariant: a contiguous COMPLETED prefix, at most one
+    IN_PROGRESS set, then NOT_STARTED.
+
     - all sets NOT_STARTED (or no sets) -> NOT_STARTED
     - all sets COMPLETED -> COMPLETED
     - anything else (any IN_PROGRESS, or a mix of COMPLETED and NOT_STARTED) -> IN_PROGRESS

--- a/backend/bracket/routes/match_sets.py
+++ b/backend/bracket/routes/match_sets.py
@@ -4,6 +4,7 @@ from starlette import status
 
 from bracket.config import config
 from bracket.database import database
+from bracket.logic.match_sets.pointer import IllegalSetTransitionError
 from bracket.logic.ranking.calculation import recalculate_ranking_for_stage_item
 from bracket.logic.ranking.elimination import update_inputs_in_subsequent_elimination_rounds
 from bracket.logic.scheduling.handle_stage_activation import (
@@ -75,7 +76,13 @@ async def update_match_set_and_recalculate(
     # recalculations must be atomic, so a failure can't leave the score and the derived
     # state out of sync.
     async with database.transaction():
-        await sql_update_match_set(match_set_id, body)
+        try:
+            await sql_update_match_set(match.id, match_set_id, body)
+        except IllegalSetTransitionError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(exc),
+            ) from exc
 
         # completed_at side effect: set when the match becomes completed, clear when it reverts.
         if new_state is MatchState.COMPLETED and match.completed_at is None:

--- a/backend/bracket/schema.py
+++ b/backend/bracket/schema.py
@@ -184,10 +184,13 @@ matches = Table(
     Column("input1_slot", Integer, nullable=True),
     Column("input2_slot", Integer, nullable=True),
     Column("referee_slot", Integer, nullable=True),
+    Column("completed_set_count", Integer, nullable=False, server_default="0"),
+    Column("current_set_in_progress", Boolean, nullable=False, server_default="f"),
     CheckConstraint(
         "referee_stage_item_input_id IS NULL OR referee_name IS NULL",
         name="matches_at_most_one_referee",
     ),
+    CheckConstraint("completed_set_count >= 0", name="matches_completed_set_count_non_negative"),
 )
 
 match_sets = Table(
@@ -204,17 +207,6 @@ match_sets = Table(
     Column("set_number", Integer, nullable=False),
     Column("stage_item_input1_score", Integer, nullable=False, server_default="0"),
     Column("stage_item_input2_score", Integer, nullable=False, server_default="0"),
-    Column(
-        "state",
-        Enum(
-            "NOT_STARTED",
-            "IN_PROGRESS",
-            "COMPLETED",
-            name="match_set_state",
-        ),
-        nullable=False,
-        server_default="NOT_STARTED",
-    ),
     UniqueConstraint("match_id", "set_number"),
 )
 

--- a/backend/bracket/sql/match_sets.py
+++ b/backend/bracket/sql/match_sets.py
@@ -1,12 +1,56 @@
 from bracket.database import database
+from bracket.logic.match_sets.pointer import (
+    IllegalSetTransitionError,
+    apply_pointer_transition,
+)
 from bracket.models.db.match import MatchSet, MatchSetBody
 from bracket.utils.id_types import MatchId, MatchSetId, RankingId, StageItemId
 
+_MATCH_SET_STATE_CASE_OUTER = """
+    CASE
+        WHEN ms.set_number <= matches.completed_set_count THEN 'COMPLETED'
+        WHEN ms.set_number = matches.completed_set_count + 1
+             AND matches.current_set_in_progress THEN 'IN_PROGRESS'
+        ELSE 'NOT_STARTED'
+    END
+"""
+
+_MATCH_SET_STATE_CASE_JOINED = """
+    CASE
+        WHEN ms.set_number <= m.completed_set_count THEN 'COMPLETED'
+        WHEN ms.set_number = m.completed_set_count + 1
+             AND m.current_set_in_progress THEN 'IN_PROGRESS'
+        ELSE 'NOT_STARTED'
+    END
+"""
+
+_MATCH_SET_COLUMNS = f"""
+    ms.id,
+    ms.match_id,
+    ms.set_number,
+    ms.stage_item_input1_score,
+    ms.stage_item_input2_score,
+    {_MATCH_SET_STATE_CASE_JOINED} AS state
+"""
+
 # SQL fragment that aggregates a match's sets into a JSON array, ordered by set number.
 # Correlates on the outer ``matches`` row, so callers must alias the matches table as ``matches``.
-MATCH_SETS_SUBQUERY = """
+MATCH_SETS_SUBQUERY = f"""
     (
-        SELECT COALESCE(json_agg(ms.* ORDER BY ms.set_number), '[]'::json)
+        SELECT COALESCE(
+            json_agg(
+                json_build_object(
+                    'id', ms.id,
+                    'match_id', ms.match_id,
+                    'set_number', ms.set_number,
+                    'stage_item_input1_score', ms.stage_item_input1_score,
+                    'stage_item_input2_score', ms.stage_item_input2_score,
+                    'state', {_MATCH_SET_STATE_CASE_OUTER}
+                )
+                ORDER BY ms.set_number
+            ),
+            '[]'::json
+        )
         FROM match_sets ms
         WHERE ms.match_id = matches.id
     ) AS match_sets
@@ -14,17 +58,24 @@ MATCH_SETS_SUBQUERY = """
 
 
 async def get_sets_for_match(match_id: MatchId) -> list[MatchSet]:
-    query = """
-        SELECT * FROM match_sets
-        WHERE match_id = :match_id
-        ORDER BY set_number
+    query = f"""
+        SELECT {_MATCH_SET_COLUMNS}
+        FROM match_sets ms
+        JOIN matches m ON m.id = ms.match_id
+        WHERE ms.match_id = :match_id
+        ORDER BY ms.set_number
         """
     rows = await database.fetch_all(query=query, values={"match_id": match_id})
     return [MatchSet.model_validate(dict(row._mapping)) for row in rows]
 
 
 async def sql_get_match_set(match_set_id: MatchSetId) -> MatchSet | None:
-    query = "SELECT * FROM match_sets WHERE id = :match_set_id"
+    query = f"""
+        SELECT {_MATCH_SET_COLUMNS}
+        FROM match_sets ms
+        JOIN matches m ON m.id = ms.match_id
+        WHERE ms.id = :match_set_id
+    """
     row = await database.fetch_one(query=query, values={"match_set_id": match_set_id})
     return MatchSet.model_validate(dict(row._mapping)) if row is not None else None
 
@@ -37,31 +88,79 @@ async def sql_create_match_sets(match_id: MatchId, num_sets: int) -> None:
     """
     await database.execute(
         query="""
-            INSERT INTO match_sets (match_id, set_number, state)
-            SELECT :match_id, set_number, 'NOT_STARTED'
+            INSERT INTO match_sets (match_id, set_number)
+            SELECT :match_id, set_number
             FROM generate_series(1, CAST(:num_sets AS integer)) AS set_number
         """,
         values={"match_id": match_id, "num_sets": max(num_sets, 1)},
     )
 
 
-async def sql_update_match_set(match_set_id: MatchSetId, body: MatchSetBody) -> None:
-    query = """
-        UPDATE match_sets
-        SET stage_item_input1_score = :stage_item_input1_score,
-            stage_item_input2_score = :stage_item_input2_score,
-            state = :state
-        WHERE id = :match_set_id
-        """
+async def sql_update_match_set(
+    match_id: MatchId, match_set_id: MatchSetId, body: MatchSetBody
+) -> None:
+    """Atomically update set scores and advance the match progress pointer."""
+    lock_row = await database.fetch_one(
+        query="""
+            SELECT
+                m.completed_set_count,
+                m.current_set_in_progress,
+                ms.set_number
+            FROM matches m
+            JOIN match_sets ms ON ms.match_id = m.id
+            WHERE m.id = :match_id AND ms.id = :match_set_id
+            FOR UPDATE OF m
+        """,
+        values={"match_id": match_id, "match_set_id": match_set_id},
+    )
+    if lock_row is None:
+        raise ValueError(f"Could not find set {match_set_id} for match {match_id}")
+
+    completed_set_count = int(lock_row._mapping["completed_set_count"])
+    current_set_in_progress = bool(lock_row._mapping["current_set_in_progress"])
+    set_number = int(lock_row._mapping["set_number"])
+
+    try:
+        new_completed, new_in_progress = apply_pointer_transition(
+            completed_set_count,
+            current_set_in_progress,
+            set_number,
+            body.state,
+        )
+    except IllegalSetTransitionError:
+        raise
+
     await database.execute(
-        query=query,
+        query="""
+            UPDATE match_sets
+            SET stage_item_input1_score = :stage_item_input1_score,
+                stage_item_input2_score = :stage_item_input2_score
+            WHERE id = :match_set_id
+        """,
         values={
             "match_set_id": match_set_id,
             "stage_item_input1_score": body.stage_item_input1_score,
             "stage_item_input2_score": body.stage_item_input2_score,
-            "state": body.state.value,
         },
     )
+
+    if (
+        new_completed != completed_set_count
+        or new_in_progress != current_set_in_progress
+    ):
+        await database.execute(
+            query="""
+                UPDATE matches
+                SET completed_set_count = :completed_set_count,
+                    current_set_in_progress = :current_set_in_progress
+                WHERE id = :match_id
+            """,
+            values={
+                "match_id": match_id,
+                "completed_set_count": new_completed,
+                "current_set_in_progress": new_in_progress,
+            },
+        )
 
 
 async def sql_add_trailing_sets(
@@ -71,8 +170,8 @@ async def sql_add_trailing_sets(
     # matching how sql_create_match_sets pre-populates sets at match creation.
     await database.execute(
         query="""
-            INSERT INTO match_sets (match_id, set_number, state)
-            SELECT :match_id, set_number, 'NOT_STARTED'
+            INSERT INTO match_sets (match_id, set_number)
+            SELECT :match_id, set_number
             FROM generate_series(
                 CAST(:from_set_number AS integer), CAST(:to_set_number AS integer)
             ) AS set_number
@@ -94,6 +193,18 @@ async def sql_delete_trailing_sets(match_id: MatchId, keep_up_to_set_number: int
         """,
         values={"match_id": match_id, "keep_up_to": keep_up_to_set_number},
     )
+    await database.execute(
+        query="""
+            UPDATE matches
+            SET completed_set_count = LEAST(completed_set_count, :keep_up_to),
+                current_set_in_progress = CASE
+                    WHEN completed_set_count >= :keep_up_to THEN FALSE
+                    ELSE current_set_in_progress
+                END
+            WHERE id = :match_id
+        """,
+        values={"match_id": match_id, "keep_up_to": keep_up_to_set_number},
+    )
 
 
 async def sql_get_match_ids_for_ranking(ranking_id: RankingId) -> list[MatchId]:
@@ -109,16 +220,18 @@ async def sql_get_match_ids_for_ranking(ranking_id: RankingId) -> list[MatchId]:
 
 
 async def sql_ranking_has_active_sets(ranking_id: RankingId) -> bool:
-    """True if any match under this ranking has a set that is IN_PROGRESS or COMPLETED."""
+    """True if any match under this ranking has started or completed at least one set."""
     query = """
         SELECT EXISTS (
             SELECT 1
-            FROM match_sets ms
-            JOIN matches ON matches.id = ms.match_id
+            FROM matches
             JOIN rounds ON rounds.id = matches.round_id
             JOIN stage_items ON stage_items.id = rounds.stage_item_id
             WHERE stage_items.ranking_id = :ranking_id
-              AND ms.state IN ('IN_PROGRESS', 'COMPLETED')
+              AND (
+                  matches.completed_set_count > 0
+                  OR matches.current_set_in_progress
+              )
         ) AS has_active
         """
     row = await database.fetch_one(query=query, values={"ranking_id": ranking_id})

--- a/backend/bracket/sql/tournament_issues.py
+++ b/backend/bracket/sql/tournament_issues.py
@@ -101,12 +101,10 @@ async def get_tournament_issues(
         AND matches.start_time IS NOT NULL
         AND matches.start_time + matches.duration_minutes * INTERVAL '1 minute' < :current_time
         AND (
-            EXISTS (
-                SELECT 1
-                FROM match_sets
-                WHERE match_sets.match_id = matches.id
-                AND match_sets.state <> 'COMPLETED'
+            matches.completed_set_count < (
+                SELECT count(*) FROM match_sets WHERE match_sets.match_id = matches.id
             )
+            OR matches.current_set_in_progress
             OR NOT EXISTS (
                 SELECT 1
                 FROM match_sets
@@ -128,12 +126,8 @@ async def get_tournament_issues(
         AND matches.start_time IS NOT NULL
         AND matches.start_time < :current_time
         AND matches.start_time + matches.duration_minutes * INTERVAL '1 minute' >= :current_time
-        AND NOT EXISTS (
-            SELECT 1
-            FROM match_sets
-            WHERE match_sets.match_id = matches.id
-            AND match_sets.state <> 'NOT_STARTED'
-        )
+        AND matches.completed_set_count = 0
+        AND NOT matches.current_set_in_progress
         """,
         tournament_id,
         {"current_time": current_time},

--- a/backend/bracket/utils/db_init.py
+++ b/backend/bracket/utils/db_init.py
@@ -479,6 +479,7 @@ async def apply_match_states(tournament_id: TournamentId) -> None:
         match_id = assert_some(match.id)
         for match_set in await get_sets_for_match(match_id):
             await sql_update_match_set(
+                match_id,
                 match_set.id,
                 MatchSetBody(
                     stage_item_input1_score=score1,

--- a/backend/tests/integration_tests/api/match_sets_test.py
+++ b/backend/tests/integration_tests/api/match_sets_test.py
@@ -111,6 +111,219 @@ async def test_per_set_update_sets_and_clears_completed_at(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_non_contiguous_set_ordering_rejected(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Completing set 2 while set 1 is still NOT_STARTED must be rejected."""
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as stage_inserted,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage_inserted.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item_inserted,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item_inserted.id})
+        ) as round_inserted,
+        inserted_team(
+            DUMMY_TEAM1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as team1_inserted,
+        inserted_team(
+            DUMMY_TEAM2.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as team2_inserted,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=0,
+                team_id=team1_inserted.id,
+                tournament_id=auth_context.tournament.id,
+                stage_item_id=stage_item_inserted.id,
+            )
+        ) as input1,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=1,
+                team_id=team2_inserted.id,
+                tournament_id=auth_context.tournament.id,
+                stage_item_id=stage_item_inserted.id,
+            )
+        ) as input2,
+        inserted_court(
+            DUMMY_COURT1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as court_inserted,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_inserted.id,
+                    "stage_item_input1_id": input1.id,
+                    "stage_item_input2_id": input2.id,
+                    "court_id": court_inserted.id,
+                    "completed_at": None,
+                }
+            ),
+        ) as match_inserted,
+    ):
+        ranking_id = auth_context.ranking.id
+        try:
+            await send_tournament_request(
+                HTTPMethod.PUT,
+                f"rankings/{ranking_id}?force=true",
+                auth_context,
+                json=RankingMatchPointsBody(num_sets=3).model_dump(mode="json"),
+            )
+
+            match_detail = await send_tournament_request(
+                HTTPMethod.PUT,
+                f"matches/{match_inserted.id}/sets/{match_inserted.match_sets[0].id}",
+                auth_context,
+                json={
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "state": "NOT_STARTED",
+                },
+            )
+            set_2_id = match_detail["data"]["match_sets"][1]["id"]
+            response = await send_tournament_request(
+                HTTPMethod.PUT,
+                f"matches/{match_inserted.id}/sets/{set_2_id}",
+                auth_context,
+                json={
+                    "stage_item_input1_score": 21,
+                    "stage_item_input2_score": 10,
+                    "state": "COMPLETED",
+                },
+            )
+            assert response == {
+                "detail": "Cannot update set state: sets must be completed in order"
+            }
+        finally:
+            await send_tournament_request(
+                HTTPMethod.PUT,
+                f"rankings/{ranking_id}?force=true",
+                auth_context,
+                json=RankingMatchPointsBody(num_sets=1).model_dump(mode="json"),
+            )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_multi_set_play_flow(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """A three-set match advances contiguously through IN_PROGRESS and COMPLETED."""
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as stage_inserted,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage_inserted.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item_inserted,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item_inserted.id})
+        ) as round_inserted,
+        inserted_team(
+            DUMMY_TEAM1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as team1_inserted,
+        inserted_team(
+            DUMMY_TEAM2.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as team2_inserted,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=0,
+                team_id=team1_inserted.id,
+                tournament_id=auth_context.tournament.id,
+                stage_item_id=stage_item_inserted.id,
+            )
+        ) as input1,
+        inserted_stage_item_input(
+            StageItemInputInsertable(
+                slot=1,
+                team_id=team2_inserted.id,
+                tournament_id=auth_context.tournament.id,
+                stage_item_id=stage_item_inserted.id,
+            )
+        ) as input2,
+        inserted_court(
+            DUMMY_COURT1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as court_inserted,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_inserted.id,
+                    "stage_item_input1_id": input1.id,
+                    "stage_item_input2_id": input2.id,
+                    "court_id": court_inserted.id,
+                    "completed_at": None,
+                }
+            ),
+        ) as match_inserted,
+    ):
+        ranking_id = auth_context.ranking.id
+        try:
+            await send_tournament_request(
+                HTTPMethod.PUT,
+                f"rankings/{ranking_id}?force=true",
+                auth_context,
+                json=RankingMatchPointsBody(num_sets=3).model_dump(mode="json"),
+            )
+
+            match_detail = await send_tournament_request(
+                HTTPMethod.PUT,
+                f"matches/{match_inserted.id}/sets/{match_inserted.match_sets[0].id}",
+                auth_context,
+                json={
+                    "stage_item_input1_score": 0,
+                    "stage_item_input2_score": 0,
+                    "state": "NOT_STARTED",
+                },
+            )
+            sets = match_detail["data"]["match_sets"]
+            assert len(sets) == 3
+
+            for i, set_id in enumerate(s["id"] for s in sets):
+                in_progress = await send_tournament_request(
+                    HTTPMethod.PUT,
+                    f"matches/{match_inserted.id}/sets/{set_id}",
+                    auth_context,
+                    json={
+                        "stage_item_input1_score": 10 + i,
+                        "stage_item_input2_score": 5,
+                        "state": "IN_PROGRESS",
+                    },
+                )
+                assert in_progress["data"]["match_sets"][i]["state"] == "IN_PROGRESS"
+
+                completed = await send_tournament_request(
+                    HTTPMethod.PUT,
+                    f"matches/{match_inserted.id}/sets/{set_id}",
+                    auth_context,
+                    json={
+                        "stage_item_input1_score": 21,
+                        "stage_item_input2_score": 10,
+                        "state": "COMPLETED",
+                    },
+                )
+                assert completed["data"]["match_sets"][i]["state"] == "COMPLETED"
+                for j in range(i + 1):
+                    assert completed["data"]["match_sets"][j]["state"] == "COMPLETED"
+                for j in range(i + 1, 3):
+                    assert completed["data"]["match_sets"][j]["state"] == "NOT_STARTED"
+
+            final = completed
+            assert final["data"]["state"] == "COMPLETED"
+            assert final["data"]["completed_at"] is not None
+        finally:
+            await send_tournament_request(
+                HTTPMethod.PUT,
+                f"rankings/{ranking_id}?force=true",
+                auth_context,
+                json=RankingMatchPointsBody(num_sets=1).model_dump(mode="json"),
+            )
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_num_sets_change_requires_force_when_active_and_resizes(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:

--- a/backend/tests/integration_tests/api/scheduling_matches_test.py
+++ b/backend/tests/integration_tests/api/scheduling_matches_test.py
@@ -8,7 +8,6 @@ from bracket.database import database
 from bracket.logic.scheduling.builder import build_matches_for_stage_item
 from bracket.models.db.match import (
     MatchCreateBody,
-    MatchSetState,
     MatchWithDetails,
     MatchWithDetailsDefinitive,
 )
@@ -620,16 +619,14 @@ async def test_reoptimize_keeps_started_matches_fixed_and_reflows_the_rest(
             key=lambda m: (m.start_time, m.court_id),
         )
         in_progress, completed = scheduled_before[0], scheduled_before[1]
-        for match_set in in_progress.match_sets:
-            await database.execute(
-                "UPDATE match_sets SET state = :state WHERE id = :id",
-                {"state": MatchSetState.IN_PROGRESS.value, "id": match_set.id},
-            )
-        for match_set in completed.match_sets:
-            await database.execute(
-                "UPDATE match_sets SET state = :state WHERE id = :id",
-                {"state": MatchSetState.COMPLETED.value, "id": match_set.id},
-            )
+        await database.execute(
+            "UPDATE matches SET current_set_in_progress = TRUE WHERE id = :id",
+            {"id": in_progress.id},
+        )
+        await database.execute(
+            "UPDATE matches SET completed_set_count = 1, current_set_in_progress = FALSE WHERE id = :id",
+            {"id": completed.id},
+        )
         frozen = {
             in_progress.id: (in_progress.court_id, in_progress.start_time),
             completed.id: (completed.court_id, completed.start_time),

--- a/backend/tests/integration_tests/api/stage_items_test.py
+++ b/backend/tests/integration_tests/api/stage_items_test.py
@@ -2,13 +2,13 @@ import pytest
 
 from bracket.database import database
 from bracket.logic.scheduling.builder import build_matches_for_stage_item
-from bracket.models.db.match import MatchSetState, MatchState
+from bracket.models.db.match import MatchState
 from bracket.models.db.stage_item import StageItemWithInputsCreate, StageType
 from bracket.models.db.stage_item_inputs import (
     StageItemInputCreateBodyFinal,
     StageItemInputCreateBodyTentative,
 )
-from bracket.schema import match_sets, matches, rounds, stage_item_inputs, stage_items, stages
+from bracket.schema import matches, rounds, stage_item_inputs, stage_items, stages
 from bracket.sql.match_sets import get_sets_for_match
 from bracket.sql.stage_items import get_stage_item, sql_create_stage_item_with_inputs
 from bracket.sql.stages import get_full_tournament_details
@@ -402,16 +402,15 @@ async def test_update_stage_item_fails_when_removed_empty_slot_is_in_started_mat
             if input_slot_4.id in {match.stage_item_input1_id, match.stage_item_input2_id}
         )
 
-        for match_set in blocking_match.match_sets:
-            await database.execute(
-                query=match_sets.update()
-                .where(match_sets.c.id == match_set.id)
-                .values(state=MatchSetState(state.value).value)
-            )
+        completed_set_count = (
+            len(blocking_match.match_sets) if state is MatchState.COMPLETED else 0
+        )
         await database.execute(
             query=matches.update()
             .where(matches.c.id == blocking_match.id)
             .values(
+                completed_set_count=completed_set_count,
+                current_set_in_progress=state is MatchState.IN_PROGRESS,
                 completed_at=blocking_match.completed_at if state is MatchState.COMPLETED else None,
             )
         )
@@ -449,12 +448,11 @@ async def test_update_single_elimination_stage_item_fails_after_games_started(
         stage_item = await get_stage_item(auth_context.tournament.id, stage_item_id)
         blocking_match = stage_item.rounds[0].matches[0]
 
-        for match_set in blocking_match.match_sets:
-            await database.execute(
-                query=match_sets.update()
-                .where(match_sets.c.id == match_set.id)
-                .values(state=MatchSetState.IN_PROGRESS.value)
-            )
+        await database.execute(
+            query=matches.update()
+            .where(matches.c.id == blocking_match.id)
+            .values(current_set_in_progress=True)
+        )
 
         response = await send_tournament_request(
             HTTPMethod.PUT,

--- a/backend/tests/integration_tests/api/swiss_placeholder_test.py
+++ b/backend/tests/integration_tests/api/swiss_placeholder_test.py
@@ -1,10 +1,9 @@
 import pytest
 
 from bracket.database import database
-from bracket.models.db.match import MatchSetState
 from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.stage_item import StageType
-from bracket.schema import match_sets, matches, rounds, stage_item_inputs, stage_items, stages
+from bracket.schema import matches, rounds, stage_item_inputs, stage_items, stages
 from bracket.sql.stages import get_full_tournament_details
 from bracket.utils.dummy_records import DUMMY_STAGE1
 from bracket.utils.http import HTTPMethod
@@ -242,12 +241,11 @@ async def test_lower_games_per_player_blocked_when_round_started(
         # Mark all sets in the last round's matches as IN_PROGRESS to simulate a started round
         last_round = sorted(stage_item.rounds, key=lambda r: r.id)[-1]
         for match in last_round.matches:
-            for match_set in match.match_sets:
-                await database.execute(
-                    query=match_sets.update()
-                    .where(match_sets.c.id == match_set.id)
-                    .values(state=MatchSetState.IN_PROGRESS.value)
-                )
+            await database.execute(
+                query=matches.update()
+                .where(matches.c.id == match.id)
+                .values(current_set_in_progress=True)
+            )
 
         response = await send_tournament_request(
             HTTPMethod.PUT,

--- a/backend/tests/integration_tests/sql.py
+++ b/backend/tests/integration_tests/sql.py
@@ -217,15 +217,29 @@ async def inserted_match(
         await database.execute(
             query="""
                 INSERT INTO match_sets (
-                    match_id, set_number, stage_item_input1_score, stage_item_input2_score, state
+                    match_id, set_number, stage_item_input1_score, stage_item_input2_score
                 )
-                VALUES (:match_id, 1, :score1, :score2, :state)
+                VALUES (:match_id, 1, :score1, :score2)
             """,
             values={
                 "match_id": match_row.id,
                 "score1": set_score1,
                 "score2": set_score2,
-                "state": set_state.value,
+            },
+        )
+        completed_set_count = 1 if set_state is MatchSetState.COMPLETED else 0
+        current_set_in_progress = set_state is MatchSetState.IN_PROGRESS
+        await database.execute(
+            query="""
+                UPDATE matches
+                SET completed_set_count = :completed_set_count,
+                    current_set_in_progress = :current_set_in_progress
+                WHERE id = :match_id
+            """,
+            values={
+                "match_id": match_row.id,
+                "completed_set_count": completed_set_count,
+                "current_set_in_progress": current_set_in_progress,
             },
         )
         sets = await get_sets_for_match(match_row.id)

--- a/backend/tests/unit_tests/match_set_pointer_test.py
+++ b/backend/tests/unit_tests/match_set_pointer_test.py
@@ -1,0 +1,61 @@
+import pytest
+
+from bracket.logic.match_sets.pointer import (
+    IllegalSetTransitionError,
+    apply_pointer_transition,
+    derive_match_state_from_pointer,
+    derive_set_state,
+)
+from bracket.models.db.match import MatchSetState, MatchState
+
+
+@pytest.mark.parametrize(
+    ("set_number", "completed", "in_progress", "expected"),
+    [
+        (1, 0, False, MatchSetState.NOT_STARTED),
+        (1, 0, True, MatchSetState.IN_PROGRESS),
+        (1, 1, False, MatchSetState.COMPLETED),
+        (2, 1, False, MatchSetState.NOT_STARTED),
+        (2, 1, True, MatchSetState.IN_PROGRESS),
+        (2, 2, False, MatchSetState.COMPLETED),
+    ],
+)
+def test_derive_set_state(
+    set_number: int,
+    completed: int,
+    in_progress: bool,
+    expected: MatchSetState,
+) -> None:
+    assert derive_set_state(set_number, completed, in_progress) is expected
+
+
+@pytest.mark.parametrize(
+    ("completed", "num_sets", "in_progress", "expected"),
+    [
+        (0, 3, False, MatchState.NOT_STARTED),
+        (0, 3, True, MatchState.IN_PROGRESS),
+        (1, 3, False, MatchState.IN_PROGRESS),
+        (3, 3, False, MatchState.COMPLETED),
+    ],
+)
+def test_derive_match_state_from_pointer(
+    completed: int, num_sets: int, in_progress: bool, expected: MatchState
+) -> None:
+    assert derive_match_state_from_pointer(completed, num_sets, in_progress) is expected
+
+
+def test_apply_pointer_transition_start_and_complete() -> None:
+    completed, in_progress = apply_pointer_transition(
+        0, False, 1, MatchSetState.IN_PROGRESS
+    )
+    assert (completed, in_progress) == (0, True)
+
+    completed, in_progress = apply_pointer_transition(
+        completed, in_progress, 1, MatchSetState.COMPLETED
+    )
+    assert (completed, in_progress) == (1, False)
+
+
+def test_apply_pointer_transition_rejects_skipping_a_set() -> None:
+    with pytest.raises(IllegalSetTransitionError):
+        apply_pointer_transition(0, False, 2, MatchSetState.COMPLETED)


### PR DESCRIPTION
## Summary

- Replace per-set `state` storage with a match-level progress pointer (`completed_set_count`, `current_set_in_progress`) so non-contiguous set orderings are structurally impossible to persist.
- Re-derive per-set `state` positionally in read SQL; the `MatchSet` wire shape and existing `PUT .../sets/{id}` endpoint are unchanged, so the frontend keeps working without changes.
- Guard pointer transitions with `SELECT … FOR UPDATE` on the match row and reject illegal orderings with 400.

Closes #234.

## Test plan

- [x] `ENVIRONMENT=CI uv run pytest .` — 448 tests pass
- [x] Integration: non-contiguous set completion rejected (`test_non_contiguous_set_ordering_rejected`)
- [x] Integration: multi-set play flow unchanged (`test_multi_set_play_flow`)
- [x] Unit tests for pointer transition logic (`match_set_pointer_test.py`)
- [x] Manual: score tracking list and play UI on localhost:3000 show correct states and accept score updates


Made with [Cursor](https://cursor.com)