### PR TITLE
Split reconciliation into pure planners and a single persistence seam

### DIFF
--- a/backend/bracket/logic/apply_plan.py
+++ b/backend/bracket/logic/apply_plan.py
@@ -1,0 +1,70 @@
+"""The persistence seam for reconciliation: logic modules return a plan of writes; this module
+crosses the database seam once.
+"""
+
+from collections.abc import Sequence
+
+from bracket.database import database
+from bracket.logic.plan import (
+    AssignTeamToInput,
+    PlanItem,
+    SetMatchInputs,
+    SetMatchRefereeSlot,
+    SetRoundLifecycleState,
+    SetTeamStats,
+)
+from bracket.sql.matches import sql_set_input_ids_for_match
+from bracket.sql.referees import sql_set_match_referee_slot
+from bracket.sql.rounds import set_round_lifecycle_state
+from bracket.sql.stage_item_inputs import sql_set_team_id_for_stage_item_input
+from bracket.sql.teams import update_team_stats
+from bracket.utils.id_types import TournamentId
+
+
+def ordered_team_assignment_writes(
+    items: Sequence[AssignTeamToInput],
+) -> list[AssignTeamToInput]:
+    """Order a batch of ``AssignTeamToInput`` writes swap-safely.
+
+    First NULL-clear every input whose team is actually changing, then write every final
+    assignment. This makes any permutation of teams among the batch (e.g. a ranking edit that
+    flips which position two dependent inputs track) safe with respect to the unique
+    (stage_item_id, team_id) constraint: the intermediate NULL state never collides, because it
+    is written for every changing row before any final value is written.
+    """
+    clears = [
+        AssignTeamToInput(item.stage_item_input_id, None, item.previous_team_id)
+        for item in items
+        if item.previous_team_id is not None and item.previous_team_id != item.team_id
+    ]
+    return [*clears, *items]
+
+
+async def apply_plan(tournament_id: TournamentId, plan: Sequence[PlanItem]) -> None:
+    """The persistence seam for reconciliation: logic modules return a plan of writes; this
+    module crosses the database seam once.
+
+    Opens a single transaction (a savepoint when already nested inside one) and dispatches every
+    plan item to the existing sql/ function that performs its write. ``AssignTeamToInput`` items
+    are applied as a batch via ``ordered_team_assignment_writes`` for swap safety; every other
+    item type is applied in the order it appears in the plan.
+    """
+    assignments = [item for item in plan if isinstance(item, AssignTeamToInput)]
+    other_items = [item for item in plan if not isinstance(item, AssignTeamToInput)]
+
+    async with database.transaction():
+        for item in other_items:
+            match item:
+                case SetTeamStats(stage_item_input_id, stats):
+                    await update_team_stats(tournament_id, stage_item_input_id, stats)
+                case SetMatchInputs(round_id, match_id, input_ids):
+                    await sql_set_input_ids_for_match(round_id, match_id, input_ids)
+                case SetMatchRefereeSlot(match_id, stage_item_input_id):
+                    await sql_set_match_referee_slot(match_id, stage_item_input_id)
+                case SetRoundLifecycleState(round_id, state):
+                    await set_round_lifecycle_state(round_id, tournament_id, state)
+
+        for assignment in ordered_team_assignment_writes(assignments):
+            await sql_set_team_id_for_stage_item_input(
+                tournament_id, assignment.stage_item_input_id, assignment.team_id
+            )

--- a/backend/bracket/logic/plan.py
+++ b/backend/bracket/logic/plan.py
@@ -1,0 +1,59 @@
+"""Plan vocabulary for reconciliation writes.
+
+Reconciliation logic (ranking recalculation, Swiss pairing, elimination cascades, dependent-input
+resolution) decides *what* needs to change. Rather than each step welding that decision to its own
+ad-hoc write loop, every step returns a list of these immutable plan items describing the writes
+it wants made. ``bracket.logic.apply_plan.apply_plan`` is the only place that turns a plan into
+actual database writes.
+"""
+
+from dataclasses import dataclass
+
+from bracket.logic.ranking.statistics import TeamStatistics
+from bracket.models.db.round import RoundLifecycleState
+from bracket.utils.id_types import MatchId, RoundId, StageItemInputId, TeamId
+
+
+@dataclass(frozen=True)
+class SetTeamStats:
+    stage_item_input_id: StageItemInputId
+    stats: TeamStatistics
+
+
+@dataclass(frozen=True)
+class SetMatchInputs:
+    round_id: RoundId
+    match_id: MatchId
+    input_ids: list[StageItemInputId | None]
+
+
+@dataclass(frozen=True)
+class SetMatchRefereeSlot:
+    match_id: MatchId
+    stage_item_input_id: StageItemInputId
+
+
+@dataclass(frozen=True)
+class SetRoundLifecycleState:
+    round_id: RoundId
+    state: RoundLifecycleState
+
+
+@dataclass(frozen=True)
+class AssignTeamToInput:
+    """Assign (or clear, when ``team_id`` is None) the team of a stage item input.
+
+    ``previous_team_id`` is the team currently assigned to this input (None if it has none yet).
+    It carries no write of its own; it lets the applier order a batch of these swap-safely, since
+    two sibling inputs trading teams would otherwise transiently violate the unique
+    (stage_item_id, team_id) constraint.
+    """
+
+    stage_item_input_id: StageItemInputId
+    team_id: TeamId | None
+    previous_team_id: TeamId | None
+
+
+PlanItem = (
+    SetTeamStats | SetMatchInputs | SetMatchRefereeSlot | SetRoundLifecycleState | AssignTeamToInput
+)

