### PR TITLE
Move SQL aggregate quirks out of the composite models into sql/rows.py

### DIFF
--- a/backend/bracket/models/db/util.py
+++ b/backend/bracket/models/db/util.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from pydantic import field_validator, model_validator
 
-from bracket.models.db.match import Match, MatchWithDetails, MatchWithDetailsDefinitive
+from bracket.models.db.match import MatchWithDetails, MatchWithDetailsDefinitive
 from bracket.models.db.round import Round
 from bracket.models.db.stage import Stage
 from bracket.models.db.stage_item import StageItem, StageType
@@ -15,21 +14,15 @@ from bracket.models.db.stage_item_inputs import StageItemInput
 class RoundWithMatches(Round):
     matches: list[MatchWithDetailsDefinitive | MatchWithDetails]
 
-    @field_validator("matches", mode="before")
-    @staticmethod
-    def handle_matches(values: list[Match]) -> list[Match]:
-        if values == [None]:
-            return []
-        return values
-
     @field_validator("matches", mode="after")
     @staticmethod
     def sort_matches_by_id(
         values: list[MatchWithDetailsDefinitive | MatchWithDetails],
     ) -> list[MatchWithDetailsDefinitive | MatchWithDetails]:
-        # Guarantee a stable, deterministic match order (by id, i.e. creation order) regardless of
-        # how the database happened to aggregate them. The SQL already orders these, but this keeps
-        # the contract from silently regressing if that query is ever changed.
+        # Domain invariant: matches are always in id order (i.e. creation order), regardless of
+        # what order the caller assembled them in. This is the single owner of that guarantee from
+        # the model's point of view -- the SQL's `ORDER BY m.id` is an optimization/no-op given
+        # this validator, not the source of truth.
         return sorted(values, key=lambda match: match.id)
 
 
@@ -49,33 +42,16 @@ class StageItemWithRounds(StageItem):
 
         return values
 
-    @field_validator("rounds", "inputs", mode="before")
-    @staticmethod
-    def handle_empty_list_elements(values: list[Any] | None) -> list[Any]:
-        if values is None:
-            return []
-        return [value for value in values if value is not None]
-
     @field_validator("rounds", mode="after")
     @staticmethod
     def sort_rounds_by_id(values: list[RoundWithMatches]) -> list[RoundWithMatches]:
-        # Guarantee a stable, deterministic round order (by id, i.e. round 1, 2, 3 …) regardless of
-        # how the database aggregated them. The SQL already orders these, but this keeps the
-        # contract from silently regressing if that query is ever changed, and ensures round-1
-        # logic (e.g. Swiss resolution) always sees the real round 1 first.
+        # Domain invariant: rounds are always in id order (i.e. round 1, 2, 3 ...), regardless of
+        # what order the caller assembled them in. This is the single owner of that guarantee from
+        # the model's point of view -- the SQL's `ORDER BY r.id` is an optimization/no-op given
+        # this validator -- and it ensures round-1 logic (e.g. Swiss resolution) always sees the
+        # real round 1 first.
         return sorted(values, key=lambda round_: round_.id)
 
 
 class StageWithStageItems(Stage):
     stage_items: list[StageItemWithRounds]
-
-    @field_validator("stage_items", mode="before")
-    @staticmethod
-    def handle_stage_items(values: list[StageItemWithRounds]) -> list[StageItemWithRounds]:
-        if isinstance(values, str):
-            values_json = json.loads(values)
-            if values_json == [None]:
-                return []
-            return values_json
-
-        return values

