### PR TITLE
Collapse auth-vs-token match verb shells onto one resolution seam

### DIFF
--- a/backend/bracket/routes/match_access.py
+++ b/backend/bracket/routes/match_access.py
@@ -1,0 +1,57 @@
+from typing import NamedTuple
+
+from fastapi import Depends, HTTPException
+from starlette import status
+
+from bracket.models.db.match import Match
+from bracket.models.db.tournament import Tournament
+from bracket.models.db.user import UserPublic
+from bracket.routes.auth import (
+    tournament_by_score_tracking_token,
+    user_authenticated_for_tournament,
+)
+from bracket.routes.util import match_dependency
+from bracket.utils.id_types import MatchId, TournamentId
+
+
+class ResolvedMatch(NamedTuple):
+    """The (tournament, match) pair a verb operates on, resolved by whichever adapter
+    authorized the request: an authenticated user, or a score-tracking token."""
+
+    tournament_id: TournamentId
+    match: Match
+
+
+def _raise_if_unscheduled(match: Match) -> None:
+    if match.start_time is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Could not find scheduled match"
+        )
+
+
+async def resolved_match_via_auth(
+    tournament_id: TournamentId,
+    match_id: MatchId,
+    _: UserPublic = Depends(user_authenticated_for_tournament),
+) -> ResolvedMatch:
+    match = await match_dependency(tournament_id, match_id)
+    return ResolvedMatch(tournament_id=tournament_id, match=match)
+
+
+async def resolved_scheduled_match_via_auth(
+    tournament_id: TournamentId,
+    match_id: MatchId,
+    _: UserPublic = Depends(user_authenticated_for_tournament),
+) -> ResolvedMatch:
+    match = await match_dependency(tournament_id, match_id)
+    _raise_if_unscheduled(match)
+    return ResolvedMatch(tournament_id=tournament_id, match=match)
+
+
+async def resolved_match_via_token(
+    match_id: MatchId,
+    tournament: Tournament = Depends(tournament_by_score_tracking_token),
+) -> ResolvedMatch:
+    match = await match_dependency(tournament.id, match_id)
+    _raise_if_unscheduled(match)
+    return ResolvedMatch(tournament_id=tournament.id, match=match)

--- a/backend/bracket/routes/match_sets.py
+++ b/backend/bracket/routes/match_sets.py
@@ -3,15 +3,13 @@ from starlette import status
 
 from bracket.config import config
 from bracket.logic.match_sets.apply_update import score_edit_and_recalculate