--- a/backend/bracket/logic/ranking/calculation.py
+++ b/backend/bracket/logic/ranking/calculation.py
@@ -2,13 +2,14 @@ import math
 from collections import defaultdict
 from decimal import Decimal
 
+from bracket.logic.apply_plan import apply_plan
+from bracket.logic.plan import PlanItem, SetTeamStats
 from bracket.logic.ranking.statistics import START_ELO, TeamStatistics
 from bracket.models.db.match import MatchState, MatchWithDetailsDefinitive
 from bracket.models.db.ranking import Ranking, ScoringType
 from bracket.models.db.stage_item import StageType
 from bracket.models.db.util import StageItemWithRounds
 from bracket.sql.rankings import get_ranking_for_stage_item
-from bracket.sql.teams import update_team_stats
 from bracket.utils.id_types import StageItemInputId, TournamentId
 
 K = 32
@@ -146,6 +147,22 @@ def determine_team_ranking_for_stage_item(
     )
 
 
+def build_team_stats_plan(
+    stage_item: StageItemWithRounds,
+    ranking: Ranking,
+) -> list[PlanItem]:
+    """Compute the ``SetTeamStats`` writes for every concrete input of ``stage_item``."""
+    stats_per_input = determine_ranking_for_stage_item(stage_item, ranking)
+    return [
+        SetTeamStats(
+            stage_item_input_id=stage_item_input.id,
+            stats=stats_per_input[stage_item_input.id],
+        )
+        for stage_item_input in stage_item.inputs
+        if stage_item_input.team_id is not None
+    ]
+
+
 async def recalculate_ranking_for_stage_item(
     tournament_id: TournamentId,
     stage_item: StageItemWithRounds,
@@ -154,15 +171,5 @@ async def recalculate_ranking_for_stage_item(
     assert stage_item, "Stage item not found"
     assert ranking, "Ranking not found"
 
-    team_x_stage_item_input_lookup = {
-        stage_item_input.team_id: stage_item_input.id
-        for stage_item_input in stage_item.inputs
-        if stage_item_input.team_id is not None
-    }
-
-    elo_per_input = determine_ranking_for_stage_item(stage_item, ranking)
-
-    for stage_item_input_id in team_x_stage_item_input_lookup.values():
-        await update_team_stats(
-            tournament_id, stage_item_input_id, elo_per_input[stage_item_input_id]
-        )
+    plan = build_team_stats_plan(stage_item, ranking)
+    await apply_plan(tournament_id, plan)

--- a/backend/bracket/logic/ranking/elimination.py
+++ b/backend/bracket/logic/ranking/elimination.py
@@ -1,12 +1,14 @@
 from collections import defaultdict
 
+from bracket.logic.apply_plan import apply_plan
+from bracket.logic.plan import PlanItem, SetMatchInputs
 from bracket.models.db.match import Match, MatchState, derive_match_state
 from bracket.models.db.stage_item_inputs import StageItemInput
 from bracket.models.db.util import StageItemWithRounds
-from bracket.sql.matches import sql_set_input_ids_for_match
 from bracket.utils.id_types import (
     MatchId,
     RoundId,
+    TournamentId,
 )
 
 
@@ -165,7 +167,19 @@ def get_started_elimination_followers(
     return started
 
 
+def build_elimination_input_plan(updates: dict[MatchId, Match]) -> list[PlanItem]:
+    return [
+        SetMatchInputs(
+            round_id=match.round_id,
+            match_id=match.id,
+            input_ids=[match.stage_item_input1_id, match.stage_item_input2_id],
+        )
+        for match in updates.values()
+    ]
+
+
 async def update_inputs_in_subsequent_elimination_rounds(
+    tournament_id: TournamentId,
     current_round_id: RoundId,
     stage_item: StageItemWithRounds,
     match_ids: set[MatchId] | None = None,
@@ -173,14 +187,27 @@ async def update_inputs_in_subsequent_elimination_rounds(
     updates = get_inputs_to_update_in_subsequent_elimination_rounds(
         current_round_id, stage_item, match_ids
     )
-    for _, match in updates.items():
-        await sql_set_input_ids_for_match(
-            match.round_id, match.id, [match.stage_item_input1_id, match.stage_item_input2_id]
-        )
+    plan = build_elimination_input_plan(updates)
+    # Skip empty plans to avoid opening a pointless transaction.
+    if plan:
+        await apply_plan(tournament_id, plan)
 
 
 async def update_inputs_in_complete_elimination_stage_item(
+    tournament_id: TournamentId,
     stage_item: StageItemWithRounds,
 ) -> None:
-    for round_ in stage_item.rounds:
-        await update_inputs_in_subsequent_elimination_rounds(round_.id, stage_item)
+    # Each round's updates are computed by the pure planner against the same in-memory
+    # stage_item, which never changes across this loop (only the database does), so later
+    # iterations don't observe earlier ones' writes -- collecting every round's plan items and
+    # applying them once at the end is equivalent to applying them one round at a time.
+    plan: list[PlanItem] = [
+        item
+        for round_ in stage_item.rounds
+        for item in build_elimination_input_plan(
+            get_inputs_to_update_in_subsequent_elimination_rounds(round_.id, stage_item)
+        )
+    ]
+    # Skip empty plans to avoid opening a pointless transaction.
+    if plan:
+        await apply_plan(tournament_id, plan)

--- a/backend/bracket/logic/reconcile.py
+++ b/backend/bracket/logic/reconcile.py
@@ -38,9 +38,9 @@ async def reconcile_stage_item(
     if stage_item.type is StageType.SINGLE_ELIMINATION:
         if changed_round_id is not None:
             await update_inputs_in_subsequent_elimination_rounds(
-                changed_round_id, stage_item, changed_match_ids
+                tournament_id, changed_round_id, stage_item, changed_match_ids
             )
         else:
-            await update_inputs_in_complete_elimination_stage_item(stage_item)
+            await update_inputs_in_complete_elimination_stage_item(tournament_id, stage_item)
 
     await resolve_dependent_inputs_for_completed_stage_item(tournament_id, stage_item.id)

--- a/backend/bracket/logic/scheduling/handle_stage_activation.py
+++ b/backend/bracket/logic/scheduling/handle_stage_activation.py
@@ -1,32 +1,23 @@
 from bracket.database import database
+from bracket.logic.apply_plan import apply_plan
+from bracket.logic.plan import AssignTeamToInput, PlanItem
 from bracket.logic.ranking.calculation import (
     determine_team_ranking_for_stage_item,
 )
 from bracket.logic.ranking.statistics import TeamStatistics
-from bracket.logic.scheduling.swiss_round_pairing import select_round_pairing
-from bracket.logic.scheduling.swiss_slot_assigner import (
-    assign_pairs_to_slots,
-    skeleton_from_slot_pairs,
-)
+from bracket.logic.scheduling.swiss_resolution_orchestrator import build_round_assignment_plan
 from bracket.models.db.match import MatchState
 from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.stage_item import StageType
-from bracket.models.db.stage_item_inputs import StageItemInput, StageItemInputFinal
+from bracket.models.db.stage_item_inputs import StageItemInputFinal
 from bracket.models.db.util import StageItemWithRounds, StageWithStageItems
-from bracket.sql.matches import sql_set_input_ids_for_match
 from bracket.sql.rankings import get_ranking_for_stage_item
-from bracket.sql.referees import sql_set_match_referee_slot
-from bracket.sql.rounds import set_round_lifecycle_state
-from bracket.sql.stage_item_inputs import (
-    get_stage_item_input_by_id,
-    sql_set_team_id_for_stage_item_input,
-)
+from bracket.sql.stage_item_inputs import get_stage_item_input_by_id
 from bracket.sql.stage_items import get_stage_item
 from bracket.sql.stages import get_full_tournament_details
 from bracket.utils.id_types import (
     StageItemId,
     StageItemInputId,
-    TeamId,
     TournamentId,
 )
 from bracket.utils.types import assert_some
@@ -83,43 +74,11 @@ async def _resolve_round_1_for_swiss_stage_item(
     if first_round is None or first_round.lifecycle_state is not RoundLifecycleState.PLACEHOLDER:
         return
 
-    placeholder_round = first_round
-
-    inputs = [i for i in stage_item.inputs if isinstance(i, StageItemInputFinal) and i.team.active]
-    if not inputs:
-        return
-
-    slot_pairs = [
-        (m.input1_slot, m.input2_slot)
-        for m in placeholder_round.matches
-        if m.input1_slot is not None and m.input2_slot is not None
-    ]
-    bye_slot = next(
-        (m.referee_slot for m in placeholder_round.matches if m.referee_slot is not None),
-        None,
-    )
-
-    pairs, bye = select_round_pairing(inputs, [])
-    skeleton = skeleton_from_slot_pairs(slot_pairs, bye_slot)
-    slot_mapping = assign_pairs_to_slots(pairs, bye, skeleton)
-
-    for match in placeholder_round.matches:
-        if match.input1_slot is None or match.input2_slot is None:
-            continue
-        input1_id = slot_mapping.get(match.input1_slot)
-        input2_id = slot_mapping.get(match.input2_slot)
-        if input1_id is None or input2_id is None:
-            continue
-        await sql_set_input_ids_for_match(placeholder_round.id, match.id, [input1_id, input2_id])
-
-        if match.referee_slot is not None:
-            ref_id = slot_mapping.get(match.referee_slot)
-            if ref_id is not None:
-                await sql_set_match_referee_slot(match.id, ref_id)
-
-    await set_round_lifecycle_state(
-        placeholder_round.id, tournament_id, RoundLifecycleState.RESOLVED
-    )
+    # build_round_assignment_plan derives previous_rounds from stage_item.rounds, which are all
+    # still PLACEHOLDER at this point (round 1 is the very first round ever resolved), so it
+    # naturally computes the same empty previous_rounds this used to pass explicitly.
+    plan = build_round_assignment_plan(stage_item, first_round, advance_to_resolved=True)
+    await apply_plan(tournament_id, plan)
 
 
 async def try_resolve_first_swiss_round_when_inputs_filled(
@@ -203,8 +162,9 @@ async def resolve_dependent_inputs_for_completed_stage_item(
     # Compute every target assignment before writing anything: sibling inputs of the same
     # dependent stage item may swap teams (e.g. a ranking edit flips positions 1 and 2 of the
     # source), and updating them one row at a time would transiently violate the unique
-    # (stage_item_id, team_id) constraint.
-    assignments: list[tuple[StageItemInput, TeamId]] = []
+    # (stage_item_id, team_id) constraint. previous_team_id lets apply_plan order the batch
+    # swap-safely.
+    plan: list[PlanItem] = []
     affected_stage_item_ids: set[StageItemId] = set()
     for stage in stages:
         for stage_item in stage.stage_items:
@@ -221,22 +181,16 @@ async def resolve_dependent_inputs_for_completed_stage_item(
                 if not isinstance(target_input, StageItemInputFinal):
                     continue
 
-                assignments.append((stage_item_input, target_input.team.id))
+                plan.append(
+                    AssignTeamToInput(
+                        stage_item_input_id=stage_item_input.id,
+                        team_id=target_input.team.id,
+                        previous_team_id=stage_item_input.team_id,
+                    )
+                )
                 affected_stage_item_ids.add(stage_item.id)
 
-    # Two passes inside a transaction (a savepoint when the caller already holds one), so the
-    # intermediate NULL state is never visible outside: first clear every input whose team
-    # changes, then write the final team ids. This makes any permutation of teams among the
-    # dependent inputs safe with respect to the unique constraint.
-    async with database.transaction():
-        for stage_item_input, new_team_id in assignments:
-            if stage_item_input.team_id is not None and stage_item_input.team_id != new_team_id:
-                await sql_set_team_id_for_stage_item_input(tournament_id, stage_item_input.id, None)
-
-        for stage_item_input, new_team_id in assignments:
-            await sql_set_team_id_for_stage_item_input(
-                tournament_id, stage_item_input.id, new_team_id
-            )
+    await apply_plan(tournament_id, plan)
 
     for stage_item_id in affected_stage_item_ids:
         affected_stage_item = await get_stage_item(tournament_id, stage_item_id)

--- a/backend/bracket/logic/scheduling/swiss_resolution_orchestrator.py
+++ b/backend/bracket/logic/scheduling/swiss_resolution_orchestrator.py
@@ -1,3 +1,5 @@
+from bracket.logic.apply_plan import apply_plan
+from bracket.logic.plan import PlanItem, SetMatchInputs, SetMatchRefereeSlot, SetRoundLifecycleState
 from bracket.logic.scheduling.swiss_resolution_policy import (
     get_next_round_to_resolve,
     get_rounds_to_re_resolve,
@@ -12,24 +14,18 @@ from bracket.models.db.round import RoundLifecycleState
 from bracket.models.db.stage_item import StageType
 from bracket.models.db.stage_item_inputs import StageItemInputFinal
 from bracket.models.db.util import RoundWithMatches, StageItemWithRounds
-from bracket.sql.matches import sql_set_input_ids_for_match
-from bracket.sql.referees import sql_set_match_referee_slot
-from bracket.sql.rounds import set_round_lifecycle_state
 from bracket.sql.stage_items import get_stage_item
 from bracket.utils.id_types import TournamentId
 
 
-async def unwire_swiss_rounds_with_incomplete_predecessor(
-    tournament_id: TournamentId,
-    fresh: StageItemWithRounds,
-) -> bool:
-    """Clear team assignments and revert RESOLVED rounds with incomplete predecessors.
+def build_unwire_plan(fresh: StageItemWithRounds) -> list[PlanItem]:
+    """Plan clearing team assignments and reverting RESOLVED rounds with incomplete predecessors.
 
     Skips rounds that have already started (any match not NOT_STARTED) or that are pinned:
     no cascade may ever modify a downstream round that has started, and pinned rounds are
     never touched by the automated policy (consistent with ``get_rounds_to_re_resolve``).
     """
-    changed = False
+    plan: list[PlanItem] = []
     sorted_rounds = sorted(fresh.rounds, key=lambda r: r.id)
     for i, round_ in enumerate(sorted_rounds):
         if round_.lifecycle_state is not RoundLifecycleState.RESOLVED:
@@ -51,28 +47,49 @@ async def unwire_swiss_rounds_with_incomplete_predecessor(
 
         for match in round_.matches:
             if match.stage_item_input1_id is not None or match.stage_item_input2_id is not None:
-                await sql_set_input_ids_for_match(round_.id, match.id, [None, None])
-                changed = True
-        await set_round_lifecycle_state(round_.id, tournament_id, RoundLifecycleState.PLACEHOLDER)
-        changed = True
-    return changed
+                plan.append(
+                    SetMatchInputs(round_id=round_.id, match_id=match.id, input_ids=[None, None])
+                )
+        plan.append(
+            SetRoundLifecycleState(round_id=round_.id, state=RoundLifecycleState.PLACEHOLDER)
+        )
+    return plan
 
 
-async def _assign_teams_to_round(
+async def unwire_swiss_rounds_with_incomplete_predecessor(
     tournament_id: TournamentId,
     fresh: StageItemWithRounds,
+) -> bool:
+    """Clear team assignments and revert RESOLVED rounds with incomplete predecessors.
+
+    Returns whether anything changed (i.e. the plan was non-empty).
+    """
+    plan = build_unwire_plan(fresh)
+    if plan:
+        await apply_plan(tournament_id, plan)
+    return bool(plan)
+
+
+def build_round_assignment_plan(
+    stage_item: StageItemWithRounds,
     round_: RoundWithMatches,
     *,
     advance_to_resolved: bool,
-) -> None:
-    """Run pairing selection + slot assignment for a single round and persist the result."""
-    inputs = [i for i in fresh.inputs if isinstance(i, StageItemInputFinal) and i.team.active]
+) -> list[PlanItem]:
+    """Run pairing selection + slot assignment for a single round and plan the result.
+
+    Shared by the Swiss auto-resolution passes below and by round-1 resolution
+    (``handle_stage_activation._resolve_round_1_for_swiss_stage_item``), which resolves against a
+    ``stage_item`` whose other rounds are still all PLACEHOLDER -- the same as this function
+    computing an empty ``previous_rounds``.
+    """
+    inputs = [i for i in stage_item.inputs if isinstance(i, StageItemInputFinal) and i.team.active]
     if not inputs:
-        return
+        return []
 
     previous_rounds = [
         r
-        for r in fresh.rounds
+        for r in stage_item.rounds
         if r.lifecycle_state != RoundLifecycleState.PLACEHOLDER and r.id != round_.id
     ]
 
@@ -90,6 +107,7 @@ async def _assign_teams_to_round(
     skeleton = skeleton_from_slot_pairs(slot_pairs, bye_slot)
     slot_mapping = assign_pairs_to_slots(pairs, bye, skeleton)
 
+    plan: list[PlanItem] = []
     for match in round_.matches:
         if match.input1_slot is None or match.input2_slot is None:
             continue
@@ -97,15 +115,19 @@ async def _assign_teams_to_round(
         input2_id = slot_mapping.get(match.input2_slot)
         if input1_id is None or input2_id is None:
             continue
-        await sql_set_input_ids_for_match(round_.id, match.id, [input1_id, input2_id])
+        plan.append(
+            SetMatchInputs(round_id=round_.id, match_id=match.id, input_ids=[input1_id, input2_id])
+        )
 
         if match.referee_slot is not None:
             ref_id = slot_mapping.get(match.referee_slot)
             if ref_id is not None:
-                await sql_set_match_referee_slot(match.id, ref_id)
+                plan.append(SetMatchRefereeSlot(match_id=match.id, stage_item_input_id=ref_id))
 
     if advance_to_resolved:
-        await set_round_lifecycle_state(round_.id, tournament_id, RoundLifecycleState.RESOLVED)
+        plan.append(SetRoundLifecycleState(round_id=round_.id, state=RoundLifecycleState.RESOLVED))
+
+    return plan
 
 
 async def auto_resolve_next_swiss_round(
@@ -133,7 +155,8 @@ async def auto_resolve_next_swiss_round(
     if next_placeholder is not None:
         round_ = next((r for r in fresh.rounds if r.id == next_placeholder.id), None)
         if round_ is not None and round_.lifecycle_state == RoundLifecycleState.PLACEHOLDER:
-            await _assign_teams_to_round(tournament_id, fresh, round_, advance_to_resolved=True)
+            plan = build_round_assignment_plan(fresh, round_, advance_to_resolved=True)
+            await apply_plan(tournament_id, plan)
             # Refresh after the first resolution so pass 2 sees the updated state
             fresh = await get_stage_item(tournament_id, stage_item.id)
 
@@ -141,4 +164,5 @@ async def auto_resolve_next_swiss_round(
     for candidate in get_rounds_to_re_resolve(fresh.rounds):
         round_ = next((r for r in fresh.rounds if r.id == candidate.id), None)
         if round_ is not None and round_.lifecycle_state == RoundLifecycleState.RESOLVED:
-            await _assign_teams_to_round(tournament_id, fresh, round_, advance_to_resolved=False)
+            plan = build_round_assignment_plan(fresh, round_, advance_to_resolved=False)
+            await apply_plan(tournament_id, plan)

--- a/backend/tests/unit_tests/test_apply_plan_ordering.py
+++ b/backend/tests/unit_tests/test_apply_plan_ordering.py
@@ -1,0 +1,76 @@
+"""Unit tests for ordered_team_assignment_writes, the pure ordering decision behind apply_plan's
+AssignTeamToInput batch handling. The end-to-end DB behavior (writes actually landing correctly
+for a full swap) is covered by the integration test
+rankings_test.py::test_update_ranking_swaps_teams_between_dependent_inputs.
+"""
+
+from bracket.logic.apply_plan import ordered_team_assignment_writes
+from bracket.logic.plan import AssignTeamToInput
+from bracket.utils.id_types import StageItemInputId, TeamId
+
+
+def test_full_swap_clears_both_before_writing_either_final() -> None:
+    """Two sibling inputs trading teams: both clears must precede both finals, else a write of
+    one final could collide with the other input's still-unwritten old team_id.
+    """
+    a = AssignTeamToInput(
+        stage_item_input_id=StageItemInputId(1), team_id=TeamId(2), previous_team_id=TeamId(1)
+    )
+    b = AssignTeamToInput(
+        stage_item_input_id=StageItemInputId(2), team_id=TeamId(1), previous_team_id=TeamId(2)
+    )
+
+    ordered = ordered_team_assignment_writes([a, b])
+
+    clear_a = AssignTeamToInput(
+        stage_item_input_id=StageItemInputId(1), team_id=None, previous_team_id=TeamId(1)
+    )
+    clear_b = AssignTeamToInput(
+        stage_item_input_id=StageItemInputId(2), team_id=None, previous_team_id=TeamId(2)
+    )
+
+    assert ordered == [clear_a, clear_b, a, b]
+
+
+def test_unchanged_assignment_is_not_cleared() -> None:
+    """An input whose team_id isn't actually changing gets no clear write."""
+    unchanged = AssignTeamToInput(
+        stage_item_input_id=StageItemInputId(1), team_id=TeamId(1), previous_team_id=TeamId(1)
+    )
+
+    ordered = ordered_team_assignment_writes([unchanged])
+
+    assert ordered == [unchanged]
+
+
+def test_first_time_assignment_is_not_cleared() -> None:
+    """An input with no previous team (previous_team_id=None) gets no clear write."""
+    first_time = AssignTeamToInput(
+        stage_item_input_id=StageItemInputId(1), team_id=TeamId(1), previous_team_id=None
+    )
+
+    ordered = ordered_team_assignment_writes([first_time])
+
+    assert ordered == [first_time]
+
+
+def test_mixed_batch_clears_only_the_changing_ones_first() -> None:
+    """A batch with both changing and unchanged/first-time inputs clears only the changing one,
+    and every clear still precedes every final write.
+    """
+    changing = AssignTeamToInput(
+        stage_item_input_id=StageItemInputId(1), team_id=TeamId(2), previous_team_id=TeamId(1)
+    )
+    unchanged = AssignTeamToInput(
+        stage_item_input_id=StageItemInputId(2), team_id=TeamId(3), previous_team_id=TeamId(3)
+    )
+    first_time = AssignTeamToInput(
+        stage_item_input_id=StageItemInputId(3), team_id=TeamId(4), previous_team_id=None
+    )
+
+    ordered = ordered_team_assignment_writes([changing, unchanged, first_time])
+
+    clear_changing = AssignTeamToInput(
+        stage_item_input_id=StageItemInputId(1), team_id=None, previous_team_id=TeamId(1)
+    )
+    assert ordered == [clear_changing, changing, unchanged, first_time]

--- a/backend/tests/unit_tests/test_build_round_assignment_plan.py
+++ b/backend/tests/unit_tests/test_build_round_assignment_plan.py
@@ -1,0 +1,144 @@
+"""Unit tests for build_round_assignment_plan, the pure planner behind Swiss round resolution
+(formerly the writing half of swiss_resolution_orchestrator._assign_teams_to_round).
+"""
+
+from collections.abc import Sequence
+from decimal import Decimal
+
+from bracket.logic.plan import SetMatchInputs, SetRoundLifecycleState
+from bracket.logic.scheduling.swiss_resolution_orchestrator import build_round_assignment_plan
+from bracket.models.db.match import Match, MatchWithDetails, MatchWithDetailsDefinitive
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.stage_item import StageType
+from bracket.models.db.stage_item_inputs import (
+    StageItemInputEmpty,
+    StageItemInputFinal,
+    StageItemInputTentative,
+)
+from bracket.models.db.team import Team
+from bracket.models.db.util import RoundWithMatches, StageItemWithRounds
+from bracket.utils.dummy_records import DUMMY_MATCH1, DUMMY_MOCK_TIME, DUMMY_TEAM1
+from bracket.utils.id_types import (
+    MatchId,
+    RoundId,
+    StageId,
+    StageItemId,
+    StageItemInputId,
+    TeamId,
+    TournamentId,
+)
+
+
+def _input(n: int, elo: int = 1000) -> StageItemInputFinal:
+    return StageItemInputFinal(
+        id=StageItemInputId(n),
+        slot=n,
+        tournament_id=TournamentId(-1),
+        team_id=TeamId(n),
+        points=Decimal(str(elo)),
+        wins=0,
+        draws=0,
+        losses=0,
+        team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(n)),
+    )
+
+
+def _placeholder_match(
+    match_id: int, round_id: int, input1_slot: int, input2_slot: int
+) -> MatchWithDetails:
+    base = Match.model_validate(
+        DUMMY_MATCH1.model_dump()
+        | {
+            "id": MatchId(match_id),
+            "round_id": RoundId(round_id),
+            "stage_item_input1_id": None,
+            "stage_item_input2_id": None,
+            "input1_slot": input1_slot,
+            "input2_slot": input2_slot,
+        }
+    )
+    return MatchWithDetails(**base.model_dump(), court=None)
+
+
+def _placeholder_round(
+    round_id: int, matches: Sequence[MatchWithDetailsDefinitive | MatchWithDetails]
+) -> RoundWithMatches:
+    return RoundWithMatches(
+        id=RoundId(round_id),
+        matches=list(matches),
+        lifecycle_state=RoundLifecycleState.PLACEHOLDER,
+        stage_item_id=StageItemId(-1),
+        name=f"R{round_id}",
+        created=DUMMY_MOCK_TIME,
+    )
+
+
+def _stage_item(
+    inputs: Sequence[StageItemInputTentative | StageItemInputFinal | StageItemInputEmpty],
+    rounds: list[RoundWithMatches],
+) -> StageItemWithRounds:
+    return StageItemWithRounds(
+        rounds=rounds,
+        inputs=list(inputs),
+        type_name="Swiss",
+        team_count=max(len(inputs), 2),
+        ranking_id=None,
+        id=StageItemId(-1),
+        stage_id=StageId(-1),
+        name="",
+        created=DUMMY_MOCK_TIME,
+        type=StageType.SWISS,
+    )
+
+
+def test_build_round_assignment_plan_pairs_all_inputs_and_advances_round() -> None:
+    """For 4 active inputs and no round history, the plan wires both matches' slots to concrete
+    inputs and, with advance_to_resolved=True, appends a RESOLVED lifecycle transition.
+    """
+    inputs = [_input(i) for i in range(1, 5)]
+    match1 = _placeholder_match(1, round_id=-1, input1_slot=0, input2_slot=1)
+    match2 = _placeholder_match(2, round_id=-1, input1_slot=2, input2_slot=3)
+    round_ = _placeholder_round(-1, [match1, match2])
+    stage_item = _stage_item(inputs, [round_])
+
+    plan = build_round_assignment_plan(stage_item, round_, advance_to_resolved=True)
+
+    set_match_inputs = [item for item in plan if isinstance(item, SetMatchInputs)]
+    lifecycle_items = [item for item in plan if isinstance(item, SetRoundLifecycleState)]
+
+    assert len(set_match_inputs) == 2
+    all_assigned_ids = {
+        input_id for item in set_match_inputs for input_id in item.input_ids if input_id is not None
+    }
+    assert all_assigned_ids == {inp.id for inp in inputs}
+    for item in set_match_inputs:
+        assert item.round_id == round_.id
+        assert None not in item.input_ids
+
+    assert lifecycle_items == [
+        SetRoundLifecycleState(round_id=round_.id, state=RoundLifecycleState.RESOLVED)
+    ]
+
+
+def test_build_round_assignment_plan_no_lifecycle_item_when_not_advancing() -> None:
+    """advance_to_resolved=False (the re-resolution pass) never appends a lifecycle transition."""
+    inputs = [_input(i) for i in range(1, 5)]
+    match1 = _placeholder_match(1, round_id=-1, input1_slot=0, input2_slot=1)
+    match2 = _placeholder_match(2, round_id=-1, input1_slot=2, input2_slot=3)
+    round_ = _placeholder_round(-1, [match1, match2])
+    stage_item = _stage_item(inputs, [round_])
+
+    plan = build_round_assignment_plan(stage_item, round_, advance_to_resolved=False)
+
+    assert not any(isinstance(item, SetRoundLifecycleState) for item in plan)
+    assert sum(1 for item in plan if isinstance(item, SetMatchInputs)) == 2
+
+
+def test_build_round_assignment_plan_empty_when_no_active_inputs() -> None:
+    """No active final inputs means nothing to pair: the plan is empty."""
+    round_ = _placeholder_round(-1, [])
+    stage_item = _stage_item([], [round_])
+
+    plan = build_round_assignment_plan(stage_item, round_, advance_to_resolved=True)
+
+    assert not plan

--- a/backend/tests/unit_tests/test_build_team_stats_plan.py
+++ b/backend/tests/unit_tests/test_build_team_stats_plan.py
@@ -1,0 +1,178 @@
+"""Unit tests for build_team_stats_plan, the pure planner behind
+recalculate_ranking_for_stage_item.
+"""
+
+from decimal import Decimal
+
+from heliclockter import datetime_utc
+
+from bracket.logic.plan import SetTeamStats
+from bracket.logic.ranking.calculation import build_team_stats_plan
+from bracket.logic.ranking.statistics import TeamStatistics
+from bracket.models.db.match import MatchState, MatchWithDetailsDefinitive
+from bracket.models.db.ranking import Ranking, RankingMatchPointsData, ScoringType
+from bracket.models.db.round import RoundLifecycleState
+from bracket.models.db.stage_item import StageType
+from bracket.models.db.stage_item_inputs import StageItemInputFinal
+from bracket.models.db.team import Team
+from bracket.models.db.util import RoundWithMatches, StageItemWithRounds
+from bracket.utils.dummy_records import DUMMY_TEAM1, DUMMY_TEAM2
+from bracket.utils.id_types import (
+    MatchId,
+    RankingId,
+    RoundId,
+    StageId,
+    StageItemId,
+    StageItemInputId,
+    TeamId,
+    TournamentId,
+)
+from tests.unit_tests.mocks import match_sets_for_state
+
+
+def test_build_team_stats_plan_produces_set_team_stats_for_round_robin() -> None:
+    """build_team_stats_plan emits one SetTeamStats per concrete input, matching the stats that
+    determine_ranking_for_stage_item computes (see ranking_calculation_test.py for the equivalent
+    determine_ranking_for_stage_item assertions on the same fixture shape).
+    """
+    tournament_id = TournamentId(-1)
+    now = datetime_utc.now()
+    stage_item_input1 = StageItemInputFinal(
+        id=StageItemInputId(-1),
+        team_id=TeamId(-1),
+        slot=1,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(-1)),
+    )
+    stage_item_input2 = StageItemInputFinal(
+        id=StageItemInputId(-2),
+        team_id=TeamId(-2),
+        slot=2,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM2.model_dump(), id=TeamId(-2)),
+    )
+
+    stage_item = StageItemWithRounds(
+        rounds=[
+            RoundWithMatches(
+                id=RoundId(-1),
+                matches=[
+                    MatchWithDetailsDefinitive(
+                        id=MatchId(-1),
+                        stage_item_input1=stage_item_input1,
+                        stage_item_input2=stage_item_input2,
+                        created=now,
+                        duration_minutes=90,
+                        round_id=RoundId(-1),
+                        match_sets=match_sets_for_state(MatchId(0), MatchState.COMPLETED, 2, 0),
+                    ),
+                ],
+                stage_item_id=StageItemId(-1),
+                created=now,
+                lifecycle_state=RoundLifecycleState.ACTIVE,
+                name="",
+            )
+        ],
+        inputs=[stage_item_input1, stage_item_input2],
+        type_name="Round Robin",
+        team_count=2,
+        ranking_id=None,
+        id=StageItemId(-1),
+        stage_id=StageId(-1),
+        name="",
+        created=now,
+        type=StageType.ROUND_ROBIN,
+    )
+    ranking = Ranking(
+        id=RankingId(-1),
+        tournament_id=tournament_id,
+        created=now,
+        position=0,
+        scoring_type=ScoringType.MATCH_POINTS,
+        match_points=RankingMatchPointsData(
+            win_points=Decimal("3.0"),
+            draw_points=Decimal("1.0"),
+            loss_points=Decimal("0.0"),
+        ),
+    )
+
+    plan = build_team_stats_plan(stage_item, ranking)
+
+    # Deterministic order: build_team_stats_plan walks stage_item.inputs in order.
+    assert plan == [
+        SetTeamStats(
+            stage_item_input_id=StageItemInputId(-1),
+            stats=TeamStatistics(
+                wins=1,
+                draws=0,
+                losses=0,
+                points=Decimal("3.0"),
+                set_difference=1,
+                point_difference=2,
+            ),
+        ),
+        SetTeamStats(
+            stage_item_input_id=StageItemInputId(-2),
+            stats=TeamStatistics(
+                wins=0,
+                draws=0,
+                losses=1,
+                points=Decimal("0.0"),
+                set_difference=-1,
+                point_difference=-2,
+            ),
+        ),
+    ]
+
+
+def test_build_team_stats_plan_skips_inputs_without_a_team() -> None:
+    """A tentative/empty input (no team_id) never gets a SetTeamStats write."""
+    tournament_id = TournamentId(-1)
+    now = datetime_utc.now()
+    stage_item_input1 = StageItemInputFinal(
+        id=StageItemInputId(-1),
+        team_id=TeamId(-1),
+        slot=1,
+        tournament_id=tournament_id,
+        team=Team(**DUMMY_TEAM1.model_dump(), id=TeamId(-1)),
+    )
+
+    stage_item = StageItemWithRounds(
+        rounds=[
+            RoundWithMatches(
+                id=RoundId(-1),
+                matches=[],
+                stage_item_id=StageItemId(-1),
+                created=now,
+                lifecycle_state=RoundLifecycleState.ACTIVE,
+                name="",
+            )
+        ],
+        inputs=[stage_item_input1],
+        type_name="Round Robin",
+        team_count=2,
+        ranking_id=None,
+        id=StageItemId(-1),
+        stage_id=StageId(-1),
+        name="",
+        created=now,
+        type=StageType.ROUND_ROBIN,
+    )
+    ranking = Ranking(
+        id=RankingId(-1),
+        tournament_id=tournament_id,
+        created=now,
+        position=0,
+        scoring_type=ScoringType.MATCH_POINTS,
+        match_points=RankingMatchPointsData(
+            win_points=Decimal("3.0"),
+            draw_points=Decimal("1.0"),
+            loss_points=Decimal("0.0"),
+        ),
+    )
+
+    plan = build_team_stats_plan(stage_item, ranking)
+
+    assert plan == [
+        SetTeamStats(stage_item_input_id=StageItemInputId(-1), stats=TeamStatistics()),
+    ]


### PR DESCRIPTION
## Summary

Builds on #250. The reconciliation steps each welded their pure decision core to an ad-hoc write loop: ranking recalc wrote team stats per input, the Swiss orchestrator interleaved match-input/referee/lifecycle writes per round, the elimination cascade looped SQL updates, and dependent-input resolution carried its own two-pass swap-safe write ordering. The wiring — where the real bugs live — was only reachable through Postgres-backed integration tests.

### Changes

- **`logic/plan.py`** (new) — immutable write intents: `SetTeamStats`, `SetMatchInputs`, `SetMatchRefereeSlot`, `SetRoundLifecycleState`, `AssignTeamToInput` (carries `previous_team_id` for swap safety). A plan is a `list[PlanItem]`.
- **`logic/apply_plan.py`** (new) — the only place reconciliation writes cross the database seam: one transaction (savepoint when nested), items dispatched to the existing `sql/` functions. The swap-safe two-pass ordering for team assignments moved here (`ordered_team_assignment_writes`, pure), so **any** batch of dependent-input updates is permutation-safe — not just the one call site that previously knew the trick.
- **Step modules now plan, then apply**: pure `build_team_stats_plan`, `build_elimination_input_plan`, `build_round_assignment_plan` (replaces `_assign_teams_to_round` and also absorbs round-1 resolution's duplicate pairing code), `build_unwire_plan`. `auto_resolve_next_swiss_round` still applies pass 1's plan before the re-fetch that feeds pass 2.
- **`database` no longer imported** by `ranking/calculation.py`, `ranking/elimination.py`, or `swiss_resolution_orchestrator.py`. The only remaining direct use in the step modules is the advisory-lock entry point for concurrent round-1 resolution (a legitimate concurrency-control boundary).
- `tournament_id` threaded explicitly through the elimination cascade instead of being inferred from `stage_item.inputs[0]`.

### Tests

- 9 new **DB-free unit tests**: `test_build_team_stats_plan.py`, `test_build_round_assignment_plan.py`, `test_apply_plan_ordering.py` — the planners and the swap-safe ordering are now testable without Postgres.
- Behavior-preservation notes: the combined-plan form of the complete elimination cascade was verified equivalent (the pure planner reads only the in-memory stage item, which never mutates across the round loop, and plan order preserves last-write-wins); round-1 Swiss resolution's empty `previous_rounds` falls out naturally since all sibling rounds are still PLACEHOLDER.
- Full backend suite: **482 passed** (473 baseline + 9 new). ruff/mypy/pyrefly/pylint/vulture clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi)_