### PR TITLE
Replace "back to matches" with "next match" in score tracker

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -321,7 +321,7 @@
     "resume_match_button": "Spiel fortsetzen",
     "finish_match_button": "Spiel beenden",
     "open_score_tracker_button": "Spielstandserfassung öffnen",
-    "back_to_matches_button": "Zurück zu den Spielen",
+    "next_match_button": "Nächstes Spiel",
     "match_state_not_started": "Nicht gestartet",
     "match_state_in_progress": "Läuft",
     "match_state_completed": "Abgeschlossen",

--- a/frontend/public/locales/el/common.json
+++ b/frontend/public/locales/el/common.json
@@ -367,7 +367,6 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
     "match_state_label": "Match state",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -321,7 +321,7 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
+    "next_match_button": "Next match",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",
     "match_state_completed": "Completed",

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -367,7 +367,6 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
     "match_state_label": "Match state",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",

--- a/frontend/public/locales/fa/common.json
+++ b/frontend/public/locales/fa/common.json
@@ -353,7 +353,6 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
     "match_state_label": "Match state",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -367,7 +367,6 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
     "match_state_label": "Match state",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -367,7 +367,6 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
     "match_state_label": "Match state",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",

--- a/frontend/public/locales/ja/common.json
+++ b/frontend/public/locales/ja/common.json
@@ -367,7 +367,6 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
     "match_state_label": "Match state",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",

--- a/frontend/public/locales/nl/common.json
+++ b/frontend/public/locales/nl/common.json
@@ -367,7 +367,6 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
     "match_state_label": "Match state",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -367,7 +367,6 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
     "match_state_label": "Match state",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",

--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -367,7 +367,6 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
     "match_state_label": "Match state",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -367,7 +367,6 @@
     "resume_match_button": "Resume match",
     "finish_match_button": "Finish match",
     "open_score_tracker_button": "Open score tracker",
-    "back_to_matches_button": "Back to matches",
     "match_state_label": "Match state",
     "match_state_not_started": "Not started",
     "match_state_in_progress": "In progress",

