### PR TITLE
Deepen the frontend mutation seam with performMutation in adapter.tsx

### DIFF
--- a/frontend/src/services/adapter.tsx
+++ b/frontend/src/services/adapter.tsx
@@ -144,6 +144,84 @@ export async function mutateIssues(tournament_id: number) {
   await mutate(getIssuesKey(tournament_id));
 }
 
+export type MutationVerb = 'post' | 'put' | 'delete' | 'patch';
+
+export type MutationOptions = {
+  /**
+   * Invalidate the tournament-issues SWR key after the request settles. This is the default
+   * policy (AGENTS.md: every mutation that can change a tournament-issue count must invalidate
+   * the shared issues key). Pass `false` only where the call site deliberately skips
+   * invalidation -- no tournament scope, or the mutation genuinely cannot affect issue counts.
+   */
+  invalidateIssues?: boolean;
+  /**
+   * Tournament id whose issues key gets invalidated, or a thunk that resolves one. Required
+   * when `invalidateIssues` is true (the default); resolving to `null`/`undefined` skips
+   * invalidation for that call. The thunk form exists for token-authenticated flows that must
+   * resolve the tournament id first (see the score-tracking-token mutations in `match.tsx`).
+   */
+  tournamentId?: number | null | (() => Promise<number | null | undefined>);
+  /**
+   * When `false`, request errors are not caught here -- they propagate to the caller instead of
+   * being swallowed by `handleRequestError`. Used by the handful of call sites that intentionally
+   * let the `AxiosError` propagate: the scheduling planner mutations (which must see failures to
+   * refetch the schedule and clear the selection) and a few call sites that chain their own
+   * `.then`/`.catch` on the returned promise. Defaults to `true`, matching the historical
+   * `createAxios().<verb>(url, body).catch(handleRequestError)` behavior.
+   */
+  catchErrors?: boolean;
+};
+
+function sendMutationRequest(
+  instance: AxiosInstance,
+  method: MutationVerb,
+  url: string,
+  body?: unknown
+): Promise<AxiosResponse> {
+  switch (method) {
+    case 'post':
+      return instance.post(url, body);
+    case 'put':
+      return instance.put(url, body);
+    case 'patch':
+      return instance.patch(url, body);
+    case 'delete':
+      // None of today's call sites send a body with DELETE, so there's no config to forward.
+      return instance.delete(url);
+  }
+}
+
+/**
+ * The single seam for write requests. Same request semantics as
+ * `createAxios().<verb>(url, body).catch(handleRequestError)` -- including the return contract
+ * (an `AxiosResponse` on success, `undefined` when the catch swallows an `AxiosError`) -- plus
+ * the tournament-issues invalidation that AGENTS.md requires after every issue-affecting
+ * mutation.
+ */
+export async function performMutation(
+  method: MutationVerb,
+  url: string,
+  body?: unknown,
+  options: MutationOptions = {}
+) {
+  const { invalidateIssues = true, tournamentId = null, catchErrors = true } = options;
+
+  const request = sendMutationRequest(createAxios(), method, url, body);
+  const response = catchErrors
+    ? await request.catch((err: any) => handleRequestError(err))
+    : await request;
+
+  if (invalidateIssues) {
+    const resolvedTournamentId =
+      typeof tournamentId === 'function' ? await tournamentId() : tournamentId;
+    if (resolvedTournamentId != null) {
+      await mutateIssues(resolvedTournamentId);
+    }
+  }
+
+  return response;
+}
+
 export function getTournaments(filter: TournamentFilter): SWRResponse<TournamentsResponse> {
   return useSWR(`tournaments?filter_=${filter}`, fetcher);
 }

--- a/frontend/src/services/club.tsx
+++ b/frontend/src/services/club.tsx
@@ -1,21 +1,14 @@
-import { createAxios, handleRequestError } from './adapter';
+import { performMutation } from './adapter';
 
 export async function createClub(name: string) {
-  return createAxios()
-    .post('clubs', { name })
-    .catch((response: any) => handleRequestError(response));
+  // Clubs aren't tournament-scoped, so there's no tournament-issues key to invalidate.
+  return performMutation('post', 'clubs', { name }, { invalidateIssues: false });
 }
 
 export async function deleteClub(club_id: number) {
-  return createAxios()
-    .delete(`clubs/${club_id}`)
-    .catch((response: any) => handleRequestError(response));
+  return performMutation('delete', `clubs/${club_id}`, undefined, { invalidateIssues: false });
 }
 
 export async function updateClub(club_id: number, name: string) {
-  return createAxios()
-    .put(`clubs/${club_id}`, {
-      name,
-    })
-    .catch((response: any) => handleRequestError(response));
+  return performMutation('put', `clubs/${club_id}`, { name }, { invalidateIssues: false });
 }

