### PR TITLE
Show teams and expected time for not-started score-tracking match

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -452,6 +452,7 @@
     "user_settings_spotlight_description": "Name, E-Mail, Passwort usw. ändern.",
     "user_settings_title": "Benutzereinstellungen",
     "user_title": "Benutzer",
+    "versus_label": "gegen",
     "view_dashboard_button": "Dashboard anzeigen",
     "website_title": "Webseite",
     "welcome_title": "Willkommen bei",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -452,6 +452,7 @@
     "user_settings_spotlight_description": "Change name, email, password etc.",
     "user_settings_title": "User Settings",
     "user_title": "User",
+    "versus_label": "vs",
     "view_dashboard_button": "View Dashboard",
     "website_title": "Website",
     "welcome_title": "Welcome to",

--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -14,13 +14,13 @@ import {
   Text,
   Title,
 } from '@mantine/core';
-import { IconArrowsExchange, IconMinus, IconPlus } from '@tabler/icons-react';
+import { IconArrowsExchange, IconClock, IconMinus, IconPlus } from '@tabler/icons-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SWRResponse } from 'swr';
 
 import { LevelBadge, LevelFilterSelect } from '@components/levels/levels';
-import { Time } from '@components/utils/datetime';
+import { formatTimeRange, Time } from '@components/utils/datetime';
 import PreloadLink from '@components/utils/link';
 import {
   formatMatchInput1,
@@ -430,11 +430,30 @@ export function ScoreTrackingMatchView({
 
   function renderNotStarted() {
     return (
-      <Center>
+      <Stack align="center" gap="lg">
+        <Group gap="sm" justify="center" wrap="nowrap">
+          <Text ta="center" fw={700} fz="lg">
+            {displayedTeams[0].name}
+          </Text>
+          <Text c="dimmed" fw={500}>
+            {t('versus_label')}
+          </Text>
+          <Text ta="center" fw={700} fz="lg">
+            {displayedTeams[1].name}
+          </Text>
+        </Group>
+        {match.start_time != null ? (
+          <Group gap={6} justify="center">
+            <IconClock size={18} color="var(--mantine-color-dimmed)" />
+            <Text fw={500} c="dimmed">
+              {formatTimeRange(match.start_time, match.duration_minutes)}
+            </Text>
+          </Group>
+        ) : null}
         <Button size="xl" loading={isSaving} onClick={() => runAction(actions.startMatch)}>
           {t('start_game_button')}
         </Button>
-      </Center>
+      </Stack>
     );
   }
 

--- a/frontend/src/components/utils/datetime.tsx
+++ b/frontend/src/components/utils/datetime.tsx
@@ -1,4 +1,4 @@
-import { format, parseISO } from 'date-fns';
+import { addMinutes, format, parseISO } from 'date-fns';
 
 export function DateTime({ datetime }: { datetime: string }) {
   const date = parseISO(datetime);
@@ -12,6 +12,12 @@ export function Time({ datetime }: { datetime: string }) {
 
 export function formatTime(datetime: string) {
   return format(parseISO(datetime), 'HH:mm');
+}
+
+export function formatTimeRange(datetime: string, durationMinutes: number) {
+  const start = parseISO(datetime);
+  const end = addMinutes(start, durationMinutes);
+  return `${format(start, 'HH:mm')} – ${format(end, 'HH:mm')}`;
 }
 
 export function compareDateTime(datetime1: string, datetime2: string) {


### PR DESCRIPTION
When a not_started match is selected in the score-tracking view, display
the two playing teams and the expected start/end time above the start
button, so the match can be identified before it begins.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NNi21cnX4boRjNY7Vqv9Mp