--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -299,14 +299,14 @@ export type ScoreTrackingMatchActions = {
 
 export function ScoreTrackingMatchView({
   swrResponse,
-  backHref,
+  nextMatchHref,
   storageKey,
   actions,
   levels = [],
   refereesEnabled = false,
 }: {
   swrResponse: SWRResponse<ScoreTrackingMatchResponse>;
-  backHref: string;
+  nextMatchHref?: string | null;
   storageKey: string;
   levels?: LevelResponse[];
   refereesEnabled?: boolean;
@@ -454,11 +454,22 @@ export function ScoreTrackingMatchView({
 
   function renderCompleted() {
     return (
-      <Center>
+      <Stack gap="sm" align="center">
         <Button size="lg" loading={isSaving} onClick={() => runAction(actions.reopenMatch)}>
           {t('resume_match_button')}
         </Button>
-      </Center>
+        {nextMatchHref != null ? (
+          <Button
+            component={PreloadLink}
+            href={nextMatchHref}
+            size="lg"
+            color="blue"
+            variant="light"
+          >
+            {t('next_match_button')}
+          </Button>
+        ) : null}
+      </Stack>
     );
   }
 
@@ -630,14 +641,9 @@ export function ScoreTrackingMatchView({
   return (
     <Container size="sm" py="xl">
       <Stack gap="lg">
-        <Group justify="space-between">
-          <Group gap="xs">
-            <Title order={2}>{t('score_tracking_match_title')}</Title>
-            <LevelBadge levels={levels} levelId={match.level_id} />
-          </Group>
-          <Button component={PreloadLink} href={backHref} variant="subtle">
-            {t('back_to_matches_button')}
-          </Button>
+        <Group gap="xs">
+          <Title order={2}>{t('score_tracking_match_title')}</Title>
+          <LevelBadge levels={levels} levelId={match.level_id} />
         </Group>
         <RefereeDisplay match={match} refereesEnabled={refereesEnabled} />
         {renderMatchBody()}

--- a/frontend/src/logic/score_tracking.test.ts
+++ b/frontend/src/logic/score_tracking.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { MatchSet } from '@openapi';
+import { MatchSet, MatchWithDetails } from '@openapi';
 
 import {
   getDisplayScores,
+  getNextMatchOnCourt,
   getScoreTrackingViewState,
   isEndSetDisabled,
   nextScoresAfterAdjust,
@@ -75,6 +76,78 @@ describe('getScoreTrackingViewState', () => {
   it('returns completed for single set COMPLETED', () => {
     const sets = [makeSet({ set_number: 1, state: 'COMPLETED' })];
     expect(getScoreTrackingViewState(sets)).toEqual({ kind: 'completed' });
+  });
+});
+
+function makeMatch(
+  overrides: Pick<MatchWithDetails, 'id'> &
+    Partial<Pick<MatchWithDetails, 'court_id' | 'start_time' | 'state'>>
+): MatchWithDetails {
+  return {
+    court_id: null,
+    start_time: null,
+    state: 'NOT_STARTED',
+    ...overrides,
+  } as MatchWithDetails;
+}
+
+describe('getNextMatchOnCourt', () => {
+  it('returns the next match on the same court by start time', () => {
+    const current = makeMatch({ id: 1, court_id: 5, start_time: '2026-07-04T10:00:00Z' });
+    const next = makeMatch({ id: 2, court_id: 5, start_time: '2026-07-04T10:30:00Z' });
+    const matches = [current, next];
+    expect(getNextMatchOnCourt(matches, current)).toBe(next);
+  });
+
+  it('ignores matches on other courts', () => {
+    const current = makeMatch({ id: 1, court_id: 5, start_time: '2026-07-04T10:00:00Z' });
+    const otherCourt = makeMatch({ id: 2, court_id: 6, start_time: '2026-07-04T10:15:00Z' });
+    const sameCourt = makeMatch({ id: 3, court_id: 5, start_time: '2026-07-04T10:30:00Z' });
+    expect(getNextMatchOnCourt([current, otherCourt, sameCourt], current)).toBe(sameCourt);
+  });
+
+  it('skips already-completed matches and returns the next unplayed one', () => {
+    const current = makeMatch({ id: 1, court_id: 5, start_time: '2026-07-04T10:00:00Z' });
+    const completedNext = makeMatch({
+      id: 2,
+      court_id: 5,
+      start_time: '2026-07-04T10:30:00Z',
+      state: 'COMPLETED',
+    });
+    const unplayed = makeMatch({ id: 3, court_id: 5, start_time: '2026-07-04T11:00:00Z' });
+    expect(getNextMatchOnCourt([current, completedNext, unplayed], current)).toBe(unplayed);
+  });
+
+  it('returns null when it is the last match on the court', () => {
+    const earlier = makeMatch({ id: 1, court_id: 5, start_time: '2026-07-04T10:00:00Z' });
+    const current = makeMatch({ id: 2, court_id: 5, start_time: '2026-07-04T10:30:00Z' });
+    expect(getNextMatchOnCourt([earlier, current], current)).toBeNull();
+  });
+
+  it('returns null when every later match on the court is completed', () => {
+    const current = makeMatch({ id: 1, court_id: 5, start_time: '2026-07-04T10:00:00Z' });
+    const laterCompleted = makeMatch({
+      id: 2,
+      court_id: 5,
+      start_time: '2026-07-04T10:30:00Z',
+      state: 'COMPLETED',
+    });
+    expect(getNextMatchOnCourt([current, laterCompleted], current)).toBeNull();
+  });
+
+  it('returns null when the current match has no court assigned', () => {
+    const current = makeMatch({ id: 1, court_id: null, start_time: '2026-07-04T10:00:00Z' });
+    const other = makeMatch({ id: 2, court_id: null, start_time: '2026-07-04T10:30:00Z' });
+    expect(getNextMatchOnCourt([current, other], current)).toBeNull();
+  });
+
+  it('breaks start-time ties by id', () => {
+    const current = makeMatch({ id: 5, court_id: 5, start_time: '2026-07-04T10:00:00Z' });
+    const sameTimeLowerId = makeMatch({ id: 3, court_id: 5, start_time: '2026-07-04T10:00:00Z' });
+    const sameTimeHigherId = makeMatch({ id: 7, court_id: 5, start_time: '2026-07-04T10:00:00Z' });
+    expect(getNextMatchOnCourt([current, sameTimeLowerId, sameTimeHigherId], current)).toBe(
+      sameTimeHigherId
+    );
   });
 });
 

--- a/frontend/src/logic/score_tracking.ts
+++ b/frontend/src/logic/score_tracking.ts
@@ -1,4 +1,4 @@
-import { MatchSet } from '@openapi';
+import { MatchSet, MatchWithDetails } from '@openapi';
 
 export type ScoreTrackingViewState =
   | { kind: 'not_started' }
@@ -40,6 +40,38 @@ export function nextScoresAfterAdjust(
     stage_item_input1_score: Math.max(0, set.stage_item_input1_score + (slot === 1 ? delta : 0)),
     stage_item_input2_score: Math.max(0, set.stage_item_input2_score + (slot === 2 ? delta : 0)),
   };
+}
+
+// Order scheduled matches the way they play out on a court: by start time (matches without a start
+// time sort last), breaking ties by id for a stable ordering.
+function compareMatchesByScheduleThenId(a: MatchWithDetails, b: MatchWithDetails): number {
+  if (a.start_time !== b.start_time) {
+    if (a.start_time == null) return 1;
+    if (b.start_time == null) return -1;
+    return a.start_time < b.start_time ? -1 : 1;
+  }
+  return a.id - b.id;
+}
+
+// Given the full list of scheduled matches and the current match, find the next match on the same
+// court that still needs to be played (i.e. is not completed). Returns null when there is none.
+export function getNextMatchOnCourt(
+  matches: MatchWithDetails[],
+  currentMatch: MatchWithDetails
+): MatchWithDetails | null {
+  if (currentMatch.court_id == null) return null;
+
+  const sameCourt = matches
+    .filter((match) => match.court_id === currentMatch.court_id)
+    .sort(compareMatchesByScheduleThenId);
+
+  const currentIndex = sameCourt.findIndex((match) => match.id === currentMatch.id);
+  if (currentIndex === -1) return null;
+
+  for (let i = currentIndex + 1; i < sameCourt.length; i += 1) {
+    if (sameCourt[i].state !== 'COMPLETED') return sameCourt[i];
+  }
+  return null;
 }
 
 export function isEndSetDisabled(

--- a/frontend/src/pages/score_tracking_match.tsx
+++ b/frontend/src/pages/score_tracking_match.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router';
 
 import { ScoreTrackingMatchView } from '@components/score_tracking/views';
+import { getNextMatchOnCourt } from '@logic/score_tracking';
 import {
   endScoreTrackingMatch,
   reopenScoreTrackingMatch,
@@ -20,10 +21,18 @@ export default function ScoreTrackingMatchPage() {
   const tournamentId = swrInfoResponse.data?.data.tournament_id ?? null;
   const refereesEnabled = swrInfoResponse.data?.data.referees_enabled ?? false;
 
+  const currentMatch = swrResponse.data?.data ?? null;
+  const nextMatch =
+    currentMatch != null
+      ? getNextMatchOnCourt(swrInfoResponse.data?.data.matches ?? [], currentMatch)
+      : null;
+  const nextMatchHref =
+    nextMatch != null ? `/score-tracking/${score_tracking_token}/matches/${nextMatch.id}` : null;
+
   return (
     <ScoreTrackingMatchView
       swrResponse={swrResponse}
-      backHref={`/score-tracking/${score_tracking_token}`}
+      nextMatchHref={nextMatchHref}
       storageKey={`score-tracking:${score_tracking_token}:${matchId}:swapped`}
       refereesEnabled={refereesEnabled}
       actions={{

--- a/frontend/src/pages/tournaments/[id]/score_tracking_match.tsx
+++ b/frontend/src/pages/tournaments/[id]/score_tracking_match.tsx
@@ -1,9 +1,13 @@
 import { ScoreTrackingMatchView } from '@components/score_tracking/views';
 import { getTournamentIdFromRouter, responseIsValid } from '@components/utils/util';
+import { getNextMatchOnCourt } from '@logic/score_tracking';
 import TournamentLayout from '@pages/tournaments/_tournament_layout';
 import { getTournamentById } from '@services/adapter';
 import { endMatch, reopenMatch, scoreEditMatchSet, startMatch } from '@services/match';
-import { getTournamentScoreTrackingMatch } from '@services/score_tracking';
+import {
+  getTournamentScoreTrackingInfo,
+  getTournamentScoreTrackingMatch,
+} from '@services/score_tracking';
 import { useParams } from 'react-router';
 
 export default function TournamentScoreTrackingMatchPage() {
@@ -12,13 +16,24 @@ export default function TournamentScoreTrackingMatchPage() {
   const matchId = match_id != null ? parseInt(match_id, 10) : null;
   const swrResponse = getTournamentScoreTrackingMatch(tournamentData.id, matchId);
   const swrTournamentResponse = getTournamentById(tournamentData.id);
+  const swrInfoResponse = getTournamentScoreTrackingInfo(tournamentData.id, null);
+
+  const currentMatch = swrResponse.data?.data ?? null;
+  const nextMatch =
+    currentMatch != null
+      ? getNextMatchOnCourt(swrInfoResponse.data?.data.matches ?? [], currentMatch)
+      : null;
+  const nextMatchHref =
+    nextMatch != null
+      ? `/tournaments/${tournamentData.id}/score-tracking/matches/${nextMatch.id}`
+      : null;
 
   return (
     <TournamentLayout tournament_id={tournamentData.id}>
       {responseIsValid(swrResponse) || swrResponse.error != null ? (
         <ScoreTrackingMatchView
           swrResponse={swrResponse}
-          backHref={`/tournaments/${tournamentData.id}/score-tracking`}
+          nextMatchHref={nextMatchHref}
           storageKey={`tournament-score-tracking:${tournamentData.id}:${matchId}:swapped`}
           levels={swrTournamentResponse.data?.data.levels ?? []}
           refereesEnabled={swrTournamentResponse.data?.data.referees_enabled ?? false}


### PR DESCRIPTION
Remove the "Back to matches" button from the score tracking match view
header entirely. When a match is completed, show a "Next match" button
that opens the next unplayed match on the same court directly.

The next match is determined from the score-tracking info list: matches
on the same court are ordered by start time (ties broken by id), and the
first later match that is not yet completed is chosen. Both the public
token-based page and the authenticated tournament page compute and pass
the target href to the shared view.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ARtS56ECvhy9jWCfLawADf