--- a/frontend/src/services/court.tsx
+++ b/frontend/src/services/court.tsx
@@ -1,13 +1,22 @@
-import { createAxios, handleRequestError } from './adapter';
+import { performMutation } from './adapter';
+
+// NOTE: neither of these has ever invalidated tournament issues, though courts can plausibly
+// affect scheduling-related issues (e.g. "no courts assigned"). Looks like a pre-existing
+// omission rather than a deliberate one -- preserved as-is and flagged for the architect.
 
 export async function createCourt(tournament_id: number, name: string) {
-  return createAxios()
-    .post(`tournaments/${tournament_id}/courts`, { name })
-    .catch((response: any) => handleRequestError(response));
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/courts`,
+    { name },
+    {
+      invalidateIssues: false,
+    }
+  );
 }
 
 export async function deleteCourt(tournament_id: number, court_id: number) {
-  return createAxios()
-    .delete(`tournaments/${tournament_id}/courts/${court_id}`)
-    .catch((response: any) => handleRequestError(response));
+  return performMutation('delete', `tournaments/${tournament_id}/courts/${court_id}`, undefined, {
+    invalidateIssues: false,
+  });
 }

--- a/frontend/src/services/court.tsx
+++ b/frontend/src/services/court.tsx
@@ -1,8 +1,8 @@
 import { performMutation } from './adapter';
 
-// NOTE: neither of these has ever invalidated tournament issues, though courts can plausibly
-// affect scheduling-related issues (e.g. "no courts assigned"). Looks like a pre-existing
-// omission rather than a deliberate one -- preserved as-is and flagged for the architect.
+// No tournament-issue counter involves courts, and the backend refuses to delete a court
+// that is used by any match (so deletion can never unschedule anything) -- neither mutation
+// can change an issue count, so both skip invalidation.
 
 export async function createCourt(tournament_id: number, name: string) {
   return performMutation(

--- a/frontend/src/services/match.tsx
+++ b/frontend/src/services/match.tsx
@@ -8,22 +8,18 @@ import {
   SchedulerWeights,
   ScoreTrackingInfoResponse,
 } from '@openapi';
-import { createAxios, handleRequestError, mutateIssues } from './adapter';
+import { createAxios, handleRequestError, performMutation } from './adapter';
 
 export async function createMatch(tournament_id: number, match: MatchCreateBodyFrontend) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/matches`, match)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation('post', `tournaments/${tournament_id}/matches`, match, {
+    tournamentId: tournament_id,
+  });
 }
 
 export async function deleteMatch(tournament_id: number, match_id: number) {
-  const response = await createAxios()
-    .delete(`tournaments/${tournament_id}/matches/${match_id}`)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation('delete', `tournaments/${tournament_id}/matches/${match_id}`, undefined, {
+    tournamentId: tournament_id,
+  });
 }
 
 export async function updateMatch(
@@ -32,11 +28,9 @@ export async function updateMatch(
   match: Omit<MatchBody, 'referee_stage_item_input_id' | 'referee_name'> &
     Partial<Pick<MatchBody, 'referee_stage_item_input_id' | 'referee_name'>>
 ) {
-  const response = await createAxios()
-    .put(`tournaments/${tournament_id}/matches/${match_id}`, match)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation('put', `tournaments/${tournament_id}/matches/${match_id}`, match, {
+    tournamentId: tournament_id,
+  });
 }
 
 // Scores live on sets. A set's scores are the unit of change for both the authenticated
@@ -48,43 +42,48 @@ export async function scoreEditMatchSet(
   set_id: number,
   body: MatchSetScoreEditBody
 ) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/matches/${match_id}/sets/${set_id}/score-edit`, body)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/matches/${match_id}/sets/${set_id}/score-edit`,
+    body,
+    { tournamentId: tournament_id }
+  );
 }
 
 export async function startMatch(tournament_id: number, match_id: number) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/matches/${match_id}/start`)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/matches/${match_id}/start`,
+    undefined,
+    { tournamentId: tournament_id }
+  );
 }
 
 export async function endMatch(tournament_id: number, match_id: number) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/matches/${match_id}/end`)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/matches/${match_id}/end`,
+    undefined,
+    { tournamentId: tournament_id }
+  );
 }
 
 export async function reopenMatch(tournament_id: number, match_id: number) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/matches/${match_id}/reopen`)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/matches/${match_id}/reopen`,
+    undefined,
+    { tournamentId: tournament_id }
+  );
 }
 
 export async function resetMatch(tournament_id: number, match_id: number) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/matches/${match_id}/reset`)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/matches/${match_id}/reset`,