--- a/backend/bracket/sql/rows.py
+++ b/backend/bracket/sql/rows.py
@@ -1,0 +1,70 @@
+"""Row-shape normalization for the ``to_json(array_agg(...))`` queries in ``sql/stages.py``.
+
+``get_full_tournament_details`` builds a ``StageWithStageItems`` tree by repeatedly
+``LEFT JOIN``-ing and ``array_agg``-ing rounds onto stage items, matches onto rounds, and
+stage items onto stages. Two artifacts of that pattern leak into the raw row:
+
+- An empty ``LEFT JOIN`` aggregate comes back as ``[None]`` (a one-element array containing a
+  SQL NULL) rather than an empty array, because ``array_agg`` over zero joined rows still
+  aggregates the one placeholder NULL row that the outer join produces.
+- The outermost aggregated column (``stage_items``) is returned by the driver as a JSON string
+  rather than an already-parsed Python value, while the columns nested inside it (``rounds``,
+  ``matches``, ``inputs``) come back already parsed, because they were embedded verbatim by
+  Postgres's ``to_json`` when the outer document was built.
+
+This module is the single place that knows about those quirks. It turns a raw row (as returned
+by ``dict(x._mapping)``) into a clean nested structure -- ``[None]`` and ``None`` aggregates
+become ``[]``, and the JSON-string form is parsed -- so that ``StageWithStageItems.model_validate``
+only ever sees clean data and its validators don't need to reason about SQL artifacts.
+"""
+
+import json
+from typing import Any
+
+
+def _clean_aggregate(values: Any) -> list[Any]:
+    """Normalize a ``to_json(array_agg(...))`` column into a plain list.
+
+    Handles the three shapes such a column can arrive in: ``None`` (no aggregation happened),
+    ``[None]`` (an empty ``LEFT JOIN`` was aggregated), or a real list that may still contain
+    ``None`` placeholders.
+    """
+    if values is None:
+        return []
+    return [value for value in values if value is not None]
+
+
+def _normalize_round_row(round_row: dict[str, Any]) -> dict[str, Any]:
+    round_row = dict(round_row)
+    round_row["matches"] = _clean_aggregate(round_row.get("matches"))
+    return round_row
+
+
+def _normalize_stage_item_row(stage_item_row: dict[str, Any]) -> dict[str, Any]:
+    stage_item_row = dict(stage_item_row)
+    stage_item_row["rounds"] = [
+        _normalize_round_row(round_row)
+        for round_row in _clean_aggregate(stage_item_row.get("rounds"))
+    ]
+    stage_item_row["inputs"] = _clean_aggregate(stage_item_row.get("inputs"))
+    return stage_item_row
+
+
+def normalize_stage_row(stage_row: dict[str, Any]) -> dict[str, Any]:
+    """Clean a raw ``stages`` row (with its nested ``stage_items``/``rounds``/``matches``
+    aggregates) so it is safe to pass to ``StageWithStageItems.model_validate``.
+
+    This is the row-shape contract of the ``to_json(array_agg(...))`` queries in
+    ``sql/stages.py``: the models receive clean data and no longer need to know how the SQL
+    aggregated it.
+    """
+    stage_row = dict(stage_row)
+    stage_items = stage_row.get("stage_items")
+    if isinstance(stage_items, str):
+        stage_items = json.loads(stage_items)
+
+    stage_row["stage_items"] = [
+        _normalize_stage_item_row(stage_item_row)
+        for stage_item_row in _clean_aggregate(stage_items)
+    ]
+    return stage_row

--- a/backend/bracket/sql/stages.py
+++ b/backend/bracket/sql/stages.py
@@ -2,6 +2,7 @@ from bracket.database import database
 from bracket.models.db.stage import Stage
 from bracket.models.db.util import StageWithStageItems
 from bracket.sql.matches import MATCH_DETAILS_COLUMNS, inputs_with_teams_cte
+from bracket.sql.rows import normalize_stage_row
 from bracket.utils.id_types import LevelId, RoundId, StageId, StageItemId, TournamentId
 from bracket.utils.types import dict_without_none
 
@@ -97,7 +98,9 @@ async def get_full_tournament_details(
         }
     )
     result = await database.fetch_all(query=query, values=values)
-    return [StageWithStageItems.model_validate(dict(x._mapping)) for x in result]
+    return [
+        StageWithStageItems.model_validate(normalize_stage_row(dict(x._mapping))) for x in result
+    ]
 
 
 async def sql_delete_stage(tournament_id: TournamentId, stage_id: StageId) -> None:

