### PR TITLE
Fix +/- buttons adjusting the wrong team's score when sides are swapped

### DIFF
--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -35,6 +35,7 @@ import {
   getDisplayScores,
   getScoreTrackingViewState,
   isEndSetDisabled,
+  nextScoresAfterAdjust,
 } from '@logic/score_tracking';
 import { computeSideSwitchState } from '@logic/side_switch';
 import {
@@ -402,14 +403,8 @@ export function ScoreTrackingMatchView({
 
   async function adjustScore(slot: 1 | 2, delta: number) {
     if (activeSet == null) return;
-    const realSlot = isSwapped ? (slot === 1 ? 2 : 1) : slot;
-    const next1 = Math.max(0, activeSet.stage_item_input1_score + (realSlot === 1 ? delta : 0));
-    const next2 = Math.max(0, activeSet.stage_item_input2_score + (realSlot === 2 ? delta : 0));
     await runAction(() =>
-      actions.scoreEdit(activeSet.id, {
-        stage_item_input1_score: next1,
-        stage_item_input2_score: next2,
-      })
+      actions.scoreEdit(activeSet.id, nextScoresAfterAdjust(activeSet, slot, delta))
     );
   }
 

--- a/frontend/src/logic/score_tracking.test.ts
+++ b/frontend/src/logic/score_tracking.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import { MatchSet } from '@openapi';
 
-import { getDisplayScores, getScoreTrackingViewState, isEndSetDisabled } from './score_tracking';
+import {
+  getDisplayScores,
+  getScoreTrackingViewState,
+  isEndSetDisabled,
+  nextScoresAfterAdjust,
+} from './score_tracking';
 
 function makeSet(overrides: Partial<MatchSet> & Pick<MatchSet, 'set_number' | 'state'>): MatchSet {
   return {
@@ -190,5 +195,51 @@ describe('getDisplayScores', () => {
       stage_item_input2_score: 7,
     });
     expect(getDisplayScores(set, true)).toEqual({ first: 7, second: 11 });
+  });
+});
+
+describe('nextScoresAfterAdjust', () => {
+  const set = makeSet({
+    set_number: 1,
+    state: 'IN_PROGRESS',
+    stage_item_input1_score: 5,
+    stage_item_input2_score: 3,
+  });
+
+  it('adjusts input1_score when slot is 1', () => {
+    expect(nextScoresAfterAdjust(set, 1, 1)).toEqual({
+      stage_item_input1_score: 6,
+      stage_item_input2_score: 3,
+    });
+  });
+
+  it('adjusts input2_score when slot is 2', () => {
+    expect(nextScoresAfterAdjust(set, 2, 1)).toEqual({
+      stage_item_input1_score: 5,
+      stage_item_input2_score: 4,
+    });
+  });
+
+  it('adjusts the score belonging to the given slot regardless of side switching', () => {
+    // The slot passed in is always the team's real (unswapped) slot, since that's
+    // what identifies whose score is being changed — a "switch sides" toggle only
+    // affects display order, not which slot a team's score lives in.
+    expect(nextScoresAfterAdjust(set, 2, -1)).toEqual({
+      stage_item_input1_score: 5,
+      stage_item_input2_score: 2,
+    });
+  });
+
+  it('clamps scores at 0', () => {
+    const zeroSet = makeSet({
+      set_number: 1,
+      state: 'IN_PROGRESS',
+      stage_item_input1_score: 0,
+      stage_item_input2_score: 0,
+    });
+    expect(nextScoresAfterAdjust(zeroSet, 1, -1)).toEqual({
+      stage_item_input1_score: 0,
+      stage_item_input2_score: 0,
+    });
   });
 });

--- a/frontend/src/logic/score_tracking.ts
+++ b/frontend/src/logic/score_tracking.ts
@@ -31,6 +31,17 @@ export function getDisplayScores(
     : { first: set.stage_item_input1_score, second: set.stage_item_input2_score };
 }
 
+export function nextScoresAfterAdjust(
+  set: Pick<MatchSet, 'stage_item_input1_score' | 'stage_item_input2_score'>,
+  slot: 1 | 2,
+  delta: number
+): { stage_item_input1_score: number; stage_item_input2_score: number } {
+  return {
+    stage_item_input1_score: Math.max(0, set.stage_item_input1_score + (slot === 1 ? delta : 0)),
+    stage_item_input2_score: Math.max(0, set.stage_item_input2_score + (slot === 2 ? delta : 0)),
+  };
+}
+
 export function isEndSetDisabled(
   set: MatchSet,
   match: {


### PR DESCRIPTION
## Summary

- Follow-up to #242 (score display fix). The `+`/`-` score buttons in the score tracking view had the same class of bug: `adjustScore` inverted the `slot` argument via `isSwapped` before applying the delta, but `slot` (from `team.slot`) is already the team's real, unswapped slot — so the inversion redirected the edit to the wrong team whenever sides were swapped.
- Removed the inversion and extracted the score-update logic into a tested `nextScoresAfterAdjust` helper in `frontend/src/logic/score_tracking.ts`.

## Test plan

- [x] Added `nextScoresAfterAdjust` unit tests in `frontend/src/logic/score_tracking.test.ts` covering slot 1/2 adjustment, side-switch independence, and clamping at 0
- [x] `pnpm exec vitest run` — 264 tests passing
- [x] `pnpm run typecheck` — no errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdJErqN1p37Xeq1pXEUFcs)_