### PR TITLE
Fix switch sides button not swapping scores in score tracking

### DIFF
--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -31,7 +31,11 @@ import {
 import { RefereeDisplay } from '@components/utils/referee';
 import { responseIsValid } from '@components/utils/util';
 import { getScoreColors } from '@logic/colors';
-import { getScoreTrackingViewState, isEndSetDisabled } from '@logic/score_tracking';
+import {
+  getDisplayScores,
+  getScoreTrackingViewState,
+  isEndSetDisabled,
+} from '@logic/score_tracking';
 import { computeSideSwitchState } from '@logic/side_switch';
 import {
   LevelResponse,
@@ -448,15 +452,8 @@ export function ScoreTrackingMatchView({
     const isLastSet = set.set_number === numSets;
     const endDisabled = isSaving || isEndSetDisabled(set, match, isSwapped);
 
-    const teamDisplayScores = displayedTeams.map((team) =>
-      team.slot === 1
-        ? isSwapped
-          ? set.stage_item_input2_score
-          : set.stage_item_input1_score
-        : isSwapped
-          ? set.stage_item_input1_score
-          : set.stage_item_input2_score
-    );
+    const { first, second } = getDisplayScores(set, isSwapped);
+    const teamDisplayScores = [first, second];
 
     return (
       <>
@@ -546,12 +543,7 @@ export function ScoreTrackingMatchView({
   }
 
   function renderBetweenSets(completed: MatchSet, _next: MatchSet, allSets: MatchSet[]) {
-    const displayScore1 = isSwapped
-      ? completed.stage_item_input2_score
-      : completed.stage_item_input1_score;
-    const displayScore2 = isSwapped
-      ? completed.stage_item_input1_score
-      : completed.stage_item_input2_score;
+    const { first: displayScore1, second: displayScore2 } = getDisplayScores(completed, isSwapped);
 
     const setsWon1 = isSwapped ? countSetsWon(allSets, 2) : countSetsWon(allSets, 1);
     const setsWon2 = isSwapped ? countSetsWon(allSets, 1) : countSetsWon(allSets, 2);

--- a/frontend/src/logic/score_tracking.test.ts
+++ b/frontend/src/logic/score_tracking.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { MatchSet } from '@openapi';
 
-import { getScoreTrackingViewState, isEndSetDisabled } from './score_tracking';
+import { getDisplayScores, getScoreTrackingViewState, isEndSetDisabled } from './score_tracking';
 
 function makeSet(overrides: Partial<MatchSet> & Pick<MatchSet, 'set_number' | 'state'>): MatchSet {
   return {
@@ -166,5 +166,29 @@ describe('isEndSetDisabled', () => {
       stage_item_input2_score: 21,
     });
     expect(isEndSetDisabled(set, { ...baseMatch, two_point_advantage: true }, false)).toBe(true);
+  });
+});
+
+describe('getDisplayScores', () => {
+  it('returns scores in original order when not swapped', () => {
+    const set = makeSet({
+      set_number: 1,
+      state: 'IN_PROGRESS',
+      stage_item_input1_score: 11,
+      stage_item_input2_score: 7,
+    });
+    expect(getDisplayScores(set, false)).toEqual({ first: 11, second: 7 });
+  });
+
+  it('swaps which score is shown first when isSwapped is true', () => {
+    // The team names swap sides too, so the score must move with its team:
+    // whichever side now shows input2's team must show input2's score.
+    const set = makeSet({
+      set_number: 1,
+      state: 'IN_PROGRESS',
+      stage_item_input1_score: 11,
+      stage_item_input2_score: 7,
+    });
+    expect(getDisplayScores(set, true)).toEqual({ first: 7, second: 11 });
   });
 });

--- a/frontend/src/logic/score_tracking.ts
+++ b/frontend/src/logic/score_tracking.ts
@@ -22,6 +22,15 @@ export function getScoreTrackingViewState(sets: MatchSet[]): ScoreTrackingViewSt
   return { kind: 'completed' };
 }
 
+export function getDisplayScores(
+  set: Pick<MatchSet, 'stage_item_input1_score' | 'stage_item_input2_score'>,
+  isSwapped: boolean
+): { first: number; second: number } {
+  return isSwapped
+    ? { first: set.stage_item_input2_score, second: set.stage_item_input1_score }
+    : { first: set.stage_item_input1_score, second: set.stage_item_input2_score };
+}
+
 export function isEndSetDisabled(
   set: MatchSet,
   match: {


### PR DESCRIPTION
The in-progress-set view computed each team's displayed score off its
original slot plus an extra isSwapped correction, which cancelled out
the reordering already applied to team names via displayedTeams — so
switching sides moved the team names but left scores in place.
Extracted the correct swap logic (already used in the between-sets
view) into a shared getDisplayScores helper and applied it in both
places.