+    undefined,
+    { tournamentId: tournament_id }
+  );
 }
 
 export async function scoreEditScoreTrackingMatchSet(
@@ -94,18 +93,15 @@ export async function scoreEditScoreTrackingMatchSet(
   set_id: number,
   body: MatchSetScoreEditBody
 ) {
-  const response = await createAxios()
-    .post(
-      `score-tracking/${score_tracking_token}/matches/${match_id}/sets/${set_id}/score-edit`,
-      body
-    )
-    .catch((response: any) => handleRequestError(response));
-  const tournamentId =
-    tournament_id ?? (await getTournamentIdForScoreTrackingToken(score_tracking_token));
-  if (tournamentId != null) {
-    await mutateIssues(tournamentId);
-  }
-  return response;
+  return performMutation(
+    'post',
+    `score-tracking/${score_tracking_token}/matches/${match_id}/sets/${set_id}/score-edit`,
+    body,
+    {
+      tournamentId: async () =>
+        tournament_id ?? (await getTournamentIdForScoreTrackingToken(score_tracking_token)),
+    }
+  );
 }
 
 export async function startScoreTrackingMatch(
@@ -113,15 +109,15 @@ export async function startScoreTrackingMatch(
   tournament_id: number | null,
   match_id: number
 ) {
-  const response = await createAxios()
-    .post(`score-tracking/${score_tracking_token}/matches/${match_id}/start`)
-    .catch((response: any) => handleRequestError(response));
-  const tournamentId =
-    tournament_id ?? (await getTournamentIdForScoreTrackingToken(score_tracking_token));
-  if (tournamentId != null) {
-    await mutateIssues(tournamentId);
-  }
-  return response;
+  return performMutation(
+    'post',
+    `score-tracking/${score_tracking_token}/matches/${match_id}/start`,
+    undefined,
+    {
+      tournamentId: async () =>
+        tournament_id ?? (await getTournamentIdForScoreTrackingToken(score_tracking_token)),
+    }
+  );
 }
 
 export async function endScoreTrackingMatch(
@@ -129,15 +125,15 @@ export async function endScoreTrackingMatch(
   tournament_id: number | null,
   match_id: number
 ) {
-  const response = await createAxios()
-    .post(`score-tracking/${score_tracking_token}/matches/${match_id}/end`)
-    .catch((response: any) => handleRequestError(response));
-  const tournamentId =
-    tournament_id ?? (await getTournamentIdForScoreTrackingToken(score_tracking_token));
-  if (tournamentId != null) {
-    await mutateIssues(tournamentId);
-  }
-  return response;
+  return performMutation(
+    'post',
+    `score-tracking/${score_tracking_token}/matches/${match_id}/end`,
+    undefined,
+    {
+      tournamentId: async () =>
+        tournament_id ?? (await getTournamentIdForScoreTrackingToken(score_tracking_token)),
+    }
+  );
 }
 
 export async function reopenScoreTrackingMatch(
@@ -145,15 +141,15 @@ export async function reopenScoreTrackingMatch(
   tournament_id: number | null,
   match_id: number
 ) {
-  const response = await createAxios()
-    .post(`score-tracking/${score_tracking_token}/matches/${match_id}/reopen`)
-    .catch((response: any) => handleRequestError(response));
-  const tournamentId =
-    tournament_id ?? (await getTournamentIdForScoreTrackingToken(score_tracking_token));
-  if (tournamentId != null) {
-    await mutateIssues(tournamentId);
-  }
-  return response;
+  return performMutation(
+    'post',
+    `score-tracking/${score_tracking_token}/matches/${match_id}/reopen`,
+    undefined,
+    {
+      tournamentId: async () =>
+        tournament_id ?? (await getTournamentIdForScoreTrackingToken(score_tracking_token)),
+    }
+  );
 }
 
 async function getTournamentIdForScoreTrackingToken(score_tracking_token: string) {
@@ -170,11 +166,12 @@ async function getTournamentIdForScoreTrackingToken(score_tracking_token: string
 // schedule and clear the selection.
 
 export async function unscheduleMatch(tournament_id: number, match_id: number) {
-  const response = await createAxios().post(
-    `tournaments/${tournament_id}/matches/${match_id}/unschedule`
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/matches/${match_id}/unschedule`,
+    undefined,
+    { tournamentId: tournament_id, catchErrors: false }
   );
-  await mutateIssues(tournament_id);
-  return response;
 }
 
 export async function rescheduleMatch(
@@ -182,18 +179,19 @@ export async function rescheduleMatch(
   match_id: number,
   match: MatchRescheduleBody
 ) {
-  const response = await createAxios().post(
+  return performMutation(
+    'post',
     `tournaments/${tournament_id}/matches/${match_id}/reschedule`,
-    match
+    match,
+    { tournamentId: tournament_id, catchErrors: false }
   );
-  await mutateIssues(tournament_id);
-  return response;
 }
 
 export async function swapMatches(tournament_id: number, body: MatchSwapBody) {
-  const response = await createAxios().post(`tournaments/${tournament_id}/matches/swap`, body);
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation('post', `tournaments/${tournament_id}/matches/swap`, body, {
+    tournamentId: tournament_id,
+    catchErrors: false,
+  });
 }
 
 export async function resizeMatchBreak(
@@ -201,32 +199,35 @@ export async function resizeMatchBreak(
   match_id: number,
   body: MatchResizeBreakBody
 ) {
-  const response = await createAxios().post(
+  return performMutation(
+    'post',
     `tournaments/${tournament_id}/matches/${match_id}/resize_break`,
-    body
+    body,
+    { tournamentId: tournament_id, catchErrors: false }
   );
-  await mutateIssues(tournament_id);
-  return response;
 }
 
 export async function autoAssignReferees(tournament_id: number, weights?: SchedulerWeights) {
-  return createAxios()
-    .post(`tournaments/${tournament_id}/matches/auto-assign-referees`, weights)
-    .catch((response: any) => handleRequestError(response));
+  // NOTE: unlike every other match mutation above, this has never invalidated tournament issues.
+  // Referee assignment can plausibly affect issue counts (e.g. "missing referee"), so this looks
+  // like an accidental omission rather than a deliberate one -- preserved as-is and flagged for
+  // the architect rather than silently "fixed" here.
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/matches/auto-assign-referees`,
+    weights,
+    { invalidateIssues: false }
+  );
 }
 
 export async function scheduleMatches(tournament_id: number, weights?: SchedulerWeights) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/schedule_matches`, weights)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation('post', `tournaments/${tournament_id}/schedule_matches`, weights, {
+    tournamentId: tournament_id,
+  });
 }
 
 export async function reoptimizeMatches(tournament_id: number, weights?: SchedulerWeights) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/reoptimize_matches`, weights)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation('post', `tournaments/${tournament_id}/reoptimize_matches`, weights, {
+    tournamentId: tournament_id,
+  });
 }

--- a/frontend/src/services/match.tsx
+++ b/frontend/src/services/match.tsx
@@ -208,10 +208,9 @@ export async function resizeMatchBreak(
 }
 
 export async function autoAssignReferees(tournament_id: number, weights?: SchedulerWeights) {
-  // NOTE: unlike every other match mutation above, this has never invalidated tournament issues.
-  // Referee assignment can plausibly affect issue counts (e.g. "missing referee"), so this looks
-  // like an accidental omission rather than a deliberate one -- preserved as-is and flagged for
-  // the architect rather than silently "fixed" here.
+  // No tournament-issue counter involves referees, so referee assignment provably cannot
+  // change any issue count today. If a referee issue source is ever added, wire this up
+  // (see AGENTS.md on tournament issue badges).
   return performMutation(
     'post',
     `tournaments/${tournament_id}/matches/auto-assign-referees`,

--- a/frontend/src/services/player.tsx
+++ b/frontend/src/services/player.tsx
@@ -33,9 +33,9 @@ export async function updatePlayer(
   active: boolean,
   team_id: string | null
 ) {
-  // NOTE: unlike create/delete above, this has never invalidated tournament issues. Toggling
-  // `active` or moving a player between teams can plausibly change issue counts, so this looks
-  // like an accidental omission rather than a deliberate one -- preserved as-is and flagged.
+  // The backend's PlayerBody is {name, active} only -- the team_id sent here is silently
+  // dropped, team membership is unchanged, and no issue counter filters on `active`, so this
+  // update cannot change an issue count and skips invalidation.
   return performMutation(
     'put',
     `tournaments/${tournament_id}/players/${player_id}`,

--- a/frontend/src/services/player.tsx
+++ b/frontend/src/services/player.tsx
@@ -1,27 +1,29 @@
-import { createAxios, handleRequestError, mutateIssues } from './adapter';
+import { performMutation } from './adapter';
 
 export async function createPlayer(tournament_id: number, name: string, active: boolean) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/players`, { name, active })
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/players`,
+    { name, active },
+    {
+      tournamentId: tournament_id,
+    }
+  );
 }
 
 export async function createMultiplePlayers(tournament_id: number, names: string, active: boolean) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/players_multi`, { names, active })
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/players_multi`,
+    { names, active },
+    { tournamentId: tournament_id }
+  );
 }
 
 export async function deletePlayer(tournament_id: number, player_id: number) {
-  const response = await createAxios()
-    .delete(`tournaments/${tournament_id}/players/${player_id}`)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation('delete', `tournaments/${tournament_id}/players/${player_id}`, undefined, {
+    tournamentId: tournament_id,
+  });
 }
 
 export async function updatePlayer(
@@ -31,11 +33,13 @@ export async function updatePlayer(
   active: boolean,
   team_id: string | null
 ) {
-  return createAxios()
-    .put(`tournaments/${tournament_id}/players/${player_id}`, {
-      name,
-      active,
-      team_id,
-    })
-    .catch((response: any) => handleRequestError(response));
+  // NOTE: unlike create/delete above, this has never invalidated tournament issues. Toggling
+  // `active` or moving a player between teams can plausibly change issue counts, so this looks
+  // like an accidental omission rather than a deliberate one -- preserved as-is and flagged.
+  return performMutation(
+    'put',
+    `tournaments/${tournament_id}/players/${player_id}`,
+    { name, active, team_id },
+    { invalidateIssues: false }
+  );
 }

--- a/frontend/src/services/ranking.tsx
+++ b/frontend/src/services/ranking.tsx
@@ -1,11 +1,20 @@
 import { ScoringType } from '@openapi';
 
-import { createAxios, handleRequestError } from './adapter';
+import { performMutation } from './adapter';
+
+// NOTE: none of these three has ever invalidated tournament issues (consistent across this
+// file, unlike e.g. player.tsx/round.tsx where only one sibling function omits it). Ranking
+// changes can plausibly affect standings-derived issues, so this is still worth the architect
+// double-checking, but the consistency within the file makes it read more like a deliberate
+// choice than an accident.
 
 export async function createRanking(tournament_id: number) {
-  return createAxios()
-    .post(`tournaments/${tournament_id}/rankings`, { scoring_type: 'MATCH_POINTS' })
-    .catch((response: any) => handleRequestError(response));
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/rankings`,
+    { scoring_type: 'MATCH_POINTS' },
+    { invalidateIssues: false }
+  );
 }
 
 export async function editRanking(
@@ -41,13 +50,16 @@ export async function editRanking(
   } else if (scoring_type === 'SET_POINTS_WITH_MATCH_BONUS') {
     body.match_bonus_points = match_bonus_points;
   }
-  return createAxios()
-    .put(`tournaments/${tournament_id}/rankings/${ranking_id}`, body)
-    .catch((response: any) => handleRequestError(response));
+  return performMutation('put', `tournaments/${tournament_id}/rankings/${ranking_id}`, body, {
+    invalidateIssues: false,
+  });
 }
 
 export async function deleteRanking(tournament_id: number, ranking_id: number) {
-  return createAxios()
-    .delete(`tournaments/${tournament_id}/rankings/${ranking_id}`)
-    .catch((response: any) => handleRequestError(response));
+  return performMutation(
+    'delete',
+    `tournaments/${tournament_id}/rankings/${ranking_id}`,
+    undefined,
+    { invalidateIssues: false }
+  );
 }

--- a/frontend/src/services/ranking.tsx
+++ b/frontend/src/services/ranking.tsx
@@ -2,11 +2,9 @@ import { ScoringType } from '@openapi';
 
 import { performMutation } from './adapter';
 
-// NOTE: none of these three has ever invalidated tournament issues (consistent across this
-// file, unlike e.g. player.tsx/round.tsx where only one sibling function omits it). Ranking
-// changes can plausibly affect standings-derived issues, so this is still worth the architect
-// double-checking, but the consistency within the file makes it read more like a deliberate
-// choice than an accident.
+// createRanking adds a ranking nothing references yet and deleteRanking only affects
+// unreferenced rankings; neither can change any issue counter, so both skip invalidation.
+// editRanking reconciles stage items and therefore invalidates (see below).
 
 export async function createRanking(tournament_id: number) {
   return performMutation(
@@ -50,8 +48,11 @@ export async function editRanking(
   } else if (scoring_type === 'SET_POINTS_WITH_MATCH_BONUS') {
     body.match_bonus_points = match_bonus_points;
   }
+  // A ranking edit reconciles every stage item using it, which can reassign dependent-input
+  // teams (the unassigned-teams issue counter) and resize match sets (the overdue counters) --
+  // so invalidate issues.
   return performMutation('put', `tournaments/${tournament_id}/rankings/${ranking_id}`, body, {
-    invalidateIssues: false,
+    tournamentId: tournament_id,
   });
 }
 

--- a/frontend/src/services/round.tsx
+++ b/frontend/src/services/round.tsx
@@ -23,10 +23,9 @@ export async function updateRound(
   name: string,
   lifecycle_state: string
 ) {
-  // NOTE: create/delete above invalidate issues; this update (rename + lifecycle_state change,
-  // e.g. activating a round) never has. Lifecycle changes can plausibly affect issue counts, so
-  // this looks like an accidental omission rather than a deliberate one -- preserved as-is and
-  // flagged for the architect.
+  // The backend performs a bare UPDATE of name + lifecycle_state with no cascade, and no
+  // issue counter reads round lifecycle -- this cannot change an issue count, so it skips
+  // invalidation.
   return performMutation(
     'put',
     `tournaments/${tournament_id}/rounds/${round_id}`,

--- a/frontend/src/services/round.tsx
+++ b/frontend/src/services/round.tsx
@@ -1,21 +1,20 @@
-import { createAxios, handleRequestError, mutateIssues } from './adapter';
+import { performMutation } from './adapter';
 
 export async function createRound(tournament_id: number, stage_item_id: number) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/rounds`, {
-      stage_item_id,
-    })
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/rounds`,
+    { stage_item_id },
+    {
+      tournamentId: tournament_id,
+    }
+  );
 }
 
 export async function deleteRound(tournament_id: number, round_id: number) {
-  const response = await createAxios()
-    .delete(`tournaments/${tournament_id}/rounds/${round_id}`)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation('delete', `tournaments/${tournament_id}/rounds/${round_id}`, undefined, {
+    tournamentId: tournament_id,
+  });
 }
 
 export async function updateRound(
@@ -24,7 +23,14 @@ export async function updateRound(
   name: string,
   lifecycle_state: string
 ) {
-  return createAxios()
-    .put(`tournaments/${tournament_id}/rounds/${round_id}`, { name, lifecycle_state })
-    .catch((response: any) => handleRequestError(response));
+  // NOTE: create/delete above invalidate issues; this update (rename + lifecycle_state change,
+  // e.g. activating a round) never has. Lifecycle changes can plausibly affect issue counts, so
+  // this looks like an accidental omission rather than a deliberate one -- preserved as-is and
+  // flagged for the architect.
+  return performMutation(
+    'put',
+    `tournaments/${tournament_id}/rounds/${round_id}`,
+    { name, lifecycle_state },
+    { invalidateIssues: false }
+  );
 }

--- a/frontend/src/services/stage.tsx
+++ b/frontend/src/services/stage.tsx
@@ -1,4 +1,4 @@
-import { createAxios, handleRequestError, mutateIssues } from './adapter';
+import { performMutation } from './adapter';
 
 export type StageTemplateCreateBody = {
   groups: 2 | 3 | 4;
@@ -12,24 +12,36 @@ export async function createStagesFromTemplate(
   tournament_id: number,
   body: StageTemplateCreateBody
 ) {
-  const response = await createAxios().post(
-    `tournaments/${tournament_id}/stages/from-template`,
-    body
-  );
-  await mutateIssues(tournament_id);
-  return response;
+  // The caller (create_from_template_modal.tsx) chains its own try/catch around this and must
+  // see the rejection -- errors are intentionally left uncaught here, as before.
+  return performMutation('post', `tournaments/${tournament_id}/stages/from-template`, body, {
+    tournamentId: tournament_id,
+    catchErrors: false,
+  });
 }
 
 export async function createStage(tournament_id: number, level_id: number | null = null) {
-  return createAxios()
-    .post(`tournaments/${tournament_id}/stages`, { level_id })
-    .catch((response: any) => handleRequestError(response));
+  // A freshly created stage has no stage items yet, so it cannot itself introduce issues.
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/stages`,
+    { level_id },
+    {
+      invalidateIssues: false,
+    }
+  );
 }
 
 export async function updateStage(tournament_id: number, stage_id: number, name: string) {
-  return createAxios()
-    .put(`tournaments/${tournament_id}/stages/${stage_id}`, { name })
-    .catch((response: any) => handleRequestError(response));
+  // Rename only -- cannot affect issue counts.
+  return performMutation(
+    'put',
+    `tournaments/${tournament_id}/stages/${stage_id}`,
+    { name },
+    {
+      invalidateIssues: false,
+    }
+  );
 }
 
 export async function setRankingForStageItems(
@@ -37,15 +49,18 @@ export async function setRankingForStageItems(
   stage_id: number,
   ranking_id: number
 ) {
-  return createAxios()
-    .put(`tournaments/${tournament_id}/stages/${stage_id}/ranking`, { ranking_id })
-    .catch((response: any) => handleRequestError(response));
+  // NOTE: has never invalidated tournament issues, though changing a stage's ranking can
+  // plausibly affect ranking/standings-derived issues -- preserved as-is and flagged.
+  return performMutation(
+    'put',
+    `tournaments/${tournament_id}/stages/${stage_id}/ranking`,
+    { ranking_id },
+    { invalidateIssues: false }
+  );
 }
 
 export async function deleteStage(tournament_id: number, stage_id: number) {
-  const response = await createAxios()
-    .delete(`tournaments/${tournament_id}/stages/${stage_id}`)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation('delete', `tournaments/${tournament_id}/stages/${stage_id}`, undefined, {
+    tournamentId: tournament_id,
+  });
 }

--- a/frontend/src/services/stage.tsx
+++ b/frontend/src/services/stage.tsx
@@ -49,13 +49,14 @@ export async function setRankingForStageItems(
   stage_id: number,
   ranking_id: number
 ) {
-  // NOTE: has never invalidated tournament issues, though changing a stage's ranking can
-  // plausibly affect ranking/standings-derived issues -- preserved as-is and flagged.
+  // Changing a stage's ranking resizes match sets (which feeds the overdue-match issue
+  // counters) and reconciles its stage items, which can reassign dependent-input teams
+  // (which feeds the unassigned-teams counter) -- so invalidate issues.
   return performMutation(
     'put',
     `tournaments/${tournament_id}/stages/${stage_id}/ranking`,
     { ranking_id },
-    { invalidateIssues: false }
+    { tournamentId: tournament_id }
   );
 }
 

--- a/frontend/src/services/stage_item.tsx
+++ b/frontend/src/services/stage_item.tsx
@@ -1,4 +1,4 @@
-import { createAxios, handleRequestError, mutateIssues } from './adapter';
+import { performMutation } from './adapter';
 
 export async function createStageItem(
   tournament_id: number,
@@ -8,17 +8,12 @@ export async function createStageItem(
   ranking_id: number,
   games_per_player: number | null = null
 ) {
-  const response = await createAxios()
-    .post(`tournaments/${tournament_id}/stage_items`, {
-      stage_id,
-      type,
-      team_count,
-      ranking_id,
-      games_per_player,
-    })
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/stage_items`,
+    { stage_id, type, team_count, ranking_id, games_per_player },
+    { tournamentId: tournament_id }
+  );
 }
 
 export async function updateStageItem(
@@ -29,22 +24,19 @@ export async function updateStageItem(
   team_count: number,
   games_per_player: number | null = null
 ) {
-  const response = await createAxios()
-    .put(`tournaments/${tournament_id}/stage_items/${stage_item_id}`, {
-      name,
-      ranking_id,
-      team_count,
-      games_per_player,
-    })
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'put',
+    `tournaments/${tournament_id}/stage_items/${stage_item_id}`,
+    { name, ranking_id, team_count, games_per_player },
+    { tournamentId: tournament_id }
+  );
 }
 
 export async function deleteStageItem(tournament_id: number, stage_item_id: number) {
-  const response = await createAxios()
-    .delete(`tournaments/${tournament_id}/stage_items/${stage_item_id}`)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'delete',
+    `tournaments/${tournament_id}/stage_items/${stage_item_id}`,
+    undefined,
+    { tournamentId: tournament_id }
+  );
 }

--- a/frontend/src/services/stage_item_input.tsx
+++ b/frontend/src/services/stage_item_input.tsx
@@ -1,4 +1,4 @@
-import { createAxios, handleRequestError, mutateIssues } from './adapter';
+import { performMutation } from './adapter';
 
 export async function updateStageItemInput(
   tournament_id: number,
@@ -8,12 +8,10 @@ export async function updateStageItemInput(
   winner_position: number | null,
   winner_from_stage_item_id: number | null
 ) {
-  const response = await createAxios()
-    .put(
-      `tournaments/${tournament_id}/stage_items/${stage_item_id}/inputs/${stage_item_input_id}`,
-      { team_id, winner_position, winner_from_stage_item_id }
-    )
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'put',
+    `tournaments/${tournament_id}/stage_items/${stage_item_id}/inputs/${stage_item_input_id}`,
+    { team_id, winner_position, winner_from_stage_item_id },
+    { tournamentId: tournament_id }
+  );
 }

--- a/frontend/src/services/team.tsx
+++ b/frontend/src/services/team.tsx
@@ -1,4 +1,9 @@
-import { createAxios, handleRequestError, mutateIssues } from './adapter';
+import { performMutation } from './adapter';
+
+// createTeam/createTeams/updateTeam intentionally let AxiosError propagate: their callers
+// (team_create_modal.tsx, team_update_modal.tsx) catch `instanceof AxiosError` themselves to
+// show tailored notifications (e.g. "this team is full") before falling back to
+// handleRequestError.
 
 export async function createTeam(
   tournament_id: number,
@@ -7,14 +12,12 @@ export async function createTeam(
   player_ids: string[],
   level_id: number | null
 ) {
-  const response = await createAxios().post(`tournaments/${tournament_id}/teams`, {
-    name,
-    active,
-    player_ids,
-    level_id,
-  });
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/teams`,
+    { name, active, player_ids, level_id },
+    { tournamentId: tournament_id, catchErrors: false }
+  );
 }
 
 export async function createTeams(
@@ -23,20 +26,18 @@ export async function createTeams(
   active: boolean,
   level_id: number | null
 ) {
-  const response = await createAxios().post(`tournaments/${tournament_id}/teams_multi`, {
-    names,
-    active,
-    level_id,
-  });
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/teams_multi`,
+    { names, active, level_id },
+    { tournamentId: tournament_id, catchErrors: false }
+  );
 }
 
 export async function deleteTeam(tournament_id: number, team_id: number) {
-  await createAxios()
-    .delete(`tournaments/${tournament_id}/teams/${team_id}`)
-    .catch((response: any) => handleRequestError(response));
-  await mutateIssues(tournament_id);
+  await performMutation('delete', `tournaments/${tournament_id}/teams/${team_id}`, undefined, {
+    tournamentId: tournament_id,
+  });
 }
 
 export async function updateTeam(
@@ -47,12 +48,10 @@ export async function updateTeam(
   player_ids: string[],
   level_id: number | null
 ) {
-  const response = await createAxios().put(`tournaments/${tournament_id}/teams/${team_id}`, {
-    name,
-    active,
-    player_ids,
-    level_id,
-  });
-  await mutateIssues(tournament_id);
-  return response;
+  return performMutation(
+    'put',
+    `tournaments/${tournament_id}/teams/${team_id}`,
+    { name, active, player_ids, level_id },
+    { tournamentId: tournament_id, catchErrors: false }
+  );
 }

--- a/frontend/src/services/tournament.tsx
+++ b/frontend/src/services/tournament.tsx
@@ -1,4 +1,4 @@
-import { createAxios, handleRequestError, mutateIssues } from './adapter';
+import { performMutation } from './adapter';
 
 export async function createTournament(
   club_id: number,
@@ -18,8 +18,11 @@ export async function createTournament(
   referees_enabled: boolean = false,
   levels: string[] | null = null
 ) {
-  return createAxios()
-    .post('tournaments', {
+  // No tournament id exists yet, so there's nothing to invalidate.
+  return performMutation(
+    'post',
+    'tournaments',
+    {
       name,
       club_id,
       dashboard_public,
@@ -36,20 +39,38 @@ export async function createTournament(
       score_tracking_enabled,
       referees_enabled,
       levels,
-    })
-    .catch((response: any) => handleRequestError(response));
+    },
+    { invalidateIssues: false }
+  );
 }
 
 export async function deleteTournament(tournament_id: number) {
-  return createAxios().delete(`tournaments/${tournament_id}`);
+  // The caller (settings.tsx) chains its own .then/.catch on this promise and must see the
+  // rejection to skip navigating away on failure -- errors are intentionally left uncaught here.
+  return performMutation('delete', `tournaments/${tournament_id}`, undefined, {
+    invalidateIssues: false,
+    catchErrors: false,
+  });
 }
 
 export async function archiveTournament(tournament_id: number) {
-  return createAxios().post(`tournaments/${tournament_id}/change-status`, { status: 'ARCHIVED' });
+  // The caller (settings.tsx) attaches its own .catch(handleRequestError) -- errors are
+  // intentionally left uncaught here, as before.
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/change-status`,
+    { status: 'ARCHIVED' },
+    { invalidateIssues: false, catchErrors: false }
+  );
 }
 
 export async function unarchiveTournament(tournament_id: number) {
-  return createAxios().post(`tournaments/${tournament_id}/change-status`, { status: 'OPEN' });
+  return performMutation(
+    'post',
+    `tournaments/${tournament_id}/change-status`,
+    { status: 'OPEN' },
+    { invalidateIssues: false, catchErrors: false }
+  );
 }
 
 export async function updateTournament(
@@ -70,8 +91,16 @@ export async function updateTournament(
   referees_enabled: boolean,
   rules: string | null
 ) {
-  return createAxios()
-    .put(`tournaments/${tournament_id}`, {
+  // NOTE: the original implementation only invalidated issues on the success branch of a
+  // .then/.catch chain, skipping invalidation entirely when the update failed -- unlike every
+  // other mutation in this codebase, which invalidates unconditionally once the request settles.
+  // That read as an accidental one-off inconsistency rather than deliberate design, so this now
+  // uses the standard unconditional-invalidation behavior used everywhere else. Flagged for the
+  // architect to confirm.
+  return performMutation(
+    'put',
+    `tournaments/${tournament_id}`,
+    {
       name,
       dashboard_public,
       dashboard_endpoint,
@@ -87,10 +116,7 @@ export async function updateTournament(
       score_tracking_enabled,
       referees_enabled,
       rules,
-    })
-    .then(async (response) => {
-      await mutateIssues(tournament_id);
-      return response;
-    })
-    .catch((response: any) => handleRequestError(response));
+    },
+    { tournamentId: tournament_id }
+  );
 }

--- a/frontend/src/services/user.tsx
+++ b/frontend/src/services/user.tsx
@@ -1,5 +1,5 @@
 import { UserToRegister, UserToUpdate } from '@openapi';
-import { createAxios, handleRequestError } from './adapter';
+import { createAxios, handleRequestError, performMutation } from './adapter';
 
 export async function performLogin(username: string, password: string) {
   const bodyFormData = new FormData();
@@ -28,32 +28,40 @@ export async function performLogin(username: string, password: string) {
 }
 
 export async function updateUser(user_id: number, user: UserToUpdate) {
-  return createAxios()
-    .put(`users/${user_id}`, user)
-    .catch((response: any) => handleRequestError(response));
+  // Users aren't tournament-scoped, so there's no tournament-issues key to invalidate.
+  return performMutation('put', `users/${user_id}`, user, { invalidateIssues: false });
 }
 
 export async function updatePassword(user_id: number, password: string) {
-  return createAxios()
-    .put(`users/${user_id}/password`, { password })
-    .catch((response: any) => handleRequestError(response));
+  return performMutation(
+    'put',
+    `users/${user_id}/password`,
+    { password },
+    {
+      invalidateIssues: false,
+    }
+  );
 }
 
 export async function registerUser(user: UserToRegister, captchaToken: string | null) {
-  return createAxios()
-    .post('users/register', {
+  return performMutation(
+    'post',
+    'users/register',
+    {
       email: user.email,
       name: user.name,
       password: user.password,
       captcha_token: captchaToken,
-    })
-    .catch((response: any) => handleRequestError(response));
+    },
+    { invalidateIssues: false }
+  );
 }
 
 export async function registerDemoUser(captchaToken: string | null) {
-  return createAxios()
-    .post('users/register_demo', {
-      captcha_token: captchaToken,
-    })
-    .catch((response: any) => handleRequestError(response));
+  return performMutation(
+    'post',
+    'users/register_demo',
+    { captcha_token: captchaToken },
+    { invalidateIssues: false }
+  );
 }


### PR DESCRIPTION
## Summary

Reads already had a real seam in `services/adapter.tsx`; writes didn't. The block `createAxios().<verb>(url, body).catch(handleRequestError)` + `mutateIssues(tournament_id)` was re-typed ~60× across the service files, so the AGENTS.md issues-invalidation policy was remembered per call site instead of enforced — and omissions were indistinguishable from accidents. Token-based score-tracking mutations re-implemented "resolve tournament id, then invalidate" four times.

### Changes

- **`performMutation(method, url, body?, options?)`** in `adapter.tsx` — one implementation of the write path. Options:
  - `invalidateIssues` (default **true** — the policy is now opt-out, not remember-to-add)
  - `tournamentId`: a number or an async thunk (the token flows pass the resolve-via-token thunk — one implementation instead of four copies)
  - `catchErrors` (default true, matching the historical swallow-into-`undefined` contract; `false` for the call sites whose callers chain their own `.then`/`.catch` and need real rejections — planner mutations, team/tournament deletes)
- **56 wrappers across 12 service files collapse to one-expression bodies.** Exported names, parameters, and return contracts unchanged; no component edits needed.

### Behavior notes

- 34 functions invalidate as before; the remaining opt-outs are explicit `invalidateIssues: false` with comments.
- The opt-outs originally flagged as possibly accidental were each checked against the backend's actual issue counters and resolved in the second commit:
  - **Flipped to invalidate**: `editRanking` and `setRankingForStageItems` — both reconcile stage items server-side, which can reassign dependent-input teams (`unassigned_teams` counter) and resize match sets (the overdue counters).
  - **Confirmed as correct opt-outs** (now with definitive comments): `autoAssignReferees` (no counter involves referees), `createCourt`/`deleteCourt` (no counter involves courts; deleting a court in use is refused), `updatePlayer` (backend `PlayerBody` is name+active only — note: the `team_id` the client sends is silently dropped by the backend, a pre-existing oddity), `updateRound` (bare name+lifecycle UPDATE, no cascade), `createRanking`/`deleteRanking` (only unreferenced rankings affected).
- One deliberate alignment: `updateTournament` previously invalidated issues only on success — the sole such shape in the codebase; it now invalidates unconditionally like the other call sites. Failure-path difference is a harmless extra SWR revalidation.
- The four logo upload/remove helpers in `adapter.tsx` predate the pattern (no catch, no invalidation) and are left untouched.

### Verification

`pnpm run typecheck` clean · `pnpm test` green (271/271) · `pnpm run build` succeeds · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi