### PR TITLE
Add per-ranking "Allow draws" option enforced at set transitions (#268)

### DIFF
--- a/backend/alembic/versions/b6e3f9a2c7d5_add_draws_allowed_to_rankings.py
+++ b/backend/alembic/versions/b6e3f9a2c7d5_add_draws_allowed_to_rankings.py
@@ -1,0 +1,33 @@
+"""add draws_allowed to rankings
+
+Revision ID: b6e3f9a2c7d5
+Revises: d9f3b1a7c5e2
+Create Date: 2026-07-09 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str | None = "b6e3f9a2c7d5"
+down_revision: str | None = "d9f3b1a7c5e2"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "rankings",
+        sa.Column(
+            "draws_allowed",
+            sa.Boolean(),
+            nullable=False,
+            server_default="true",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("rankings", "draws_allowed")

--- a/backend/bracket/logic/match_sets/apply_update.py
+++ b/backend/bracket/logic/match_sets/apply_update.py
@@ -6,13 +6,17 @@ from starlette import status
 
 from bracket.database import database
 from bracket.logic.match_sets.pointer import IllegalMatchTransitionError
-from bracket.logic.match_sets.validation import validate_match_can_be_started
+from bracket.logic.match_sets.validation import (
+    validate_draws_allowed_for_end,
+    validate_match_can_be_started,
+)
 from bracket.logic.ranking.elimination import get_started_elimination_followers
 from bracket.logic.reconcile import reconcile_stage_item
 from bracket.logic.scheduling.standings_resolution import is_standings_resolved_stage_type
 from bracket.models.db.match import (
     Match,
     MatchSetScoreEditBody,
+    MatchSetState,
     MatchState,
     MatchWithDetails,
     derive_match_state,
@@ -111,6 +115,10 @@ async def start_match_and_recalculate(
 
 
 async def end_match_and_recalculate(tournament_id: TournamentId, match: Match) -> MatchWithDetails:
+    sets = await get_sets_for_match(match.id)
+    in_progress_set = next((s for s in sets if s.state is MatchSetState.IN_PROGRESS), None)
+    if in_progress_set is not None:
+        await validate_draws_allowed_for_end(tournament_id, match, in_progress_set)
     return await apply_match_change_and_recalculate(
         tournament_id, match, lambda: sql_end_match(match.id)
     )

--- a/backend/bracket/logic/match_sets/validation.py
+++ b/backend/bracket/logic/match_sets/validation.py
@@ -1,8 +1,17 @@
 from fastapi import HTTPException
 from starlette import status
 
-from bracket.models.db.match import Match, MatchState
+from bracket.models.db.match import (
+    Match,
+    MatchSet,
+    MatchSetScoreEditBody,
+    MatchSetState,
+    MatchState,
+)
 from bracket.models.db.stage_item_inputs import StageItemInputFinal
+from bracket.sql.rankings import get_ranking_for_stage_item
+from bracket.sql.rounds import get_round_by_id
+from bracket.sql.stage_items import get_stage_item
 from bracket.sql.stages import get_full_tournament_details
 from bracket.utils.id_types import TournamentId
 
@@ -36,4 +45,40 @@ async def validate_match_can_be_started(
 
         raise ValueError(
             f"Could not find stage for match {existing_match.id} in tournament {tournament_id}"
+        )
+
+
+async def _draws_allowed_for_match(tournament_id: TournamentId, match: Match) -> bool:
+    round_ = await get_round_by_id(tournament_id, match.round_id)
+    stage_item = await get_stage_item(tournament_id, round_.stage_item_id)
+    ranking = await get_ranking_for_stage_item(tournament_id, stage_item.id)
+    return ranking is None or ranking.draws_allowed
+
+
+async def validate_draws_allowed_for_end(
+    tournament_id: TournamentId, match: Match, in_progress_set: MatchSet
+) -> None:
+    if in_progress_set.stage_item_input1_score != in_progress_set.stage_item_input2_score:
+        return
+    if not await _draws_allowed_for_match(tournament_id, match):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot end: draws are not allowed for this ranking",
+        )
+
+
+async def validate_draws_allowed_for_score_edit(
+    tournament_id: TournamentId,
+    match: Match,
+    current_set_state: MatchSetState,
+    body: MatchSetScoreEditBody,
+) -> None:
+    if current_set_state is not MatchSetState.COMPLETED:
+        return
+    if body.stage_item_input1_score != body.stage_item_input2_score:
+        return
+    if not await _draws_allowed_for_match(tournament_id, match):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot edit: draws are not allowed for this ranking",
         )

--- a/backend/bracket/models/db/match.py
+++ b/backend/bracket/models/db/match.py
@@ -154,6 +154,7 @@ class MatchWithDetails(Match):
     max_points: int = 21
     last_set_max_points: int | None = None
     two_point_advantage: bool = True
+    draws_allowed: bool = True
 
     @field_validator("stage_item_input1", "stage_item_input2", "court", "referee", mode="before")
     @staticmethod
@@ -181,6 +182,7 @@ class MatchWithDetailsDefinitive(Match):
     max_points: int = 21
     last_set_max_points: int | None = None
     two_point_advantage: bool = True
+    draws_allowed: bool = True
 
     @property
     def stage_item_inputs(self) -> list[StageItemInput]:

--- a/backend/bracket/models/db/ranking.py
+++ b/backend/bracket/models/db/ranking.py
@@ -37,6 +37,7 @@ class RankingBase(BaseModel):
     last_set_max_points: int | None = None
     two_point_advantage: bool = True
     side_switch_every_n_points: int | None = None
+    draws_allowed: bool = True
 
 
 # Keep for backwards-compatibility with insert helpers / existing SQL insert code
@@ -66,6 +67,7 @@ class RankingMatchPointsBody(BaseModel):
     two_point_advantage: bool = True
     position: int | None = None
     side_switch_every_n_points: int | None = None
+    draws_allowed: bool = True
 
 
 class RankingSetPointsBody(BaseModel):
@@ -77,6 +79,7 @@ class RankingSetPointsBody(BaseModel):
     two_point_advantage: bool = True
     position: int | None = None
     side_switch_every_n_points: int | None = None
+    draws_allowed: bool = True
 
 
 class RankingSetPointsWithMatchBonusBody(BaseModel):
@@ -89,6 +92,7 @@ class RankingSetPointsWithMatchBonusBody(BaseModel):
     two_point_advantage: bool = True
     position: int | None = None
     side_switch_every_n_points: int | None = None
+    draws_allowed: bool = True
 
 
 RankingBody = Annotated[

--- a/backend/bracket/routes/match_sets.py
+++ b/backend/bracket/routes/match_sets.py
@@ -3,6 +3,7 @@ from starlette import status
 
 from bracket.config import config
 from bracket.logic.match_sets.apply_update import score_edit_and_recalculate
+from bracket.logic.match_sets.validation import validate_draws_allowed_for_score_edit
 from bracket.models.db.match import MatchSet, MatchSetScoreEditBody
 from bracket.routes.match_access import (
     ResolvedMatch,
@@ -29,7 +30,10 @@ async def _get_set_belonging_to_match(match_id: MatchId, match_set_id: MatchSetI
 async def _score_edit(
     resolved: ResolvedMatch, set_id: MatchSetId, body: MatchSetScoreEditBody
 ) -> ScoreTrackingMatchResponse:
-    await _get_set_belonging_to_match(resolved.match.id, set_id)
+    match_set = await _get_set_belonging_to_match(resolved.match.id, set_id)
+    await validate_draws_allowed_for_score_edit(
+        resolved.tournament_id, resolved.match, match_set.state, body
+    )
     updated = await score_edit_and_recalculate(resolved.tournament_id, resolved.match, set_id, body)
     return ScoreTrackingMatchResponse(data=updated)
 

--- a/backend/bracket/schema.py
+++ b/backend/bracket/schema.py
@@ -317,6 +317,7 @@ rankings = Table(
     Column("two_point_advantage", Boolean, nullable=False, server_default="true"),
     Column("level_id", BigInteger, ForeignKey("levels.id"), nullable=True),
     Column("side_switch_every_n_points", Integer, nullable=True),
+    Column("draws_allowed", Boolean, nullable=False, server_default="true"),
 )
 
 ranking_match_points = Table(

--- a/backend/bracket/sql/matches.py
+++ b/backend/bracket/sql/matches.py
@@ -279,6 +279,7 @@ MATCH_DETAILS_COLUMNS = f"""
     rankings.max_points AS max_points,
     rankings.last_set_max_points AS last_set_max_points,
     rankings.two_point_advantage AS two_point_advantage,
+    rankings.draws_allowed AS draws_allowed,
     {MATCH_SETS_SUBQUERY}
 """
 

--- a/backend/bracket/sql/rankings.py
+++ b/backend/bracket/sql/rankings.py
@@ -54,6 +54,7 @@ def _row_to_ranking(row: Record) -> Ranking:
         max_points=m["max_points"],
         last_set_max_points=m.get("last_set_max_points"),
         two_point_advantage=m["two_point_advantage"],
+        draws_allowed=m["draws_allowed"],
         level_id=m.get("level_id"),
         side_switch_every_n_points=m.get("side_switch_every_n_points"),
         match_points=match_points,
@@ -176,7 +177,8 @@ async def sql_update_ranking(
                 max_points = :max_points,
                 last_set_max_points = :last_set_max_points,
                 two_point_advantage = :two_point_advantage,
-                side_switch_every_n_points = :side_switch_every_n_points
+                side_switch_every_n_points = :side_switch_every_n_points,
+                draws_allowed = :draws_allowed
             WHERE rankings.tournament_id = :tournament_id
             AND rankings.id = :ranking_id
         """,
@@ -191,6 +193,7 @@ async def sql_update_ranking(
             "last_set_max_points": ranking_body.last_set_max_points,
             "two_point_advantage": ranking_body.two_point_advantage,
             "side_switch_every_n_points": ranking_body.side_switch_every_n_points,
+            "draws_allowed": ranking_body.draws_allowed,
         },
     )
 
@@ -244,10 +247,12 @@ async def sql_create_ranking(
         query="""
             INSERT INTO rankings
             (tournament_id, position, name, scoring_type, num_sets, max_points,
-             last_set_max_points, two_point_advantage, level_id, side_switch_every_n_points)
+             last_set_max_points, two_point_advantage, level_id, side_switch_every_n_points,
+             draws_allowed)
             VALUES (
                 :tournament_id, :position, :name, :scoring_type, :num_sets, :max_points,
-                :last_set_max_points, :two_point_advantage, :level_id, :side_switch_every_n_points
+                :last_set_max_points, :two_point_advantage, :level_id, :side_switch_every_n_points,
+                :draws_allowed
             )
             RETURNING id
         """,
@@ -262,6 +267,7 @@ async def sql_create_ranking(
             "two_point_advantage": ranking_body.two_point_advantage,
             "level_id": level_id,
             "side_switch_every_n_points": ranking_body.side_switch_every_n_points,
+            "draws_allowed": ranking_body.draws_allowed,
         },
     )
     await _insert_subtype_row(ranking_id, ranking_body)

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -981,6 +981,11 @@
             ],
             "title": "Custom Duration Minutes"
           },
+          "draws_allowed": {
+            "default": true,
+            "title": "Draws Allowed",
+            "type": "boolean"
+          },
           "duration_minutes": {
             "title": "Duration Minutes",
             "type": "integer"
@@ -1245,6 +1250,7 @@
           "max_points",
           "last_set_max_points",
           "two_point_advantage",
+          "draws_allowed",
           "state"
         ],
         "title": "MatchWithDetails",