--- a/backend/tests/integration_tests/api/test_tournament_graph_contract.py
+++ b/backend/tests/integration_tests/api/test_tournament_graph_contract.py
@@ -1,0 +1,55 @@
+"""Pins the row-shape contract of ``get_full_tournament_details``.
+
+The query in ``bracket/sql/stages.py`` builds the ``StageWithStageItems`` tree via
+``LEFT JOIN`` + ``to_json(array_agg(...))``, which means an empty aggregate (a stage with no
+stage items, or a stage item with no rounds/inputs) can come back from the driver as ``[None]``
+or a JSON string rather than a clean empty list. ``bracket.sql.rows.normalize_stage_row`` is
+responsible for cleaning that up before the row reaches ``StageWithStageItems.model_validate``.
+These tests exercise that end-to-end, through real inserts, so a regression in either the
+normalizer or the query shows up here rather than only in the model's own validators.
+"""
+
+import pytest
+
+from bracket.sql.stages import get_full_tournament_details
+from bracket.utils.dummy_records import DUMMY_STAGE1, DUMMY_STAGE2, DUMMY_STAGE_ITEM1
+from tests.integration_tests.models import AuthContext
+from tests.integration_tests.sql import inserted_stage, inserted_stage_item
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_stage_with_zero_stage_items_returns_empty_list(
+    auth_context: AuthContext,
+) -> None:
+    tournament_id = auth_context.tournament.id
+    async with inserted_stage(
+        DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
+    ) as stage_inserted:
+        [stage] = await get_full_tournament_details(tournament_id, stage_id=stage_inserted.id)
+
+        assert stage.stage_items == []
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_stage_item_with_zero_rounds_and_inputs_returns_empty_lists(
+    auth_context: AuthContext,
+) -> None:
+    """A freshly inserted stage item has no rounds and no inputs yet (those are only created by
+    the higher-level "create stage item" flow / builder). This is the (b) case from the task: a
+    stage item with zero rounds, reachable through a real (if low-level) insert path.
+    """
+    tournament_id = auth_context.tournament.id
+    async with inserted_stage(
+        DUMMY_STAGE2.model_copy(update={"tournament_id": tournament_id})
+    ) as stage_inserted:
+        async with inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage_inserted.id, "ranking_id": auth_context.ranking.id}
+            )
+        ):
+            [stage] = await get_full_tournament_details(tournament_id, stage_id=stage_inserted.id)
+
+            assert len(stage.stage_items) == 1
+            [stage_item] = stage.stage_items
+            assert stage_item.rounds == []
+            assert stage_item.inputs == []

