### PR TITLE
Hide switch sides button once a match is completed

### DIFF
--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -613,20 +613,7 @@ export function ScoreTrackingMatchView({
     if (viewState == null) return null;
     if (viewState.kind === 'not_started') return renderNotStarted();
     if (viewState.kind === 'completed') {
-      return (
-        <>
-          <Stack align="center" gap={4}>
-            <Button
-              variant="light"
-              leftSection={<IconArrowsExchange size={18} />}
-              onClick={toggleSides}
-            >
-              {t('switch_sides_button')}
-            </Button>
-          </Stack>
-          {renderCompleted()}
-        </>
-      );
+      return renderCompleted();
     }
     if (viewState.kind === 'between_sets') {
       return renderBetweenSets(viewState.completed, viewState.next, viewState.allSets);


### PR DESCRIPTION
## Summary
- The score tracking screen showed the "switch sides" button above the "resume match" button even after a match/set had finished.
- Removed the switch-sides button from the completed-match view; it now only shows while a set is in progress.

## Test plan
- [x] Ran the app locally (backend + frontend + Postgres) and drove the score tracker via browser automation.
- [x] Verified the switch sides button is shown while a match is in progress.
- [x] Verified it disappears once the match is finished, leaving only the resume/next match buttons.
- [x] `pnpm run typecheck` and `pnpm run prettier:check` pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HqYiqUek6P4B4vMKVdNiNB)_