@@ -1301,6 +1307,11 @@
             ],
             "title": "Custom Duration Minutes"
           },
+          "draws_allowed": {
+            "default": true,
+            "title": "Draws Allowed",
+            "type": "boolean"
+          },
           "duration_minutes": {
             "title": "Duration Minutes",
             "type": "integer"
@@ -1559,6 +1570,7 @@
           "max_points",
           "last_set_max_points",
           "two_point_advantage",
+          "draws_allowed",
           "state"
         ],
         "title": "MatchWithDetailsDefinitive",
@@ -1859,6 +1871,11 @@
             "title": "Created",
             "type": "string"
           },
+          "draws_allowed": {
+            "default": true,
+            "title": "Draws Allowed",
+            "type": "boolean"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
@@ -1960,6 +1977,7 @@
           "last_set_max_points",
           "two_point_advantage",
           "side_switch_every_n_points",
+          "draws_allowed",
           "id",
           "created",
           "match_points",
@@ -1982,6 +2000,11 @@
             ],
             "default": "0.5",
             "title": "Draw Points"
+          },
+          "draws_allowed": {
+            "default": true,
+            "title": "Draws Allowed",
+            "type": "boolean"
           },
           "last_set_max_points": {
             "anyOf": [
@@ -2086,7 +2109,8 @@
           "last_set_max_points",
           "two_point_advantage",
           "position",
-          "side_switch_every_n_points"
+          "side_switch_every_n_points",
+          "draws_allowed"
         ],
         "title": "RankingMatchPointsBody",
         "type": "object"
@@ -2119,6 +2143,11 @@
       },
       "RankingSetPointsBody": {
         "properties": {
+          "draws_allowed": {
+            "default": true,
+            "title": "Draws Allowed",
+            "type": "boolean"
+          },
           "last_set_max_points": {
             "anyOf": [
               {
@@ -2193,13 +2222,19 @@
           "last_set_max_points",
           "two_point_advantage",
           "position",
-          "side_switch_every_n_points"
+          "side_switch_every_n_points",
+          "draws_allowed"
         ],
         "title": "RankingSetPointsBody",
         "type": "object"
       },
       "RankingSetPointsWithMatchBonusBody": {
         "properties": {
+          "draws_allowed": {
+            "default": true,
+            "title": "Draws Allowed",
+            "type": "boolean"
+          },
           "last_set_max_points": {
             "anyOf": [
               {
@@ -2288,7 +2323,8 @@
           "last_set_max_points",
           "two_point_advantage",
           "position",
-          "side_switch_every_n_points"
+          "side_switch_every_n_points",
+          "draws_allowed"
         ],
         "title": "RankingSetPointsWithMatchBonusBody",
         "type": "object"

--- a/backend/tests/integration_tests/api/match_set_verbs_test.py
+++ b/backend/tests/integration_tests/api/match_set_verbs_test.py
@@ -142,6 +142,131 @@ async def test_score_edit_and_end_complete_match(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_match_detail_response_carries_draws_allowed_from_ranking(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with _simple_match(auth_context) as match_inserted:
+        response = await send_tournament_request(
+            HTTPMethod.POST, f"matches/{match_inserted.id}/start", auth_context
+        )
+        assert response["data"]["draws_allowed"] is True
+
+    async with (
+        _draws_disallowed_ranking(auth_context),
+        _simple_match(auth_context) as match_inserted,
+    ):
+        response = await send_tournament_request(
+            HTTPMethod.POST, f"matches/{match_inserted.id}/start", auth_context
+        )
+        assert response["data"]["draws_allowed"] is False
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_end_rejected_at_equal_scores_when_draws_disallowed(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with (
+        _draws_disallowed_ranking(auth_context),
+        _simple_match(auth_context) as match_inserted,
+    ):
+        set_id = match_inserted.match_sets[0].id
+        await send_tournament_request(
+            HTTPMethod.POST, f"matches/{match_inserted.id}/start", auth_context
+        )
+        await send_tournament_request(
+            HTTPMethod.POST,
+            f"matches/{match_inserted.id}/sets/{set_id}/score-edit",
+            auth_context,
+            json={"stage_item_input1_score": 10, "stage_item_input2_score": 10},
+        )
+        response = await send_tournament_request(
+            HTTPMethod.POST, f"matches/{match_inserted.id}/end", auth_context
+        )
+        assert response == {"detail": "Cannot end: draws are not allowed for this ranking"}
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_editing_completed_set_to_equal_scores_rejected_when_draws_disallowed(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with (
+        _draws_disallowed_ranking(auth_context),
+        _simple_match(auth_context) as match_inserted,
+    ):
+        set_id = match_inserted.match_sets[0].id
+        await complete_match(auth_context, match_inserted.id, set_id, score1=21, score2=10)
+        response = await send_tournament_request(
+            HTTPMethod.POST,
+            f"matches/{match_inserted.id}/sets/{set_id}/score-edit",
+            auth_context,
+            json={"stage_item_input1_score": 15, "stage_item_input2_score": 15},
+        )
+        assert response == {"detail": "Cannot edit: draws are not allowed for this ranking"}
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_editing_in_progress_set_to_equal_scores_succeeds_when_draws_disallowed(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with (
+        _draws_disallowed_ranking(auth_context),
+        _simple_match(auth_context) as match_inserted,
+    ):
+        set_id = match_inserted.match_sets[0].id
+        await send_tournament_request(
+            HTTPMethod.POST, f"matches/{match_inserted.id}/start", auth_context
+        )
+        response = await send_tournament_request(
+            HTTPMethod.POST,
+            f"matches/{match_inserted.id}/sets/{set_id}/score-edit",
+            auth_context,
+            json={"stage_item_input1_score": 5, "stage_item_input2_score": 5},
+        )
+        assert response["data"]["match_sets"][0]["stage_item_input1_score"] == 5
+        assert response["data"]["match_sets"][0]["stage_item_input2_score"] == 5
+        assert response["data"]["match_sets"][0]["state"] == "IN_PROGRESS"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_end_at_equal_scores_still_succeeds_when_draws_allowed(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with _simple_match(auth_context) as match_inserted:
+        set_id = match_inserted.match_sets[0].id
+        await send_tournament_request(
+            HTTPMethod.POST, f"matches/{match_inserted.id}/start", auth_context
+        )
+        await send_tournament_request(
+            HTTPMethod.POST,
+            f"matches/{match_inserted.id}/sets/{set_id}/score-edit",
+            auth_context,
+            json={"stage_item_input1_score": 10, "stage_item_input2_score": 10},
+        )
+        response = await send_tournament_request(
+            HTTPMethod.POST, f"matches/{match_inserted.id}/end", auth_context
+        )
+        assert response["data"]["state"] == "COMPLETED"
+        assert response["data"]["match_sets"][0]["state"] == "COMPLETED"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_editing_completed_set_to_equal_scores_still_succeeds_when_draws_allowed(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    async with _simple_match(auth_context) as match_inserted:
+        set_id = match_inserted.match_sets[0].id
+        await complete_match(auth_context, match_inserted.id, set_id, score1=21, score2=10)
+        response = await send_tournament_request(
+            HTTPMethod.POST,
+            f"matches/{match_inserted.id}/sets/{set_id}/score-edit",
+            auth_context,
+            json={"stage_item_input1_score": 15, "stage_item_input2_score": 15},
+        )
+        assert response["data"]["match_sets"][0]["stage_item_input1_score"] == 15
+        assert response["data"]["match_sets"][0]["stage_item_input2_score"] == 15
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_reopen_clears_completed_at(
     startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
 ) -> None:
@@ -790,6 +915,21 @@ async def _best_of_three_ranking(auth_context: AuthContext) -> AsyncIterator[Non
     finally:
         await database.execute(
             query=rankings.update().where(rankings.c.id == ranking_id).values(num_sets=1),
+        )
+
+
+@asynccontextmanager
+async def _draws_disallowed_ranking(auth_context: AuthContext) -> AsyncIterator[None]:
+    """Temporarily configure the session-scoped ranking to disallow draws."""
+    ranking_id = auth_context.ranking.id
+    await database.execute(
+        query=rankings.update().where(rankings.c.id == ranking_id).values(draws_allowed=False),
+    )
+    try:
+        yield
+    finally:
+        await database.execute(
+            query=rankings.update().where(rankings.c.id == ranking_id).values(draws_allowed=True),
         )
 
 

--- a/backend/tests/integration_tests/api/rankings_test.py
+++ b/backend/tests/integration_tests/api/rankings_test.py
@@ -62,6 +62,7 @@ async def test_rankings_endpoint(
                     "max_points": 21,
                     "last_set_max_points": None,
                     "two_point_advantage": True,
+                    "draws_allowed": True,
                     "match_points": {
                         "win_points": "1.0",
                         "draw_points": "0.5",
@@ -335,6 +336,33 @@ async def test_update_ranking_side_switch(
             updated_rankings = await get_all_rankings_in_tournament(auth_context.tournament.id)
             updated = next(r for r in updated_rankings if r.id == ranking_inserted.id)
             assert updated.side_switch_every_n_points == 7
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_ranking_draws_allowed(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    body = {
+        "scoring_type": "MATCH_POINTS",
+        "win_points": "1.0",
+        "draw_points": "0.5",
+        "loss_points": "0.0",
+        "position": 0,
+        "draws_allowed": False,
+    }
+    async with inserted_team(
+        DUMMY_TEAM1.model_copy(update={"tournament_id": auth_context.tournament.id})
+    ):
+        async with inserted_ranking(
+            DUMMY_RANKING1.model_copy(update={"tournament_id": auth_context.tournament.id})
+        ) as ranking_inserted:
+            response = await send_tournament_request(
+                HTTPMethod.PUT, f"rankings/{ranking_inserted.id}", auth_context, json=body
+            )
+            assert response["success"] is True
+            updated_rankings = await get_all_rankings_in_tournament(auth_context.tournament.id)
+            updated = next(r for r in updated_rankings if r.id == ranking_inserted.id)
+            assert updated.draws_allowed is False
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/backend/tests/unit_tests/ranking_model_test.py
+++ b/backend/tests/unit_tests/ranking_model_test.py
@@ -133,6 +133,7 @@ def test_schema_rankings_has_new_columns() -> None:
     assert "max_points" in cols
     assert "last_set_max_points" in cols
     assert "two_point_advantage" in cols
+    assert "draws_allowed" in cols
     assert "win_points" not in cols
     assert "draw_points" not in cols
     assert "loss_points" not in cols
@@ -158,6 +159,23 @@ def test_migration_add_ranking_name_exists_and_chains_from_head() -> None:
     migration = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(migration)
     assert migration.down_revision == "b9d3e7f1a2c4"
+    assert callable(migration.upgrade)
+    assert callable(migration.downgrade)
+
+
+def test_migration_add_draws_allowed_exists_and_chains_from_head() -> None:
+    import importlib.util
+    from pathlib import Path
+
+    versions_dir = Path(__file__).parent.parent.parent / "alembic" / "versions"
+    files = list(versions_dir.glob("*add_draws_allowed_to_rankings*.py"))
+    assert files, "No add_draws_allowed_to_rankings migration file found"
+    path = files[0]
+    spec = importlib.util.spec_from_file_location("migration", path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    assert migration.down_revision == "d9f3b1a7c5e2"
     assert callable(migration.upgrade)
     assert callable(migration.downgrade)
 
@@ -246,3 +264,40 @@ def test_ranking_new_base_fields() -> None:
     assert ranking.two_point_advantage is True
     assert ranking.match_points is not None
     assert ranking.match_points.win_points == Decimal("1.0")
+
+
+def test_ranking_draws_allowed_defaults_to_true() -> None:
+    now = datetime_utc.now()
+    ranking = Ranking(
+        id=RankingId(1),
+        tournament_id=TournamentId(1),
+        created=now,
+        position=0,
+        scoring_type=ScoringType.MATCH_POINTS,
+    )
+    assert ranking.draws_allowed is True
+
+
+def test_ranking_draws_allowed_can_be_set_false() -> None:
+    now = datetime_utc.now()
+    ranking = Ranking(
+        id=RankingId(1),
+        tournament_id=TournamentId(1),
+        created=now,
+        position=0,
+        scoring_type=ScoringType.MATCH_POINTS,
+        draws_allowed=False,
+    )
+    assert ranking.draws_allowed is False
+
+
+def test_ranking_body_variants_default_draws_allowed_to_true() -> None:
+    from bracket.models.db.ranking import (
+        RankingMatchPointsBody,
+        RankingSetPointsBody,
+        RankingSetPointsWithMatchBonusBody,
+    )
+
+    assert RankingMatchPointsBody().draws_allowed is True
+    assert RankingSetPointsBody().draws_allowed is True
+    assert RankingSetPointsWithMatchBonusBody().draws_allowed is True

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -24,6 +24,7 @@
     "all_matches_radio_label": "Alle Spiele",
     "all_matches_scheduled_description": "Die Spiele wurden in dieser Runde auf allen Gerichten geplant. Füge eine neue Runde hinzu oder füge ein neues Gericht für weitere Spiele hinzu.",
     "all_matches_scheduled_title": "Alle Spiele geplant",
+    "allow_draws_label": "Unentschieden erlauben",
     "api_docs_title": "API Dokumentation",
     "apply_break_button": "Setzen",
     "archive_tournament_button": "Turnier archivieren",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -24,6 +24,7 @@
     "all_matches_radio_label": "All matches",
     "all_matches_scheduled_description": "Matches have been scheduled on all courts in this round. Add a new round or add a new court for more matches.",
     "all_matches_scheduled_title": "All scheduled",
+    "allow_draws_label": "Allow draws",
     "api_docs_title": "API docs",
     "apply_break_button": "Set",
     "archive_tournament_button": "Archive Tournament",

--- a/frontend/src/logic/score_tracking.test.ts
+++ b/frontend/src/logic/score_tracking.test.ts
@@ -157,6 +157,7 @@ describe('isEndSetDisabled', () => {
     max_points: 21,
     last_set_max_points: null as number | null,
     num_sets: 3,
+    draws_allowed: true,
   };
 
   it('is disabled when no score has reached the limit', () => {
@@ -244,6 +245,36 @@ describe('isEndSetDisabled', () => {
       stage_item_input2_score: 21,
     });
     expect(isEndSetDisabled(set, { ...baseMatch, two_point_advantage: true }, false)).toBe(true);
+  });
+
+  it('is disabled at a tied score when draws_allowed=false, even if the limit is reached', () => {
+    const set = makeSet({
+      set_number: 1,
+      state: 'IN_PROGRESS',
+      stage_item_input1_score: 21,
+      stage_item_input2_score: 21,
+    });
+    expect(isEndSetDisabled(set, { ...baseMatch, draws_allowed: false }, false)).toBe(true);
+  });
+
+  it('is enabled at a non-tied score reaching the limit when draws_allowed=false', () => {
+    const set = makeSet({
+      set_number: 1,
+      state: 'IN_PROGRESS',
+      stage_item_input1_score: 21,
+      stage_item_input2_score: 15,
+    });
+    expect(isEndSetDisabled(set, { ...baseMatch, draws_allowed: false }, false)).toBe(false);
+  });
+
+  it('respects isSwapped when checking the tie for draws_allowed=false', () => {
+    const set = makeSet({
+      set_number: 1,
+      state: 'IN_PROGRESS',
+      stage_item_input1_score: 21,
+      stage_item_input2_score: 21,
+    });
+    expect(isEndSetDisabled(set, { ...baseMatch, draws_allowed: false }, true)).toBe(true);
   });
 });
 

--- a/frontend/src/logic/score_tracking.ts
+++ b/frontend/src/logic/score_tracking.ts
@@ -81,10 +81,11 @@ export function isEndSetDisabled(
     max_points: number;
     last_set_max_points: number | null;
     num_sets: number;
+    draws_allowed: boolean;
   },
   isSwapped: boolean
 ): boolean {
-  const { two_point_advantage, max_points, last_set_max_points, num_sets } = match;
+  const { two_point_advantage, max_points, last_set_max_points, num_sets, draws_allowed } = match;
   const limit =
     set.set_number === num_sets && last_set_max_points != null ? last_set_max_points : max_points;
   const s1 = isSwapped ? set.stage_item_input2_score : set.stage_item_input1_score;
@@ -92,5 +93,6 @@ export function isEndSetDisabled(
   const maxScore = Math.max(s1, s2);
   if (maxScore < limit) return true;
   if (two_point_advantage && Math.abs(s1 - s2) < 2) return true;
+  if (!draws_allowed && s1 === s2) return true;
   return false;
 }

--- a/frontend/src/openapi/types.gen.ts
+++ b/frontend/src/openapi/types.gen.ts
@@ -521,6 +521,10 @@ export type MatchWithDetails = {
    */
   custom_duration_minutes: number | null;
   /**
+   * Draws Allowed
+   */
+  draws_allowed: boolean;
+  /**
    * Duration Minutes
    */
   duration_minutes: number;
@@ -636,6 +640,10 @@ export type MatchWithDetailsDefinitive = {
    * Custom Duration Minutes
    */
   custom_duration_minutes: number | null;
+  /**
+   * Draws Allowed
+   */
+  draws_allowed: boolean;
   /**
    * Duration Minutes
    */
@@ -925,6 +933,10 @@ export type Ranking = {
    */
   created: string;
   /**
+   * Draws Allowed
+   */
+  draws_allowed: boolean;
+  /**
    * Id
    */
   id: number;
@@ -977,6 +989,10 @@ export type RankingMatchPointsBody = {
    * Draw Points
    */
   draw_points: number | string;
+  /**
+   * Draws Allowed
+   */
+  draws_allowed: boolean;
   /**
    * Last Set Max Points
    */
@@ -1042,6 +1058,10 @@ export type RankingMatchPointsData = {
  */
 export type RankingSetPointsBody = {
   /**
+   * Draws Allowed
+   */
+  draws_allowed: boolean;
+  /**
    * Last Set Max Points
    */
   last_set_max_points: number | null;
@@ -1079,6 +1099,10 @@ export type RankingSetPointsBody = {
  * RankingSetPointsWithMatchBonusBody
  */
 export type RankingSetPointsWithMatchBonusBody = {
+  /**
+   * Draws Allowed
+   */
+  draws_allowed: boolean;
   /**
    * Last Set Max Points
    */
@@ -2516,6 +2540,10 @@ export type MatchWithDetailsWritable = {
    */
   custom_duration_minutes: number | null;
   /**
+   * Draws Allowed
+   */
+  draws_allowed: boolean;
+  /**
    * Duration Minutes
    */
   duration_minutes: number;
@@ -2630,6 +2658,10 @@ export type MatchWithDetailsDefinitiveWritable = {
    * Custom Duration Minutes
    */
   custom_duration_minutes: number | null;
+  /**
+   * Draws Allowed
+   */
+  draws_allowed: boolean;
   /**
    * Duration Minutes
    */

--- a/frontend/src/pages/tournaments/[id]/rankings.tsx
+++ b/frontend/src/pages/tournaments/[id]/rankings.tsx
@@ -91,6 +91,7 @@ function EditRankingForm({
       max_points: ranking.max_points,
       last_set_max_points: ranking.last_set_max_points ?? 15,
       two_point_advantage: ranking.two_point_advantage,
+      draws_allowed: ranking.draws_allowed,
       position: ranking.position,
       side_switch_enabled: ranking.side_switch_every_n_points != null,
       side_switch_every_n_points: ranking.side_switch_every_n_points ?? 7,
@@ -115,6 +116,7 @@ function EditRankingForm({
           values.max_points,
           values.num_sets > 2 ? values.last_set_max_points : null,
           values.two_point_advantage,
+          values.draws_allowed,
           values.name,
           values.win_points,
           values.draw_points,
@@ -208,6 +210,11 @@ function EditRankingForm({
             mt="lg"
             label={t('two_point_advantage_label')}
             {...form.getInputProps('two_point_advantage', { type: 'checkbox' })}
+          />
+          <Checkbox
+            mt="lg"
+            label={t('allow_draws_label')}
+            {...form.getInputProps('draws_allowed', { type: 'checkbox' })}
           />
           {form.values.num_sets > 2 && (
             <NumberInput

--- a/frontend/src/services/ranking.tsx
+++ b/frontend/src/services/ranking.tsx
@@ -25,6 +25,7 @@ export async function editRanking(
   max_points: number,
   last_set_max_points: number | null,
   two_point_advantage: boolean,
+  draws_allowed: boolean,
   name: string,
   win_points?: string,
   draw_points?: string,
@@ -40,6 +41,7 @@ export async function editRanking(
     max_points,
     last_set_max_points,
     two_point_advantage,
+    draws_allowed,
   };
   if (scoring_type === 'MATCH_POINTS') {
     body.win_points = win_points;


### PR DESCRIPTION
Rankings gain a non-null draws_allowed boolean (default true, migrated
true for existing rows). When false, ending the in-progress set at equal
scores or editing a completed set to equal scores is rejected server-side
following the existing illegal-transition 400 pattern; the in-progress
set itself stays free to be tied mid-play. The flag is copied onto match
detail responses, exposed in the ranking form, and disables the end-set
button in score tracking when scores are tied.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RvRBtsrxp3fWYrkbFfAzzE