### PR TITLE
Add reconcile_stage_item as the single entry point for standings changes

### DIFF
--- a/backend/bracket/logic/match_sets/apply_update.py
+++ b/backend/bracket/logic/match_sets/apply_update.py
@@ -7,17 +7,8 @@ from starlette import status
 from bracket.database import database
 from bracket.logic.match_sets.pointer import IllegalMatchTransitionError
 from bracket.logic.match_sets.validation import validate_match_can_be_started
-from bracket.logic.ranking.calculation import recalculate_ranking_for_stage_item
-from bracket.logic.ranking.elimination import (
-    get_started_elimination_followers,
-    update_inputs_in_subsequent_elimination_rounds,
-)
-from bracket.logic.scheduling.handle_stage_activation import (
-    resolve_dependent_inputs_for_completed_stage_item,
-)
-from bracket.logic.scheduling.swiss_resolution_orchestrator import (
-    auto_resolve_next_swiss_round,
-)
+from bracket.logic.ranking.elimination import get_started_elimination_followers
+from bracket.logic.reconcile import reconcile_stage_item
 from bracket.models.db.match import (
     Match,
     MatchSetScoreEditBody,
@@ -55,13 +46,12 @@ async def recalculate_after_match_change(
     elif new_state is not MatchState.COMPLETED and match.completed_at is not None:
         await sql_set_match_completed_at(match.id, None)
 
-    await recalculate_ranking_for_stage_item(tournament_id, stage_item)
-    await auto_resolve_next_swiss_round(tournament_id, stage_item)
-
-    if stage_item.type == StageType.SINGLE_ELIMINATION:
-        await update_inputs_in_subsequent_elimination_rounds(round_.id, stage_item, {match.id})
-
-    await resolve_dependent_inputs_for_completed_stage_item(tournament_id, stage_item.id)
+    await reconcile_stage_item(
+        tournament_id,
+        stage_item,
+        changed_round_id=round_.id,
+        changed_match_ids={match.id},
+    )
 
     updated = await sql_get_match_with_details(tournament_id, match.id)
     if updated is None:

--- a/backend/bracket/logic/reconcile.py
+++ b/backend/bracket/logic/reconcile.py
@@ -1,0 +1,46 @@
+from bracket.logic.ranking.calculation import recalculate_ranking_for_stage_item
+from bracket.logic.ranking.elimination import (
+    update_inputs_in_complete_elimination_stage_item,
+    update_inputs_in_subsequent_elimination_rounds,
+)
+from bracket.logic.scheduling.handle_stage_activation import (
+    resolve_dependent_inputs_for_completed_stage_item,
+)
+from bracket.logic.scheduling.swiss_resolution_orchestrator import (
+    auto_resolve_next_swiss_round,
+)
+from bracket.models.db.stage_item import StageType
+from bracket.models.db.util import StageItemWithRounds
+from bracket.utils.id_types import MatchId, RoundId, TournamentId
+
+
+async def reconcile_stage_item(
+    tournament_id: TournamentId,
+    stage_item: StageItemWithRounds,
+    *,
+    changed_round_id: RoundId | None = None,
+    changed_match_ids: set[MatchId] | None = None,
+) -> None:
+    """Reconciliation.
+
+    After anything moves a stage item's standings (score change, ranking config edit, round
+    deletion, stage item rebuild), bring every standings-derived structure back in line: team
+    stats/ELO, Swiss round pairings, elimination-tree inputs, and cross-stage-item inputs that
+    reference this item's final ranking. Callers state THAT standings moved; this module decides
+    what follows. All steps are idempotent no-ops when nothing they manage changed.
+    """
+    if changed_match_ids is not None and changed_round_id is None:
+        raise ValueError("changed_match_ids may only be passed together with changed_round_id")
+
+    await recalculate_ranking_for_stage_item(tournament_id, stage_item)
+    await auto_resolve_next_swiss_round(tournament_id, stage_item)
+
+    if stage_item.type is StageType.SINGLE_ELIMINATION:
+        if changed_round_id is not None:
+            await update_inputs_in_subsequent_elimination_rounds(
+                changed_round_id, stage_item, changed_match_ids
+            )
+        else:
+            await update_inputs_in_complete_elimination_stage_item(stage_item)
+
+    await resolve_dependent_inputs_for_completed_stage_item(tournament_id, stage_item.id)

--- a/backend/bracket/logic/scheduling/builder.py
+++ b/backend/bracket/logic/scheduling/builder.py
@@ -1,7 +1,7 @@
 from fastapi import HTTPException
 from heliclockter import datetime_utc
 
-from bracket.logic.ranking.calculation import recalculate_ranking_for_stage_item
+from bracket.logic.reconcile import reconcile_stage_item
 from bracket.logic.scheduling.elimination import (
     build_single_elimination_stage_item,
     get_number_of_rounds_to_create_single_elimination,
@@ -107,7 +107,7 @@ async def build_matches_for_stage_item(stage_item: StageItem, tournament_id: Tou
                 400, f"Cannot automatically create matches for stage type {stage_item.type}"
             )
 
-    await recalculate_ranking_for_stage_item(tournament_id, stage_item_with_rounds)
+    await reconcile_stage_item(tournament_id, stage_item_with_rounds)
 
 
 def determine_available_inputs(

--- a/backend/bracket/logic/scheduling/handle_stage_activation.py
+++ b/backend/bracket/logic/scheduling/handle_stage_activation.py
@@ -11,7 +11,7 @@ from bracket.logic.scheduling.swiss_slot_assigner import (
 from bracket.models.db.match import MatchState
 from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.stage_item import StageType
-from bracket.models.db.stage_item_inputs import StageItemInputFinal
+from bracket.models.db.stage_item_inputs import StageItemInput, StageItemInputFinal
 from bracket.models.db.util import StageItemWithRounds, StageWithStageItems
 from bracket.sql.matches import sql_set_input_ids_for_match
 from bracket.sql.rankings import get_ranking_for_stage_item
@@ -26,6 +26,7 @@ from bracket.sql.stages import get_full_tournament_details
 from bracket.utils.id_types import (
     StageItemId,
     StageItemInputId,
+    TeamId,
     TournamentId,
 )
 from bracket.utils.types import assert_some
@@ -199,6 +200,11 @@ async def resolve_dependent_inputs_for_completed_stage_item(
 
     team_rankings = await get_team_rankings_lookup_for_tournament(tournament_id, stages)
 
+    # Compute every target assignment before writing anything: sibling inputs of the same
+    # dependent stage item may swap teams (e.g. a ranking edit flips positions 1 and 2 of the
+    # source), and updating them one row at a time would transiently violate the unique
+    # (stage_item_id, team_id) constraint.
+    assignments: list[tuple[StageItemInput, TeamId]] = []
     affected_stage_item_ids: set[StageItemId] = set()
     for stage in stages:
         for stage_item in stage.stage_items:
@@ -215,10 +221,22 @@ async def resolve_dependent_inputs_for_completed_stage_item(
                 if not isinstance(target_input, StageItemInputFinal):
                     continue
 
-                await sql_set_team_id_for_stage_item_input(
-                    tournament_id, stage_item_input.id, target_input.team.id
-                )
+                assignments.append((stage_item_input, target_input.team.id))
                 affected_stage_item_ids.add(stage_item.id)
+
+    # Two passes inside a transaction (a savepoint when the caller already holds one), so the
+    # intermediate NULL state is never visible outside: first clear every input whose team
+    # changes, then write the final team ids. This makes any permutation of teams among the
+    # dependent inputs safe with respect to the unique constraint.
+    async with database.transaction():
+        for stage_item_input, new_team_id in assignments:
+            if stage_item_input.team_id is not None and stage_item_input.team_id != new_team_id:
+                await sql_set_team_id_for_stage_item_input(tournament_id, stage_item_input.id, None)
+
+        for stage_item_input, new_team_id in assignments:
+            await sql_set_team_id_for_stage_item_input(
+                tournament_id, stage_item_input.id, new_team_id
+            )
 
     for stage_item_id in affected_stage_item_ids:
         affected_stage_item = await get_stage_item(tournament_id, stage_item_id)

--- a/backend/bracket/routes/rankings.py
+++ b/backend/bracket/routes/rankings.py
@@ -3,10 +3,7 @@ from starlette import status
 
 from bracket.config import config
 from bracket.database import database
-from bracket.logic.ranking.calculation import recalculate_ranking_for_stage_item
-from bracket.logic.ranking.elimination import (
-    update_inputs_in_complete_elimination_stage_item,
-)
+from bracket.logic.reconcile import reconcile_stage_item
 from bracket.logic.subscriptions import check_requirement
 from bracket.models.db.ranking import RankingBody, RankingCreateBody
 from bracket.models.db.stage_item import StageType
@@ -96,10 +93,7 @@ async def update_ranking_by_id(
         stage_item_ids = await get_stage_item_ids_by_ranking_id(ranking_id)
         for stage_item_id in stage_item_ids:
             stage_item = await get_stage_item(tournament_id, stage_item_id)
-            await recalculate_ranking_for_stage_item(tournament_id, stage_item)
-
-            if stage_item.type == StageType.SINGLE_ELIMINATION:
-                await update_inputs_in_complete_elimination_stage_item(stage_item)
+            await reconcile_stage_item(tournament_id, stage_item)
     return SuccessResponse()
 
 

--- a/backend/bracket/routes/rounds.py
+++ b/backend/bracket/routes/rounds.py
@@ -3,9 +3,7 @@ from starlette import status
 
 from bracket.config import config
 from bracket.database import database
-from bracket.logic.ranking.calculation import (
-    recalculate_ranking_for_stage_item,
-)
+from bracket.logic.reconcile import reconcile_stage_item
 from bracket.logic.subscriptions import check_requirement
 from bracket.models.db.match import MatchState
 from bracket.models.db.round import (
@@ -56,7 +54,7 @@ async def delete_round(
     await sql_delete_round(round_id)
 
     stage_item = await get_stage_item(tournament_id, round_with_matches.stage_item_id)
-    await recalculate_ranking_for_stage_item(tournament_id, stage_item)
+    await reconcile_stage_item(tournament_id, stage_item)
     return SuccessResponse()
 
 

--- a/backend/bracket/routes/stage_items.py
+++ b/backend/bracket/routes/stage_items.py
@@ -7,10 +7,7 @@ from starlette import status
 from bracket.config import config
 from bracket.database import database
 from bracket.logic.planning.matches import update_start_times_of_matches
-from bracket.logic.ranking.calculation import recalculate_ranking_for_stage_item
-from bracket.logic.ranking.elimination import (
-    update_inputs_in_complete_elimination_stage_item,
-)
+from bracket.logic.reconcile import reconcile_stage_item
 from bracket.logic.scheduling.builder import (
     build_matches_for_stage_item,
 )
@@ -563,9 +560,7 @@ async def update_stage_item(
             await build_matches_for_stage_item(updated_stage_item, tournament_id)
 
     updated_stage_item = await get_stage_item(tournament_id, stage_item_id)
-    await recalculate_ranking_for_stage_item(tournament_id, updated_stage_item)
-    if updated_stage_item.type == StageType.SINGLE_ELIMINATION:
-        await update_inputs_in_complete_elimination_stage_item(updated_stage_item)
+    await reconcile_stage_item(tournament_id, updated_stage_item)
     if team_count_changed:
         await update_start_times_of_matches(tournament_id)
     return SuccessResponse()

--- a/backend/bracket/routes/stages.py
+++ b/backend/bracket/routes/stages.py
@@ -6,10 +6,7 @@ from bracket.database import database
 from bracket.logic.levels import validate_level_id_for_tournament
 from bracket.logic.planning.template import build_template_blueprint, max_until_rank_for_template
 from bracket.logic.planning.template_service import replace_stages_from_template
-from bracket.logic.ranking.calculation import recalculate_ranking_for_stage_item
-from bracket.logic.ranking.elimination import (
-    update_inputs_in_complete_elimination_stage_item,
-)
+from bracket.logic.reconcile import reconcile_stage_item
 from bracket.logic.scheduling.builder import determine_available_inputs
 from bracket.logic.subscriptions import check_requirement
 from bracket.models.db.stage import (
@@ -212,9 +209,7 @@ async def set_ranking_for_stage_items(
 
         for stage_item in stage.stage_items:
             updated_stage_item = await get_stage_item(tournament_id, stage_item.id)
-            await recalculate_ranking_for_stage_item(tournament_id, updated_stage_item)
-            if updated_stage_item.type is StageType.SINGLE_ELIMINATION:
-                await update_inputs_in_complete_elimination_stage_item(updated_stage_item)
+            await reconcile_stage_item(tournament_id, updated_stage_item)
 
     return SuccessResponse()
 

--- a/backend/tests/integration_tests/api/rankings_test.py
+++ b/backend/tests/integration_tests/api/rankings_test.py
@@ -27,6 +27,7 @@ from bracket.utils.dummy_records import (
     DUMMY_TEAM1,
 )
 from bracket.utils.http import HTTPMethod
+from bracket.utils.id_types import RankingId, StageId, TeamId, TournamentId
 from tests.integration_tests.api.shared import (
     SUCCESS_RESPONSE,
     complete_match,
@@ -418,6 +419,73 @@ async def test_update_ranking_even_sets_round_robin_succeeds(
                 assert response.get("success") is True, response
 
 
+async def _play_group_with_t1_win_and_draws(
+    auth_context: AuthContext,
+    tournament_id: TournamentId,
+    t1_id: TeamId,
+    t3_id: TeamId,
+) -> None:
+    """Play out a 3-team round robin (the tournament's first stage): team 1 beats team 3, and
+    the other two matches end in draws. Under the default 1.0/0.5/0.0 match points this ranks
+    team 1 first (1.5 points), team 2 second (1.0) and team 3 last (0.5).
+    """
+    [group_stage, _] = await get_full_tournament_details(tournament_id)
+    real_matches = [
+        match
+        for round_ in group_stage.stage_items[0].rounds
+        for match in round_.matches
+        if match.stage_item_input1 is not None and match.stage_item_input2 is not None
+    ]
+    assert len(real_matches) == 3
+
+    for match in real_matches:
+        input1 = match.stage_item_input1
+        input2 = match.stage_item_input2
+        assert isinstance(input1, StageItemInputFinal)
+        assert isinstance(input2, StageItemInputFinal)
+        teams = {input1.team.id, input2.team.id}
+
+        if teams == {t1_id, t3_id}:
+            # Team 1 beats team 3 outright.
+            score1, score2 = (21, 0) if input1.team.id == t1_id else (0, 21)
+        else:
+            # Team 1 vs team 2, and team 2 vs team 3, both end in a draw.
+            score1, score2 = 10, 10
+
+        for match_set in match.match_sets:
+            await complete_match(auth_context, match.id, match_set.id, score1=score1, score2=score2)
+
+
+async def _dependent_team_ids_by_slot(
+    tournament_id: TournamentId, dependent_stage_id: StageId
+) -> dict[int, TeamId | None]:
+    """Return slot -> resolved team id for the single stage item in the dependent stage."""
+    stages = await get_full_tournament_details(tournament_id)
+    dependent_stage = next(s for s in stages if s.id == dependent_stage_id)
+    return {input_.slot: input_.team_id for input_ in dependent_stage.stage_items[0].inputs}
+
+
+async def _flip_standings_via_ranking_edit(
+    auth_context: AuthContext, ranking_id: RankingId
+) -> None:
+    """Edit the ranking so draws are worth more than the gap between a win and a draw.
+
+    After ``_play_group_with_t1_win_and_draws``: team 1 -> 1.0 (win) + 2.0 (draw) = 3.0, team 2
+    -> 2.0 + 2.0 = 4.0, team 3 -> 0.0 + 2.0 = 2.0. Team 2 overtakes team 1 purely from the
+    ranking edit -- no match result changed.
+    """
+    body = {
+        "scoring_type": "MATCH_POINTS",
+        "win_points": "1.0",
+        "draw_points": "2.0",
+        "loss_points": "0.0",
+    }
+    response = await send_tournament_request(
+        HTTPMethod.PUT, f"rankings/{ranking_id}", auth_context, json=body
+    )
+    assert response.get("success") is True, response
+
+
 @pytest.mark.asyncio(loop_scope="session")
 async def test_update_ranking_reflows_dependent_stage_item_inputs(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
@@ -461,12 +529,8 @@ async def test_update_ranking_reflows_dependent_stage_item_inputs(
             ),
         )
         # Slot 2 references a fixed, unrelated team (t4) rather than "winner position 2 of
-        # stage item 1": resolve_dependent_inputs_for_completed_stage_item updates each
-        # dependent input's team_id one row at a time, so having two sibling inputs both
-        # tracking positions in the same source stage item can transiently collide with the
-        # unique (stage_item_id, team_id) constraint when their target teams swap places. That
-        # ordering quirk is a pre-existing, separate issue in that function; keeping slot 2
-        # fixed isolates the propagation behavior this test is actually about.
+        # stage item 1", so this test isolates single-input propagation. The full two-sibling
+        # swap case is covered by test_update_ranking_swaps_teams_between_dependent_inputs.
         stage_item_2 = await sql_create_stage_item_with_inputs(
             tournament_id,
             StageItemWithInputsCreate(
@@ -486,74 +550,101 @@ async def test_update_ranking_reflows_dependent_stage_item_inputs(
         await build_matches_for_stage_item(stage_item_2, tournament_id)
 
         try:
-            # Play out the group stage so that, under the default 1.0/0.5/0.0 match points,
-            # team 1 finishes first (a win and a draw), team 2 second (two draws), and team 3
-            # last (a loss and a draw).
-            [group_stage, _] = await get_full_tournament_details(tournament_id)
-            real_matches = [
-                match
-                for round_ in group_stage.stage_items[0].rounds
-                for match in round_.matches
-                if match.stage_item_input1 is not None and match.stage_item_input2 is not None
-            ]
-            assert len(real_matches) == 3
+            await _play_group_with_t1_win_and_draws(auth_context, tournament_id, t1.id, t3.id)
 
-            for match in real_matches:
-                input1 = match.stage_item_input1
-                input2 = match.stage_item_input2
-                assert isinstance(input1, StageItemInputFinal)
-                assert isinstance(input2, StageItemInputFinal)
-                teams = {input1.team.id, input2.team.id}
+            # Team 1 is the winner, so the dependent stage item's first input must already be
+            # resolved to team 1.
+            teams_by_slot = await _dependent_team_ids_by_slot(tournament_id, stage_inserted_2.id)
+            assert teams_by_slot == {1: t1.id, 2: t4.id}
 
-                if teams == {t1.id, t3.id}:
-                    # Team 1 beats team 3 outright.
-                    score1, score2 = (21, 0) if input1.team.id == t1.id else (0, 21)
-                else:
-                    # Team 1 vs team 2, and team 2 vs team 3, both end in a draw.
-                    score1, score2 = 10, 10
-
-                for match_set in match.match_sets:
-                    await complete_match(
-                        auth_context, match.id, match_set.id, score1=score1, score2=score2
-                    )
-
-            # With the default scoring (win=1.0, draw=0.5, loss=0.0): team 1 has 1.5 points,
-            # team 2 has 1.0, team 3 has 0.5. Team 1 is the winner, so the dependent stage
-            # item's first input must already be resolved to team 1.
-            stages = await get_full_tournament_details(tournament_id)
-            next_stage = next(s for s in stages if s.id == stage_inserted_2.id)
-            first_input = next(i for i in next_stage.stage_items[0].inputs if i.slot == 1)
-            assert isinstance(first_input, StageItemInputFinal)
-            assert first_input.team.id == t1.id
-
-            # Now edit the ranking so draws are worth more than the gap between a win and a
-            # draw: team 1 -> 1.0 (win) + 2.0 (draw) = 3.0, team 2 -> 2.0 + 2.0 = 4.0, team 3 ->
-            # 0.0 + 2.0 = 2.0. Team 2 is now the winner, purely from the ranking edit -- no
-            # match result changed.
-            body = {
-                "scoring_type": "MATCH_POINTS",
-                "win_points": "1.0",
-                "draw_points": "2.0",
-                "loss_points": "0.0",
-            }
-            response = await send_tournament_request(
-                HTTPMethod.PUT,
-                f"rankings/{test_ranking.id}",
-                auth_context,
-                json=body,
-            )
-            assert response.get("success") is True, response
+            await _flip_standings_via_ranking_edit(auth_context, test_ranking.id)
 
             # The dependent stage item's first input must now be re-resolved to team 2: this is
             # the propagation that didn't happen before the ranking route was switched to the
             # shared reconciliation cascade.
-            stages_after = await get_full_tournament_details(tournament_id)
-            next_stage_after = next(s for s in stages_after if s.id == stage_inserted_2.id)
-            first_input_after = next(
-                i for i in next_stage_after.stage_items[0].inputs if i.slot == 1
-            )
-            assert isinstance(first_input_after, StageItemInputFinal)
-            assert first_input_after.team.id == t2.id
+            teams_by_slot = await _dependent_team_ids_by_slot(tournament_id, stage_inserted_2.id)
+            assert teams_by_slot == {1: t2.id, 2: t4.id}
+        finally:
+            await sql_delete_stage_item_with_foreign_keys(stage_item_2.id)
+            await sql_delete_stage_item_with_foreign_keys(stage_item_1.id)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_ranking_swaps_teams_between_dependent_inputs(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """A ranking edit that swaps positions 1 and 2 of the source stage item must swap the teams
+    of the two dependent sibling inputs tracking those positions, without violating the unique
+    (stage_item_id, team_id) constraint. resolve_dependent_inputs_for_completed_stage_item used
+    to update each input's team_id one row at a time, which crashed with a UniqueViolationError
+    on exactly this full-swap case; it now clears every changing row before writing the final
+    assignments.
+    """
+    tournament_id = auth_context.tournament.id
+
+    async with (
+        inserted_ranking(
+            DUMMY_RANKING1.model_copy(update={"tournament_id": tournament_id, "position": 5})
+        ) as test_ranking,
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
+        ) as stage_inserted_1,
+        inserted_stage(
+            DUMMY_STAGE2.model_copy(update={"tournament_id": tournament_id})
+        ) as stage_inserted_2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t1,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t3,
+    ):
+        stage_item_1 = await sql_create_stage_item_with_inputs(
+            tournament_id,
+            StageItemWithInputsCreate(
+                stage_id=stage_inserted_1.id,
+                name="Group",
+                team_count=3,
+                type=StageType.ROUND_ROBIN,
+                ranking_id=test_ranking.id,
+                inputs=[
+                    StageItemInputCreateBodyFinal(slot=1, team_id=t1.id),
+                    StageItemInputCreateBodyFinal(slot=2, team_id=t2.id),
+                    StageItemInputCreateBodyFinal(slot=3, team_id=t3.id),
+                ],
+            ),
+        )
+        # Both dependent inputs track positions in the same source stage item, so a standings
+        # flip between positions 1 and 2 forces a full swap of teams between sibling rows.
+        stage_item_2 = await sql_create_stage_item_with_inputs(
+            tournament_id,
+            StageItemWithInputsCreate(
+                stage_id=stage_inserted_2.id,
+                name=DUMMY_STAGE_ITEM3.name,
+                team_count=2,
+                type=DUMMY_STAGE_ITEM3.type,
+                inputs=[
+                    StageItemInputCreateBodyTentative(
+                        slot=1, winner_from_stage_item_id=stage_item_1.id, winner_position=1
+                    ),
+                    StageItemInputCreateBodyTentative(
+                        slot=2, winner_from_stage_item_id=stage_item_1.id, winner_position=2
+                    ),
+                ],
+            ),
+        )
+        await build_matches_for_stage_item(stage_item_1, tournament_id)
+        await build_matches_for_stage_item(stage_item_2, tournament_id)
+
+        try:
+            await _play_group_with_t1_win_and_draws(auth_context, tournament_id, t1.id, t3.id)
+
+            teams_by_slot = await _dependent_team_ids_by_slot(tournament_id, stage_inserted_2.id)
+            assert teams_by_slot == {1: t1.id, 2: t2.id}
+
+            # The ranking edit swaps positions 1 and 2, so both dependent inputs must trade
+            # teams -- previously a UniqueViolationError.
+            await _flip_standings_via_ranking_edit(auth_context, test_ranking.id)
+
+            teams_by_slot = await _dependent_team_ids_by_slot(tournament_id, stage_inserted_2.id)
+            assert teams_by_slot == {1: t2.id, 2: t1.id}
         finally:
             await sql_delete_stage_item_with_foreign_keys(stage_item_2.id)
             await sql_delete_stage_item_with_foreign_keys(stage_item_1.id)

--- a/backend/tests/integration_tests/api/rankings_test.py
+++ b/backend/tests/integration_tests/api/rankings_test.py
@@ -3,20 +3,35 @@ from unittest.mock import ANY
 
 import pytest
 
+from bracket.logic.scheduling.builder import build_matches_for_stage_item
 from bracket.models.db.ranking import ScoringType
+from bracket.models.db.stage_item import StageItemWithInputsCreate, StageType
+from bracket.models.db.stage_item_inputs import (
+    StageItemInputCreateBodyFinal,
+    StageItemInputCreateBodyTentative,
+    StageItemInputFinal,
+)
 from bracket.sql.rankings import (
     get_all_rankings_in_tournament,
     sql_delete_ranking,
 )
+from bracket.sql.shared import sql_delete_stage_item_with_foreign_keys
+from bracket.sql.stage_items import sql_create_stage_item_with_inputs
+from bracket.sql.stages import get_full_tournament_details
 from bracket.utils.dummy_records import (
     DUMMY_RANKING1,
     DUMMY_STAGE1,
+    DUMMY_STAGE2,
     DUMMY_STAGE_ITEM1,
     DUMMY_STAGE_ITEM3,
     DUMMY_TEAM1,
 )
 from bracket.utils.http import HTTPMethod
-from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
+from tests.integration_tests.api.shared import (
+    SUCCESS_RESPONSE,
+    complete_match,
+    send_tournament_request,
+)
 from tests.integration_tests.models import AuthContext
 from tests.integration_tests.sql import (
     inserted_ranking,
@@ -401,3 +416,144 @@ async def test_update_ranking_even_sets_round_robin_succeeds(
                     json=body,
                 )
                 assert response.get("success") is True, response
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_ranking_reflows_dependent_stage_item_inputs(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """A ranking edit that flips a completed stage item's final order must re-resolve any
+    "winner of <stage item>" input elsewhere in the tournament, exactly like completing a match
+    does. Before the fix, the ranking PUT route only recalculated the ranking and (for single
+    elimination) the elimination tree, so a dependent stage item's input kept pointing at the
+    stale winner.
+    """
+    tournament_id = auth_context.tournament.id
+
+    async with (
+        inserted_ranking(
+            DUMMY_RANKING1.model_copy(update={"tournament_id": tournament_id, "position": 5})
+        ) as test_ranking,
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
+        ) as stage_inserted_1,
+        inserted_stage(
+            DUMMY_STAGE2.model_copy(update={"tournament_id": tournament_id})
+        ) as stage_inserted_2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t1,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t3,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t4,
+    ):
+        stage_item_1 = await sql_create_stage_item_with_inputs(
+            tournament_id,
+            StageItemWithInputsCreate(
+                stage_id=stage_inserted_1.id,
+                name="Group",
+                team_count=3,
+                type=StageType.ROUND_ROBIN,
+                ranking_id=test_ranking.id,
+                inputs=[
+                    StageItemInputCreateBodyFinal(slot=1, team_id=t1.id),
+                    StageItemInputCreateBodyFinal(slot=2, team_id=t2.id),
+                    StageItemInputCreateBodyFinal(slot=3, team_id=t3.id),
+                ],
+            ),
+        )
+        # Slot 2 references a fixed, unrelated team (t4) rather than "winner position 2 of
+        # stage item 1": resolve_dependent_inputs_for_completed_stage_item updates each
+        # dependent input's team_id one row at a time, so having two sibling inputs both
+        # tracking positions in the same source stage item can transiently collide with the
+        # unique (stage_item_id, team_id) constraint when their target teams swap places. That
+        # ordering quirk is a pre-existing, separate issue in that function; keeping slot 2
+        # fixed isolates the propagation behavior this test is actually about.
+        stage_item_2 = await sql_create_stage_item_with_inputs(
+            tournament_id,
+            StageItemWithInputsCreate(
+                stage_id=stage_inserted_2.id,
+                name=DUMMY_STAGE_ITEM3.name,
+                team_count=2,
+                type=DUMMY_STAGE_ITEM3.type,
+                inputs=[
+                    StageItemInputCreateBodyTentative(
+                        slot=1, winner_from_stage_item_id=stage_item_1.id, winner_position=1
+                    ),
+                    StageItemInputCreateBodyFinal(slot=2, team_id=t4.id),
+                ],
+            ),
+        )
+        await build_matches_for_stage_item(stage_item_1, tournament_id)
+        await build_matches_for_stage_item(stage_item_2, tournament_id)
+
+        try:
+            # Play out the group stage so that, under the default 1.0/0.5/0.0 match points,
+            # team 1 finishes first (a win and a draw), team 2 second (two draws), and team 3
+            # last (a loss and a draw).
+            [group_stage, _] = await get_full_tournament_details(tournament_id)
+            real_matches = [
+                match
+                for round_ in group_stage.stage_items[0].rounds
+                for match in round_.matches
+                if match.stage_item_input1 is not None and match.stage_item_input2 is not None
+            ]
+            assert len(real_matches) == 3
+
+            for match in real_matches:
+                input1 = match.stage_item_input1
+                input2 = match.stage_item_input2
+                assert isinstance(input1, StageItemInputFinal)
+                assert isinstance(input2, StageItemInputFinal)
+                teams = {input1.team.id, input2.team.id}
+
+                if teams == {t1.id, t3.id}:
+                    # Team 1 beats team 3 outright.
+                    score1, score2 = (21, 0) if input1.team.id == t1.id else (0, 21)
+                else:
+                    # Team 1 vs team 2, and team 2 vs team 3, both end in a draw.
+                    score1, score2 = 10, 10
+
+                for match_set in match.match_sets:
+                    await complete_match(
+                        auth_context, match.id, match_set.id, score1=score1, score2=score2
+                    )
+
+            # With the default scoring (win=1.0, draw=0.5, loss=0.0): team 1 has 1.5 points,
+            # team 2 has 1.0, team 3 has 0.5. Team 1 is the winner, so the dependent stage
+            # item's first input must already be resolved to team 1.
+            stages = await get_full_tournament_details(tournament_id)
+            next_stage = next(s for s in stages if s.id == stage_inserted_2.id)
+            first_input = next(i for i in next_stage.stage_items[0].inputs if i.slot == 1)
+            assert isinstance(first_input, StageItemInputFinal)
+            assert first_input.team.id == t1.id
+
+            # Now edit the ranking so draws are worth more than the gap between a win and a
+            # draw: team 1 -> 1.0 (win) + 2.0 (draw) = 3.0, team 2 -> 2.0 + 2.0 = 4.0, team 3 ->
+            # 0.0 + 2.0 = 2.0. Team 2 is now the winner, purely from the ranking edit -- no
+            # match result changed.
+            body = {
+                "scoring_type": "MATCH_POINTS",
+                "win_points": "1.0",
+                "draw_points": "2.0",
+                "loss_points": "0.0",
+            }
+            response = await send_tournament_request(
+                HTTPMethod.PUT,
+                f"rankings/{test_ranking.id}",
+                auth_context,
+                json=body,
+            )
+            assert response.get("success") is True, response
+
+            # The dependent stage item's first input must now be re-resolved to team 2: this is
+            # the propagation that didn't happen before the ranking route was switched to the
+            # shared reconciliation cascade.
+            stages_after = await get_full_tournament_details(tournament_id)
+            next_stage_after = next(s for s in stages_after if s.id == stage_inserted_2.id)
+            first_input_after = next(
+                i for i in next_stage_after.stage_items[0].inputs if i.slot == 1
+            )
+            assert isinstance(first_input_after, StageItemInputFinal)
+            assert first_input_after.team.id == t2.id
+        finally:
+            await sql_delete_stage_item_with_foreign_keys(stage_item_2.id)
+            await sql_delete_stage_item_with_foreign_keys(stage_item_1.id)

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -1,0 +1,26 @@
+# Bracket
+
+Tournament system: a Club runs Tournaments; a Tournament has Stages; a Stage has Stage Items
+(a round-robin group, a single-elimination bracket, or a Swiss group); a Stage Item has Rounds
+of Matches. Stage Items connect via Stage Item Inputs, which reference either a team directly
+or a ranking position of another Stage Item.
+
+## Language
+
+**Standings**:
+The ranking-derived order of a Stage Item's inputs, computed from completed matches
+(points/ELO, set difference, point difference).
+_Avoid_: leaderboard, table
+
+**Reconciliation**:
+Bringing every standings-derived structure back in line after anything moves a Stage Item's
+standings: team statistics, Swiss round pairings, elimination-tree inputs, and cross-stage
+inputs that reference the item's final ranking. Callers state *that* standings moved; the
+reconciliation module decides what follows.
+_Avoid_: recalculation-cascade, propagation (as a noun for the whole concept)
+
+**Resolution**:
+Filling a placeholder with a concrete team: a Swiss Round is *resolved* when its matches get
+teams assigned; a Stage Item Input is *resolved* when its "winner of X" reference is replaced
+by an actual team.
+_Avoid_: activation (the old manual-stage-activation term), assignment


### PR DESCRIPTION
## Summary

When anything moves a stage item's standings, up to four follow-ups are due: ranking recompute, Swiss round re-resolution, elimination-tree input cascade, and cross-stage input resolution. Previously **six callers each hand-assembled a different subset**:

| Caller | ranking | swiss | elimination | cross-stage |
|---|---|---|---|---|
| score/verb path (`apply_update.py`) | ✓ | ✓ | ✓ (targeted) | ✓ |
| `routes/rankings.py` | ✓ | — | ✓ (complete) | — |
| `routes/stages.py` | ✓ | — | ✓ (complete) | — |
| `routes/stage_items.py` | ✓ | — | ✓ (complete) | — |
| `routes/rounds.py` (delete round) | ✓ | — | — | — |
| `logic/scheduling/builder.py` | ✓ | — | — | — |

This hid a real bug: a ranking config edit that flips a completed stage item's final order never re-paired Swiss rounds or re-resolved "winner of stage X" inputs elsewhere — while the identical standings change coming from a score edit did propagate.

### Changes

- **New `logic/reconcile.py`** — `reconcile_stage_item(tournament_id, stage_item, *, changed_round_id=None, changed_match_ids=None)` owns the ordering, the stage-type dispatch, and the choice between the targeted and whole-stage-item elimination cascade. All steps are idempotent no-ops when nothing they manage changed. All six call sites collapse to one call.
- **Fix a latent crash this made more reachable**: `resolve_dependent_inputs_for_completed_stage_item` updated dependent inputs one row at a time, so sibling inputs swapping teams (ranking edit flips source positions 1↔2) violated the unique `(stage_item_id, team_id)` constraint. Assignments are now computed up front and written in two passes (clear changed rows, then write finals) inside a transaction.
- **`docs/CONTEXT.md`** — new domain glossary defining *Standings*, *Reconciliation*, and *Resolution*.

### Tests

- `test_update_ranking_reflows_dependent_stage_item_inputs` — a ranking edit flips a round-robin group's winner; asserts the dependent stage item's "winner of group" input is re-resolved. Fails on the old wiring (verified).
- `test_update_ranking_swaps_teams_between_dependent_inputs` — two dependent inputs tracking positions 1 and 2 must fully swap teams after a ranking edit. Crashes with `UniqueViolationError` before the fix (verified).
- Full backend suite: **473 passed**. ruff/mypy/pyrefly/pylint/vulture clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi)_