### PR TITLE
Reject duplicate player names within a tournament

### DIFF
--- a/backend/bracket/routes/players.py
+++ b/backend/bracket/routes/players.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from bracket.config import config
 from bracket.database import database
@@ -19,6 +19,7 @@ from bracket.sql.players import (
     get_all_players_in_tournament,
     get_player_count,
     insert_player,
+    player_name_exists,
     sql_delete_player,
 )
 from bracket.utils.db import fetch_one_parsed
@@ -27,6 +28,8 @@ from bracket.utils.pagination import PaginationPlayers
 from bracket.utils.types import assert_some
 
 router = APIRouter(prefix=config.api_prefix)
+
+_PLAYER_NAME_ALREADY_EXISTS = "A player with this name already exists"
 
 
 @router.get("/tournaments/{tournament_id}/players", response_model=PlayersResponse)
@@ -54,6 +57,12 @@ async def update_player_by_id(
     _: UserPublic = Depends(user_authenticated_for_tournament),
     __: Tournament = Depends(disallow_archived_tournament),
 ) -> SinglePlayerResponse:
+    if await player_name_exists(tournament_id, player_body.name, except_player_id=player_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_PLAYER_NAME_ALREADY_EXISTS,
+        )
+
     await database.execute(
         query=players.update().where(
             (players.c.id == player_id) & (players.c.tournament_id == tournament_id)
@@ -93,6 +102,13 @@ async def create_single_player(
 ) -> SuccessResponse:
     existing_players = await get_all_players_in_tournament(tournament_id)
     check_requirement(existing_players, user, "max_players")
+
+    if await player_name_exists(tournament_id, player_body.name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_PLAYER_NAME_ALREADY_EXISTS,
+        )
+
     await insert_player(player_body, tournament_id)
     return SuccessResponse()
 
@@ -107,6 +123,21 @@ async def create_multiple_players(
     player_names = [player.strip() for player in player_body.names.split("\n") if len(player) > 0]
     existing_players = await get_all_players_in_tournament(tournament_id)
     check_requirement(existing_players, user, "max_players", additions=len(player_names))
+
+    seen_names_lower: set[str] = set()
+    for player_name in player_names:
+        if player_name.lower() in seen_names_lower:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"A player with the name '{player_name}' already exists",
+            )
+        seen_names_lower.add(player_name.lower())
+
+        if await player_name_exists(tournament_id, player_name):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"A player with the name '{player_name}' already exists",
+            )
 
     for player_name in player_names:
         await insert_player(PlayerBody(name=player_name, active=player_body.active), tournament_id)

--- a/backend/bracket/routes/signup.py
+++ b/backend/bracket/routes/signup.py
@@ -20,9 +20,8 @@ from bracket.routes.models import (
 )
 from bracket.schema import players_x_teams, teams
 from bracket.sql.levels import sql_get_levels_for_tournament
-from bracket.sql.players import get_all_players_in_tournament, insert_player
+from bracket.sql.players import get_all_players_in_tournament, insert_player, player_name_exists
 from bracket.sql.signup import (
-    check_player_name_exists,
     count_players_on_team,
     get_signup_team_info_rows,
 )
@@ -92,7 +91,7 @@ async def post_signup(
     body: SignupBody,
     tournament: Tournament = Depends(tournament_by_signup_token),
 ) -> SuccessResponse:
-    if await check_player_name_exists(tournament.id, body.player_name):
+    if await player_name_exists(tournament.id, body.player_name):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="A player with this name already exists",

--- a/backend/bracket/sql/players.py
+++ b/backend/bracket/sql/players.py
@@ -69,6 +69,35 @@ async def get_all_players_in_tournament(
     return [PlayerWithTeams.model_validate(x) for x in result]
 
 
+async def player_name_exists(
+    tournament_id: TournamentId, name: str, *, except_player_id: PlayerId | None = None
+) -> bool:
+    """Case-insensitive check for duplicate player name in tournament.
+
+    When `except_player_id` is given, that player is excluded from the check, which allows
+    e.g. updating a player without the name colliding with itself.
+    """
+    except_player_filter = "AND id != :except_player_id" if except_player_id is not None else ""
+    query = f"""
+        SELECT COUNT(*) AS cnt
+        FROM players
+        WHERE tournament_id = :tournament_id AND LOWER(name) = LOWER(:name)
+        {except_player_filter}
+        """
+    row = await database.fetch_one(
+        query=query,
+        values=dict_without_none(
+            {
+                "tournament_id": tournament_id,
+                "name": name,
+                "except_player_id": except_player_id,
+            }
+        ),
+    )
+    assert row is not None
+    return int(row["cnt"]) > 0
+
+
 async def get_player_by_id(player_id: PlayerId, tournament_id: TournamentId) -> Player | None:
     query = """
         SELECT *

--- a/backend/bracket/sql/signup.py
+++ b/backend/bracket/sql/signup.py
@@ -31,20 +31,6 @@ async def get_tournament_by_score_tracking_token(score_tracking_token: str) -> T
     return Tournament.model_validate(result) if result is not None else None
 
 
-async def check_player_name_exists(tournament_id: TournamentId, name: str) -> bool:
-    """Case-insensitive check for duplicate player name in tournament."""
-    query = """
-        SELECT COUNT(*) AS cnt
-        FROM players
-        WHERE tournament_id = :tournament_id AND LOWER(name) = LOWER(:name)
-        """
-    row = await database.fetch_one(
-        query=query, values={"tournament_id": tournament_id, "name": name}
-    )
-    assert row is not None
-    return int(row["cnt"]) > 0
-
-
 async def count_players_on_team(team_id: TeamId, tournament_id: TournamentId) -> int:
     query = """
         SELECT COUNT(*) AS cnt

--- a/backend/tests/integration_tests/api/players_test.py
+++ b/backend/tests/integration_tests/api/players_test.py
@@ -4,7 +4,7 @@ from bracket.database import database
 from bracket.models.db.player import Player
 from bracket.schema import players
 from bracket.utils.db import fetch_one_parsed_certain
-from bracket.utils.dummy_records import DUMMY_MOCK_TIME, DUMMY_PLAYER1, DUMMY_TEAM1
+from bracket.utils.dummy_records import DUMMY_MOCK_TIME, DUMMY_PLAYER1, DUMMY_PLAYER2, DUMMY_TEAM1
 from bracket.utils.http import HTTPMethod
 from tests.integration_tests.api.shared import SUCCESS_RESPONSE, send_tournament_request
 from tests.integration_tests.models import AuthContext
@@ -55,6 +55,27 @@ async def test_create_player(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_create_player_with_duplicate_name_is_rejected(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with inserted_player(
+        DUMMY_PLAYER1.model_copy(update={"tournament_id": auth_context.tournament.id})
+    ):
+        body = {"name": "player 01", "active": True}
+        response = await send_tournament_request(
+            HTTPMethod.POST, "players", auth_context, json=body
+        )
+        assert response["detail"] == "A player with this name already exists"
+
+        remaining_players = await database.fetch_all(
+            query=players.select().where(players.c.tournament_id == auth_context.tournament.id)
+        )
+        assert [p["name"] for p in remaining_players] == ["Player 01"]
+
+        await assert_row_count_and_clear(players, 1)
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_create_players(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:
@@ -64,6 +85,45 @@ async def test_create_players(
     )
     assert response["success"] is True
     await assert_row_count_and_clear(players, 2)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_create_players_multi_rejects_name_that_already_exists(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with inserted_player(
+        DUMMY_PLAYER1.model_copy(update={"tournament_id": auth_context.tournament.id})
+    ):
+        body = {"names": "Player x\nplayer 01", "active": True}
+        response = await send_tournament_request(
+            HTTPMethod.POST, "players_multi", auth_context, json=body
+        )
+        assert "already exists" in response["detail"]
+
+        remaining_players = await database.fetch_all(
+            query=players.select().where(players.c.tournament_id == auth_context.tournament.id)
+        )
+        assert [p["name"] for p in remaining_players] == ["Player 01"]
+
+        await assert_row_count_and_clear(players, 1)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_create_players_multi_rejects_duplicate_names_within_submission(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    body = {"names": "Player x\nplayer X", "active": True}
+    response = await send_tournament_request(
+        HTTPMethod.POST, "players_multi", auth_context, json=body
+    )
+    assert "already exists" in response["detail"]
+
+    remaining_players = await database.fetch_all(
+        query=players.select().where(players.c.tournament_id == auth_context.tournament.id)
+    )
+    assert remaining_players == []
+
+    await assert_row_count_and_clear(players, 0)
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -83,6 +143,53 @@ async def test_delete_player(
                 == SUCCESS_RESPONSE
             )
             await assert_row_count_and_clear(players, 0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_player_rejects_rename_to_existing_player_name(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with (
+        inserted_player(
+            DUMMY_PLAYER1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as player1,
+        inserted_player(
+            DUMMY_PLAYER2.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as player2,
+    ):
+        body = {"name": player1.name, "active": True}
+        response = await send_tournament_request(
+            HTTPMethod.PUT, f"players/{player2.id}", auth_context, json=body
+        )
+        assert response["detail"] == "A player with this name already exists"
+
+        unchanged_player = await fetch_one_parsed_certain(
+            database, Player, query=players.select().where(players.c.id == player2.id)
+        )
+        assert unchanged_player.name == "Player 02"
+
+        await assert_row_count_and_clear(players, 2)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_player_allows_case_only_rename_to_own_name(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with inserted_player(
+        DUMMY_PLAYER1.model_copy(update={"tournament_id": auth_context.tournament.id})
+    ) as player1:
+        body = {"name": "PLAYER 01", "active": True}
+        response = await send_tournament_request(
+            HTTPMethod.PUT, f"players/{player1.id}", auth_context, json=body
+        )
+        assert response["data"]["name"] == "PLAYER 01"
+
+        updated_player = await fetch_one_parsed_certain(
+            database, Player, query=players.select().where(players.c.id == player1.id)
+        )
+        assert updated_player.name == "PLAYER 01"
+
+        await assert_row_count_and_clear(players, 1)
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/backend/tests/integration_tests/api/signup_test.py
+++ b/backend/tests/integration_tests/api/signup_test.py
@@ -2,12 +2,23 @@ import pytest
 
 from bracket.database import database
 from bracket.schema import players, teams
-from bracket.utils.dummy_records import DUMMY_LEVEL1, DUMMY_LEVEL2, DUMMY_TEAM1, DUMMY_TEAM2
+from bracket.utils.dummy_records import (
+    DUMMY_LEVEL1,
+    DUMMY_LEVEL2,
+    DUMMY_PLAYER1,
+    DUMMY_TEAM1,
+    DUMMY_TEAM2,
+)
 from bracket.utils.http import HTTPMethod
 from bracket.utils.types import JsonDict
 from tests.integration_tests.api.shared import send_request, send_tournament_request
 from tests.integration_tests.models import AuthContext
-from tests.integration_tests.sql import enabled_signup, inserted_level, inserted_team
+from tests.integration_tests.sql import (
+    enabled_signup,
+    inserted_level,
+    inserted_player,
+    inserted_team,
+)
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -143,6 +154,31 @@ async def test_signup_join_team_copies_level_to_player(
 
     player = next(p for p in players_response["data"]["players"] if p["name"] == "Team Joiner")
     assert player["level_id"] == level.id
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_signup_rejects_duplicate_player_name(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    signup_token = "duplicate-name-token"
+    tournament_id = auth_context.tournament.id
+
+    async with (
+        enabled_signup(tournament_id, signup_token),
+        inserted_player(DUMMY_PLAYER1.model_copy(update={"tournament_id": tournament_id})),
+    ):
+        response: JsonDict = await send_request(
+            HTTPMethod.POST,
+            f"signup/{signup_token}",
+            json={"player_name": "player 01", "team_action": "none"},
+        )
+
+        remaining_players = await database.fetch_all(
+            query=players.select().where(players.c.tournament_id == tournament_id)
+        )
+
+    assert response["detail"] == "A player with this name already exists"
+    assert [p["name"] for p in remaining_players] == ["Player 01"]
 
 
 @pytest.mark.asyncio(loop_scope="session")


### PR DESCRIPTION
Enforce case-insensitive unique player names per tournament on all
creation and rename paths, returning HTTP 400 with a clear error:

- POST /players rejects a name that already exists
- POST /players_multi rejects existing names and duplicates within
  the submitted list, before inserting anything
- PUT /players/{id} rejects renaming to another player's name while
  still allowing a player to keep (or re-case) their own name

Consolidate the check into player_name_exists() in sql/players.py
(with an except_player_id exclusion for updates), replacing the
signup-only check_player_name_exists, and add test coverage for the
previously untested signup duplicate-name rejection.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q9HSKdWcuq1k7Zo9myLVBG