### PR TITLE
Restyle completed score-tracker buttons: emphasize next match

### DIFF
--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -451,22 +451,21 @@ export function ScoreTrackingMatchView({
 
   function renderCompleted() {
     return (
-      <Stack gap="sm" align="center">
-        <Button size="lg" loading={isSaving} onClick={() => runAction(actions.reopenMatch)}>
+      <Group grow gap="sm" justify="center" w="100%" maw={368} mx="auto">
+        <Button
+          size="md"
+          variant="light"
+          loading={isSaving}
+          onClick={() => runAction(actions.reopenMatch)}
+        >
           {t('resume_match_button')}
         </Button>
         {nextMatchHref != null ? (
-          <Button
-            component={PreloadLink}
-            href={nextMatchHref}
-            size="lg"
-            color="blue"
-            variant="light"
-          >
+          <Button component={PreloadLink} href={nextMatchHref} size="md" color="blue">
             {t('next_match_button')}
           </Button>
         ) : null}
-      </Stack>
+      </Group>
     );
   }
 


### PR DESCRIPTION
Follow-up to #245.

In the completed state of the score-tracking match view, the "Resume match" and "Next match" buttons are restyled so the primary action stands out:

- **Next match** is now the emphasized action — a filled, darker-blue button.
- **Resume match** is demoted to a lighter, secondary button.
- The two are laid out **side by side** (Resume on the left, Next match on the right) instead of stacked.
- Both buttons share the **same size and width** (~180px each), so the row looks balanced regardless of label length.

### Verification

- `pnpm run typecheck` and `pnpm run prettier:check` pass.
- Driven end-to-end with a headless browser (Rodney): both buttons render at 178px wide, full labels visible, and "Next match" navigates to the next unplayed match on the same court.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARtS56ECvhy9jWCfLawADf