### PR TITLE
Stack completed score-tracker buttons vertically on narrow screens

### DIFF
--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -451,17 +451,26 @@ export function ScoreTrackingMatchView({
 
   function renderCompleted() {
     return (
-      <Group grow gap="sm" justify="center" w="100%" maw={368} mx="auto">
+      <Group gap="sm" justify="center" w="100%" maw={368} mx="auto">
         <Button
           size="md"
           variant="light"
+          miw={160}
+          style={{ flex: '1 1 160px' }}
           loading={isSaving}
           onClick={() => runAction(actions.reopenMatch)}
         >
           {t('resume_match_button')}
         </Button>
         {nextMatchHref != null ? (
-          <Button component={PreloadLink} href={nextMatchHref} size="md" color="blue">
+          <Button
+            component={PreloadLink}
+            href={nextMatchHref}
+            size="md"
+            color="blue"
+            miw={160}
+            style={{ flex: '1 1 160px' }}
+          >
             {t('next_match_button')}
           </Button>
         ) : null}


### PR DESCRIPTION
Follow-up to #248.

The `Group grow` layout introduced in #248 always split the "Resume match" / "Next match" row into two equal columns that never wrap. On narrow phone widths (e.g. iPhone 13 mini, 375px) each column shrank below its label and the text was cut off.

This gives each button a `160px` flex basis with a matching `min-width` and lets the group wrap:

- **Enough room** (desktop/tablet): buttons sit side by side at equal width (~180px each).
- **Too narrow** (phones): the buttons wrap and stack full-width, one per line.

### Verification

- `pnpm run typecheck` and `pnpm run prettier:check` pass.
- Driven end-to-end in a headless browser at the real iPhone 13 mini viewport (375×812): `window.innerWidth = 375`, both buttons stack full-width with the full German labels ("Spiel fortsetzen" / "Nächstes Spiel") visible and no cut-off. At desktop width they remain side by side at equal width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARtS56ECvhy9jWCfLawADf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARtS56ECvhy9jWCfLawADf)_