--- a/backend/tests/unit_tests/test_sql_rows.py
+++ b/backend/tests/unit_tests/test_sql_rows.py
@@ -1,0 +1,92 @@
+"""Unit tests for the row normalizer in ``bracket.sql.rows``.
+
+See ``bracket/sql/rows.py`` for why this normalization exists: the ``to_json(array_agg(...))``
+queries in ``bracket/sql/stages.py`` produce ``[None]`` for empty ``LEFT JOIN`` aggregates and
+return the outermost aggregated column as a JSON string, while nested aggregates arrive already
+parsed.
+"""
+
+import json
+from typing import Any, cast
+
+from bracket.sql.rows import normalize_stage_row
+
+
+def _base_stage_row(stage_items: object) -> dict[str, object]:
+    return {
+        "id": 1,
+        "name": "Stage",
+        "tournament_id": 1,
+        "level_id": None,
+        "stage_items": stage_items,
+    }
+
+
+def test_empty_stage_items_aggregate_becomes_empty_list() -> None:
+    row = normalize_stage_row(_base_stage_row([None]))
+    assert row["stage_items"] == []
+
+
+def test_none_stage_items_aggregate_becomes_empty_list() -> None:
+    row = normalize_stage_row(_base_stage_row(None))
+    assert row["stage_items"] == []
+
+
+def test_stage_items_json_string_is_parsed() -> None:
+    stage_item = {"id": 10, "rounds": [None], "inputs": None}
+    row = normalize_stage_row(_base_stage_row(json.dumps([stage_item])))
+    assert row["stage_items"] == [{"id": 10, "rounds": [], "inputs": []}]
+
+
+def test_json_string_of_empty_aggregate_becomes_empty_list() -> None:
+    row = normalize_stage_row(_base_stage_row(json.dumps([None])))
+    assert row["stage_items"] == []
+
+
+def test_empty_rounds_and_inputs_aggregates_become_empty_lists() -> None:
+    stage_item = {"id": 10, "rounds": [None], "inputs": [None]}
+    row = normalize_stage_row(_base_stage_row([stage_item]))
+    [normalized_stage_item] = cast("list[dict[str, Any]]", row["stage_items"])
+    assert normalized_stage_item["rounds"] == []
+    assert normalized_stage_item["inputs"] == []
+
+
+def test_none_rounds_and_inputs_aggregates_become_empty_lists() -> None:
+    stage_item = {"id": 10, "rounds": None, "inputs": None}
+    row = normalize_stage_row(_base_stage_row([stage_item]))
+    [normalized_stage_item] = cast("list[dict[str, Any]]", row["stage_items"])
+    assert normalized_stage_item["rounds"] == []
+    assert normalized_stage_item["inputs"] == []
+
+
+def test_empty_matches_aggregate_on_a_round_becomes_empty_list() -> None:
+    stage_item = {"id": 10, "rounds": [{"id": 100, "matches": [None]}], "inputs": []}
+    row = normalize_stage_row(_base_stage_row([stage_item]))
+    [normalized_stage_item] = cast("list[dict[str, Any]]", row["stage_items"])
+    [normalized_round] = normalized_stage_item["rounds"]
+    assert normalized_round["matches"] == []
+
+
+def test_clean_rows_pass_through_unchanged() -> None:
+    stage_item = {
+        "id": 10,
+        "rounds": [{"id": 100, "matches": [{"id": 1000}]}],
+        "inputs": [{"id": 5}],
+    }
+    row = normalize_stage_row(_base_stage_row([stage_item]))
+    assert row["stage_items"] == [
+        {
+            "id": 10,
+            "rounds": [{"id": 100, "matches": [{"id": 1000}]}],
+            "inputs": [{"id": 5}],
+        }
+    ]
+
+
+def test_does_not_mutate_the_input_row() -> None:
+    stage_item = {"id": 10, "rounds": [None], "inputs": [None]}
+    original_row = _base_stage_row([stage_item])
+    row = normalize_stage_row(original_row)
+
+    assert row is not original_row
+    assert original_row["stage_items"] == [stage_item]


### PR DESCRIPTION
## Summary

The composite models (`RoundWithMatches`, `StageItemWithRounds`, `StageWithStageItems`) carried validators that existed only to paper over artifacts of the `to_json(array_agg(...))` queries that build them: the `[None]` an empty LEFT JOIN aggregate produces, and the JSON-string form of the outermost aggregated column. The assembly contract was split across two languages — to trust the object a reader had to hold the SQL string, the Pydantic validators, and the `array_agg` quirk simultaneously.

### Changes

- **New `sql/rows.py`** — the single place that knows the row-shape quirks, documented at the source: `normalize_stage_row()` turns a raw row into a clean nested structure (`[None]`/`None` aggregates → `[]`, JSON-string → parsed). Applied at the one call site that validates these composites from raw rows (`get_full_tournament_details`; `sql/rounds.py` and `sql/stage_items.py` delegate to it rather than building rows themselves — verified by grep).
- **Models keep only the domain invariant** — `handle_matches`, `handle_empty_list_elements`, `handle_stage_items` deleted; `sort_matches_by_id` / `sort_rounds_by_id` stay as the single owner of the "always in id order" guarantee (protecting every constructor, including test fixtures), with comments reframed accordingly. `fill_type_name` untouched.
- No fixture changes were needed — unit-test fixtures already construct clean data.

### Tests

- `test_sql_rows.py` — 9 unit tests pinning the normalizer contract (`[None]` → `[]`, `None` → `[]`, JSON-string parsing, nested cleaning, clean pass-through, input non-mutation).
- `test_tournament_graph_contract.py` — 2 integration tests: a stage with zero stage items and a stage item with zero rounds/inputs both come back as empty lists, never `None`/`[None]`.
- Full backend suite: **484 passed** (473 baseline + 11 new). ruff/mypy/pyrefly/pylint/vulture clean. `openapi.json` regenerates with no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi)_