### PR TITLE
Remove dead team_id parameter from updatePlayer

### DIFF
--- a/frontend/src/components/modals/player_update_modal.tsx
+++ b/frontend/src/components/modals/player_update_modal.tsx
@@ -46,7 +46,7 @@ export default function PlayerUpdateModal({
       <Modal opened={opened} onClose={() => setOpened(false)} title={t('edit_player')}>
         <form
           onSubmit={form.onSubmit(async (values) => {
-            await updatePlayer(tournament_id, player.id, values.name, values.active, null);
+            await updatePlayer(tournament_id, player.id, values.name, values.active);
             await swrPlayersResponse.mutate();
             setOpened(false);
           })}

--- a/frontend/src/services/player.tsx
+++ b/frontend/src/services/player.tsx
@@ -30,16 +30,14 @@ export async function updatePlayer(
   tournament_id: number,
   player_id: number,
   name: string,
-  active: boolean,
-  team_id: string | null
+  active: boolean
 ) {
-  // The backend's PlayerBody is {name, active} only -- the team_id sent here is silently
-  // dropped, team membership is unchanged, and no issue counter filters on `active`, so this
-  // update cannot change an issue count and skips invalidation.
+  // The backend updates name + active only, and no issue counter filters on `active`, so this
+  // cannot change an issue count and skips invalidation.
   return performMutation(
     'put',
     `tournaments/${tournament_id}/players/${player_id}`,
-    { name, active, team_id },
+    { name, active },
     { invalidateIssues: false }
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to the oddity surfaced in #254: the frontend's `updatePlayer` sent `team_id` in the PUT body, but the backend's `PlayerBody` model is `{name, active}` only, so it has always been silently dropped. Investigating the UI showed the sole caller — the player edit modal — always passed `null`: there is no team-picker in that flow, so moving a player between teams via this endpoint was never possible and never attempted. The parameter was dead end to end.

### Changes

- `services/player.tsx`: `team_id` removed from `updatePlayer`'s signature and request body; verdict comment simplified accordingly.
- `player_update_modal.tsx`: trailing `null` argument dropped.
- Verified via grep that the modal is the only caller.

### Verification

`pnpm test` green (271/271) · `pnpm run build` succeeds · typecheck and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxiGzAyXGuzfqcih3qoxEi)_