-from bracket.models.db.match import Match, MatchSet, MatchSetScoreEditBody
-from bracket.models.db.tournament import Tournament
-from bracket.models.db.user import UserPublic
-from bracket.routes.auth import (
-    tournament_by_score_tracking_token,
-    user_authenticated_for_tournament,
+from bracket.models.db.match import MatchSet, MatchSetScoreEditBody
+from bracket.routes.match_access import (
+    ResolvedMatch,
+    resolved_match_via_auth,
+    resolved_match_via_token,
 )
 from bracket.routes.models import ScoreTrackingMatchResponse
-from bracket.routes.util import match_dependency
 from bracket.sql.match_sets import sql_get_match_set
 from bracket.utils.id_types import MatchId, MatchSetId, TournamentId
 
@@ -28,21 +26,29 @@ async def _get_set_belonging_to_match(match_id: MatchId, match_set_id: MatchSetI
     return match_set
 
 
+async def _score_edit(
+    resolved: ResolvedMatch, set_id: MatchSetId, body: MatchSetScoreEditBody
+) -> ScoreTrackingMatchResponse:
+    await _get_set_belonging_to_match(resolved.match.id, set_id)
+    updated = await score_edit_and_recalculate(resolved.tournament_id, resolved.match, set_id, body)
+    return ScoreTrackingMatchResponse(data=updated)
+
+
 @router.post(
     "/tournaments/{tournament_id}/matches/{match_id}/sets/{set_id}/score-edit",
     response_model=ScoreTrackingMatchResponse,
 )
 async def score_edit_authenticated(
+    # tournament_id/match_id are also resolved inside the dependency; they are re-declared
+    # here purely to keep the OpenAPI path-parameter order identical to before the refactor
+    # (FastAPI lists a route's own params before dependency params).
     tournament_id: TournamentId,
     match_id: MatchId,
     set_id: MatchSetId,
     body: MatchSetScoreEditBody,
-    _: UserPublic = Depends(user_authenticated_for_tournament),
-    match: Match = Depends(match_dependency),
+    resolved: ResolvedMatch = Depends(resolved_match_via_auth),
 ) -> ScoreTrackingMatchResponse:
-    await _get_set_belonging_to_match(match.id, set_id)
-    updated = await score_edit_and_recalculate(tournament_id, match, set_id, body)
-    return ScoreTrackingMatchResponse(data=updated)
+    return await _score_edit(resolved, set_id, body)
 
 
 @router.post(
@@ -50,16 +56,11 @@ async def score_edit_authenticated(
     response_model=ScoreTrackingMatchResponse,
 )
 async def score_edit_by_token(
+    # match_id is also resolved inside the dependency; it is re-declared here purely to
+    # keep the OpenAPI path-parameter order identical to before the refactor.
     match_id: MatchId,
     set_id: MatchSetId,
     body: MatchSetScoreEditBody,
-    tournament: Tournament = Depends(tournament_by_score_tracking_token),
+    resolved: ResolvedMatch = Depends(resolved_match_via_token),
 ) -> ScoreTrackingMatchResponse:
-    match = await match_dependency(tournament.id, match_id)
-    if match.start_time is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Could not find scheduled match"
-        )
-    await _get_set_belonging_to_match(match.id, set_id)
-    updated = await score_edit_and_recalculate(tournament.id, match, set_id, body)
-    return ScoreTrackingMatchResponse(data=updated)
+    return await _score_edit(resolved, set_id, body)

--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -32,9 +32,11 @@ from bracket.models.db.match import (
 )
 from bracket.models.db.tournament import Tournament
 from bracket.models.db.user import UserPublic
-from bracket.routes.auth import (
-    tournament_by_score_tracking_token,
-    user_authenticated_for_tournament,
+from bracket.routes.auth import user_authenticated_for_tournament
+from bracket.routes.match_access import (
+    ResolvedMatch,
+    resolved_match_via_auth,
+    resolved_match_via_token,
 )
 from bracket.routes.models import (
     ScoreTrackingMatchResponse,
@@ -89,15 +91,24 @@ async def get_score_tracking_match_response(
     return ScoreTrackingMatchResponse(data=match)
 
 
-async def _scheduled_match_for_score_tracking(
-    tournament_id: TournamentId, match_id: MatchId
-) -> Match:
-    match = await match_dependency(tournament_id, match_id)
-    if match.start_time is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Could not find scheduled match"
-        )
-    return match
+async def _start(resolved: ResolvedMatch) -> ScoreTrackingMatchResponse:
+    updated = await start_match_and_recalculate(resolved.tournament_id, resolved.match)
+    return ScoreTrackingMatchResponse(data=updated)
+
+
+async def _end(resolved: ResolvedMatch) -> ScoreTrackingMatchResponse:
+    updated = await end_match_and_recalculate(resolved.tournament_id, resolved.match)
+    return ScoreTrackingMatchResponse(data=updated)
+
+
+async def _reopen(resolved: ResolvedMatch) -> ScoreTrackingMatchResponse:
+    updated = await reopen_match_and_recalculate(resolved.tournament_id, resolved.match)
+    return ScoreTrackingMatchResponse(data=updated)
+
+
+async def _reset(resolved: ResolvedMatch) -> ScoreTrackingMatchResponse:
+    updated = await reset_match_and_recalculate(resolved.tournament_id, resolved.match)
+    return ScoreTrackingMatchResponse(data=updated)
 
 
 @router.post(
@@ -105,13 +116,9 @@ async def _scheduled_match_for_score_tracking(
     response_model=ScoreTrackingMatchResponse,
 )
 async def start_match_authenticated(
-    tournament_id: TournamentId,
-    match_id: MatchId,
-    _: UserPublic = Depends(user_authenticated_for_tournament),
-    match: Match = Depends(match_dependency),
+    resolved: ResolvedMatch = Depends(resolved_match_via_auth),
 ) -> ScoreTrackingMatchResponse:
-    updated = await start_match_and_recalculate(tournament_id, match)
-    return ScoreTrackingMatchResponse(data=updated)
+    return await _start(resolved)
 
 
 @router.post(
@@ -119,12 +126,9 @@ async def start_match_authenticated(
     response_model=ScoreTrackingMatchResponse,
 )
 async def start_match_by_token(
-    match_id: MatchId,
-    tournament: Tournament = Depends(tournament_by_score_tracking_token),
+    resolved: ResolvedMatch = Depends(resolved_match_via_token),
 ) -> ScoreTrackingMatchResponse:
-    match = await _scheduled_match_for_score_tracking(tournament.id, match_id)
-    updated = await start_match_and_recalculate(tournament.id, match)
-    return ScoreTrackingMatchResponse(data=updated)
+    return await _start(resolved)
 
 
 @router.post(
@@ -132,13 +136,9 @@ async def start_match_by_token(
     response_model=ScoreTrackingMatchResponse,
 )
 async def end_match_authenticated(
-    tournament_id: TournamentId,
-    match_id: MatchId,
-    _: UserPublic = Depends(user_authenticated_for_tournament),
-    match: Match = Depends(match_dependency),
+    resolved: ResolvedMatch = Depends(resolved_match_via_auth),
 ) -> ScoreTrackingMatchResponse:
-    updated = await end_match_and_recalculate(tournament_id, match)
-    return ScoreTrackingMatchResponse(data=updated)
+    return await _end(resolved)
 
 
 @router.post(
@@ -146,12 +146,9 @@ async def end_match_authenticated(
     response_model=ScoreTrackingMatchResponse,
 )
 async def end_match_by_token(
-    match_id: MatchId,
-    tournament: Tournament = Depends(tournament_by_score_tracking_token),
+    resolved: ResolvedMatch = Depends(resolved_match_via_token),
 ) -> ScoreTrackingMatchResponse:
-    match = await _scheduled_match_for_score_tracking(tournament.id, match_id)
-    updated = await end_match_and_recalculate(tournament.id, match)
-    return ScoreTrackingMatchResponse(data=updated)
+    return await _end(resolved)
 
 
 @router.post(
@@ -159,13 +156,9 @@ async def end_match_by_token(
     response_model=ScoreTrackingMatchResponse,
 )
 async def reopen_match_authenticated(
-    tournament_id: TournamentId,
-    match_id: MatchId,
-    _: UserPublic = Depends(user_authenticated_for_tournament),
-    match: Match = Depends(match_dependency),
+    resolved: ResolvedMatch = Depends(resolved_match_via_auth),
 ) -> ScoreTrackingMatchResponse:
-    updated = await reopen_match_and_recalculate(tournament_id, match)
-    return ScoreTrackingMatchResponse(data=updated)
+    return await _reopen(resolved)
 
 
 @router.post(
@@ -173,12 +166,9 @@ async def reopen_match_authenticated(
     response_model=ScoreTrackingMatchResponse,
 )
 async def reopen_match_by_token(
-    match_id: MatchId,
-    tournament: Tournament = Depends(tournament_by_score_tracking_token),
+    resolved: ResolvedMatch = Depends(resolved_match_via_token),
 ) -> ScoreTrackingMatchResponse:
-    match = await _scheduled_match_for_score_tracking(tournament.id, match_id)
-    updated = await reopen_match_and_recalculate(tournament.id, match)
-    return ScoreTrackingMatchResponse(data=updated)
+    return await _reopen(resolved)
 
 
 @router.post(
@@ -186,13 +176,9 @@ async def reopen_match_by_token(
     response_model=ScoreTrackingMatchResponse,
 )
 async def reset_match_authenticated(
-    tournament_id: TournamentId,
-    match_id: MatchId,
-    _: UserPublic = Depends(user_authenticated_for_tournament),
-    match: Match = Depends(match_dependency),
+    resolved: ResolvedMatch = Depends(resolved_match_via_auth),
 ) -> ScoreTrackingMatchResponse:
-    updated = await reset_match_and_recalculate(tournament_id, match)
-    return ScoreTrackingMatchResponse(data=updated)
+    return await _reset(resolved)
 
 
 @router.delete("/tournaments/{tournament_id}/matches/{match_id}", response_model=SuccessResponse)

--- a/backend/bracket/routes/score_tracking.py
+++ b/backend/bracket/routes/score_tracking.py
@@ -1,14 +1,18 @@
 import asyncio
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 
 from bracket.config import config
-from bracket.models.db.match import Match
 from bracket.models.db.tournament import LevelResponse, Tournament
 from bracket.models.db.user import UserPublic
 from bracket.routes.auth import (
     tournament_by_score_tracking_token,
     user_authenticated_for_tournament,
+)
+from bracket.routes.match_access import (
+    ResolvedMatch,
+    resolved_match_via_token,
+    resolved_scheduled_match_via_auth,
 )
 from bracket.routes.matches import (
     get_score_tracking_match_response,
@@ -18,12 +22,11 @@ from bracket.routes.models import (
     ScoreTrackingInfoResponse,
     ScoreTrackingMatchResponse,
 )
-from bracket.routes.util import match_dependency
 from bracket.sql.courts import get_all_courts_in_tournament
 from bracket.sql.levels import sql_get_levels_for_tournament
 from bracket.sql.matches import sql_get_scheduled_matches_with_details
 from bracket.sql.tournaments import sql_get_tournament
-from bracket.utils.id_types import CourtId, MatchId, TournamentId
+from bracket.utils.id_types import CourtId, TournamentId
 
 router = APIRouter(prefix=config.api_prefix)
 
@@ -51,26 +54,6 @@ async def get_score_tracking_info(
             courts=courts,
         )
     )
-
-
-async def score_tracking_match_dependency(
-    match_id: MatchId, tournament: Tournament = Depends(tournament_by_score_tracking_token)
-) -> Match:
-    match = await match_dependency(tournament.id, match_id)
-    if match.start_time is None:
-        raise HTTPException(status_code=404, detail="Could not find scheduled match")
-    return match
-
-
-async def tournament_score_tracking_match_dependency(
-    tournament_id: TournamentId,
-    match_id: MatchId,
-    _: UserPublic = Depends(user_authenticated_for_tournament),
-) -> Match:
-    match = await match_dependency(tournament_id, match_id)
-    if match.start_time is None:
-        raise HTTPException(status_code=404, detail="Could not find scheduled match")
-    return match
 
 
 @router.get(
@@ -105,12 +88,9 @@ async def get_authenticated_score_tracking_info(
     response_model=ScoreTrackingMatchResponse,
 )
 async def get_authenticated_score_tracking_match(
-    tournament_id: TournamentId,
-    match_id: MatchId,
-    _: UserPublic = Depends(user_authenticated_for_tournament),
-    __: Match = Depends(tournament_score_tracking_match_dependency),
+    resolved: ResolvedMatch = Depends(resolved_scheduled_match_via_auth),
 ) -> ScoreTrackingMatchResponse:
-    return await get_score_tracking_match_response(tournament_id, match_id)
+    return await get_score_tracking_match_response(resolved.tournament_id, resolved.match.id)
 
 
 @router.get(
@@ -118,8 +98,6 @@ async def get_authenticated_score_tracking_match(
     response_model=ScoreTrackingMatchResponse,
 )
 async def get_score_tracking_match(
-    match_id: MatchId,
-    tournament: Tournament = Depends(tournament_by_score_tracking_token),
-    _: Match = Depends(score_tracking_match_dependency),
+    resolved: ResolvedMatch = Depends(resolved_match_via_token),
 ) -> ScoreTrackingMatchResponse:
-    return await get_score_tracking_match_response(tournament.id, match_id)
+    return await get_score_tracking_match_response(resolved.tournament_id, resolved.match.id)

--- a/backend/tests/integration_tests/api/match_set_verbs_test.py
+++ b/backend/tests/integration_tests/api/match_set_verbs_test.py
@@ -650,6 +650,23 @@ async def test_reset_is_not_exposed_on_score_tracking_token_route(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_score_tracking_token_verb_on_unscheduled_match_returns_404(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with (
+        _simple_match(auth_context) as match_inserted,
+        _score_tracking_token(auth_context.tournament.id, "unscheduled-token") as token,
+    ):
+        await send_tournament_request(
+            HTTPMethod.POST, f"matches/{match_inserted.id}/unschedule", auth_context
+        )
+        response = await send_request(
+            HTTPMethod.POST, f"score-tracking/{token}/matches/{match_inserted.id}/start"
+        )
+        assert response == {"detail": "Could not find scheduled match"}
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_legacy_set_state_endpoint_is_removed(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:


### PR DESCRIPTION
## Summary

Every match verb — start, end, reopen, score-edit — shipped two near-identical route shells: one resolving the match via user auth (`/tournaments/{id}/matches/{id}/<verb>`), one via score-tracking token (`/score-tracking/{token}/matches/{id}/<verb>`). The "resolve tournament+match and require it to be scheduled" logic was re-implemented in **three files** (`matches.py`, `match_sets.py`, `score_tracking.py`) via four bespoke helpers.

### Changes

- **New `routes/match_access.py`** — the resolution seam: `ResolvedMatch(tournament_id, match)` with two adapters, `resolved_match_via_auth` (no scheduled check, matching current verb behavior) and `resolved_match_via_token` (scheduled 404, matching every token route), plus a scheduled-checking auth variant for the one score-tracking GET that needs it. The scheduled check lives once.
- **Verb shells collapse onto shared bodies** — each verb has one private body (`_start`, `_end`, `_reopen`, `_reset`, `_score_edit`); route registrations shrink to path + resolver. The set-belongs-to-match validation moves into the single `_score_edit` body. Four duplicated helpers deleted. No token reset route added (it deliberately doesn't exist).

### Compatibility

The HTTP interface is byte-identical: **`openapi.json` regenerates with an empty diff** — including operation ids. One non-obvious fix this required: FastAPI orders a route's own params before dependency-derived ones, so the two score-edit routes re-declare their path params (commented in code) to preserve schema parameter order.

### Tests

- Full backend suite: **474 passed** (473 baseline + 1 new).
- New: `test_score_tracking_token_verb_on_unscheduled_match_returns_404` — the token-verb-on-unscheduled-match 404 had no existing coverage.
- ruff/mypy/pyrefly/pylint/vulture clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi)_