### PR TITLE
Show court name as subtitle on score tracker header

### DIFF
--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -39,7 +39,6 @@ import {
 } from '@logic/score_tracking';
 import { computeSideSwitchState } from '@logic/side_switch';
 import {
-  LevelResponse,
   MatchSet,
   MatchWithDetails,
   ScoreTrackingInfoResponse,
@@ -302,13 +301,11 @@ export function ScoreTrackingMatchView({
   nextMatchHref,
   storageKey,
   actions,
-  levels = [],
   refereesEnabled = false,
 }: {
   swrResponse: SWRResponse<ScoreTrackingMatchResponse>;
   nextMatchHref?: string | null;
   storageKey: string;
-  levels?: LevelResponse[];
   refereesEnabled?: boolean;
   actions: ScoreTrackingMatchActions;
 }) {
@@ -641,10 +638,14 @@ export function ScoreTrackingMatchView({
   return (
     <Container size="sm" py="xl">
       <Stack gap="lg">
-        <Group gap="xs">
+        <Stack gap={0}>
           <Title order={2}>{t('score_tracking_match_title')}</Title>
-          <LevelBadge levels={levels} levelId={match.level_id} />
-        </Group>
+          {match.court != null ? (
+            <Text c="dimmed" fw={500}>
+              {match.court.name}
+            </Text>
+          ) : null}
+        </Stack>
         <RefereeDisplay match={match} refereesEnabled={refereesEnabled} />
         {renderMatchBody()}
       </Stack>

--- a/frontend/src/pages/tournaments/[id]/score_tracking_match.tsx
+++ b/frontend/src/pages/tournaments/[id]/score_tracking_match.tsx
@@ -35,7 +35,6 @@ export default function TournamentScoreTrackingMatchPage() {
           swrResponse={swrResponse}
           nextMatchHref={nextMatchHref}
           storageKey={`tournament-score-tracking:${tournamentData.id}:${matchId}:swapped`}
-          levels={swrTournamentResponse.data?.data.levels ?? []}
           refereesEnabled={swrTournamentResponse.data?.data.referees_enabled ?? false}
           actions={{
             startMatch: async () => {


### PR DESCRIPTION
Remove the level badge next to the score tracker match title and instead
display the court name as a dimmed subtitle directly below the title.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013QynBtzjsrMe9gBZ6mstbm