### PR TITLE
Best-of-n mode: auto-complete a match at a set-win majority (#267)

### DIFF
--- a/backend/alembic/versions/e4f7a2c9d1b3_add_play_all_sets_to_rankings.py
+++ b/backend/alembic/versions/e4f7a2c9d1b3_add_play_all_sets_to_rankings.py
@@ -1,0 +1,29 @@
+"""add play_all_sets to rankings
+
+Revision ID: e4f7a2c9d1b3
+Revises: b6e3f9a2c7d5
+Create Date: 2026-07-09 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str | None = "e4f7a2c9d1b3"
+down_revision: str | None = "b6e3f9a2c7d5"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # Behaviour-preserving: every existing ranking keeps playing out all sets.
+    op.add_column(
+        "rankings",
+        sa.Column("play_all_sets", sa.Boolean(), server_default="true", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("rankings", "play_all_sets")

--- a/backend/bracket/logic/match_sets/apply_update.py
+++ b/backend/bracket/logic/match_sets/apply_update.py
@@ -27,6 +27,7 @@ from bracket.sql.match_sets import get_sets_for_match, sql_score_edit_match_set
 from bracket.sql.matches import (
     sql_end_match,
     sql_get_match_with_details,
+    sql_get_play_all_sets_for_match,
     sql_reopen_match,
     sql_reset_match,
     sql_set_match_completed_at,
@@ -69,7 +70,8 @@ async def recalculate_after_match_change(
 
 async def derive_match_state_after_change(tournament_id: TournamentId, match: Match) -> MatchState:
     sets = await get_sets_for_match(match.id)
-    return derive_match_state(sets)
+    play_all_sets = await sql_get_play_all_sets_for_match(match.id)
+    return derive_match_state(sets, play_all_sets=play_all_sets)
 
 
 async def apply_match_change_and_recalculate(

--- a/backend/bracket/logic/match_sets/pointer.py
+++ b/backend/bracket/logic/match_sets/pointer.py
@@ -6,22 +6,32 @@ class IllegalMatchTransitionError(ValueError):
 
 
 def derive_match_state_from_pointer(
-    completed_set_count: int, num_sets: int, current_set_in_progress: bool
+    completed_set_count: int,
+    num_sets: int,
+    current_set_in_progress: bool,
+    *,
+    match_decided: bool = False,
 ) -> MatchState:
     if completed_set_count == 0 and not current_set_in_progress:
         return MatchState.NOT_STARTED
-    if completed_set_count >= num_sets:
+    if not current_set_in_progress and (completed_set_count >= num_sets or match_decided):
         return MatchState.COMPLETED
     return MatchState.IN_PROGRESS
 
 
 def apply_start(
-    completed_set_count: int, current_set_in_progress: bool, num_sets: int
+    completed_set_count: int,
+    current_set_in_progress: bool,
+    num_sets: int,
+    *,
+    match_decided: bool = False,
 ) -> tuple[int, bool]:
     if current_set_in_progress:
         raise IllegalMatchTransitionError("Cannot start: a set is already in progress")
     if completed_set_count >= num_sets:
         raise IllegalMatchTransitionError("Cannot start: all sets are already completed")
+    if match_decided:
+        raise IllegalMatchTransitionError("Cannot start: the match is already decided")
     return completed_set_count, True
 
 

--- a/backend/bracket/logic/ranking/elimination.py
+++ b/backend/bracket/logic/ranking/elimination.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from bracket.logic.apply_plan import apply_plan
 from bracket.logic.plan import PlanItem, SetMatchInputs
-from bracket.models.db.match import Match, MatchState, derive_match_state
+from bracket.models.db.match import Match, MatchState
 from bracket.models.db.stage_item_inputs import StageItemInput
 from bracket.models.db.util import StageItemWithRounds
 from bracket.utils.id_types import (
@@ -78,7 +78,7 @@ def get_inputs_to_update_in_subsequent_elimination_rounds(
 
     for subsequent_round in subsequent_rounds:
         for subsequent_match in subsequent_round.matches:
-            if derive_match_state(subsequent_match.match_sets) is not MatchState.NOT_STARTED:
+            if subsequent_match.state is not MatchState.NOT_STARTED:
                 # This follower has already started: it must never be touched by a cascade, and
                 # since it never changes, nothing it feeds further downstream changes either.
                 continue
@@ -118,10 +118,7 @@ def get_inputs_to_update_in_subsequent_elimination_rounds(
                     updated.stage_item_input2_winner_from_match_id is not None
                     and updated.stage_item_input2_id is None
                 )
-                if (
-                    derive_match_state(updated.match_sets) is not MatchState.COMPLETED
-                    or has_unresolved_inputs
-                ):
+                if updated.state is not MatchState.COMPLETED or has_unresolved_inputs:
                     cleared_match_ids.add(subsequent_match.id)
 
     return {
@@ -160,7 +157,7 @@ def get_started_elimination_followers(
             if follower.id in seen:
                 continue
             seen.add(follower.id)
-            if derive_match_state(follower.match_sets) is not MatchState.NOT_STARTED:
+            if follower.state is not MatchState.NOT_STARTED:
                 started.append(follower)
             else:
                 frontier.append(follower.id)

--- a/backend/bracket/models/db/match.py
+++ b/backend/bracket/models/db/match.py
@@ -41,21 +41,44 @@ class MatchSet(BaseModelORM):
     state: MatchSetState
 
 
-def derive_match_state(sets: list["MatchSet"]) -> MatchState:
-    """Derive a match's overall state from the states of its sets.
+def count_set_wins(sets: list["MatchSet"]) -> tuple[int, int]:
+    """Count completed-set wins per side; drawn sets count toward neither."""
+    completed = [s for s in sets if s.state is MatchSetState.COMPLETED]
+    wins1 = sum(1 for s in completed if s.stage_item_input1_score > s.stage_item_input2_score)
+    wins2 = sum(1 for s in completed if s.stage_item_input2_score > s.stage_item_input1_score)
+    return wins1, wins2
+
+
+def is_match_decided(sets: list["MatchSet"], play_all_sets: bool) -> bool:
+    """Whether one side holds a best-of-n majority of set wins.
+
+    Best-of-n mode is active only when ``play_all_sets`` is off and the match has more than
+    one set; the majority target counts the total pre-created set rows as ``num_sets``.
+    """
+    if play_all_sets or len(sets) <= 1:
+        return False
+    majority = len(sets) // 2 + 1
+    return max(count_set_wins(sets)) >= majority
+
+
+def derive_match_state(sets: list["MatchSet"], *, play_all_sets: bool = True) -> MatchState:
+    """Derive a match's overall state from the states (and scores) of its sets.
 
     Set states are derived positionally from the match progress pointer at read time,
     so this reflects the pointer invariant: a contiguous COMPLETED prefix, at most one
     IN_PROGRESS set, then NOT_STARTED.
 
     - all sets NOT_STARTED (or no sets) -> NOT_STARTED
-    - all sets COMPLETED -> COMPLETED
-    - anything else (any IN_PROGRESS, or a mix of COMPLETED and NOT_STARTED) -> IN_PROGRESS
+    - no set IN_PROGRESS and (all sets COMPLETED, or one side holds a best-of-n
+      majority of set wins) -> COMPLETED
+    - anything else -> IN_PROGRESS
     """
     states = {match_set.state for match_set in sets}
     if not states or states == {MatchSetState.NOT_STARTED}:
         return MatchState.NOT_STARTED
     if states == {MatchSetState.COMPLETED}:
+        return MatchState.COMPLETED
+    if MatchSetState.IN_PROGRESS not in states and is_match_decided(sets, play_all_sets):
         return MatchState.COMPLETED
     return MatchState.IN_PROGRESS
 
@@ -94,6 +117,9 @@ class Match(MatchInsertable):
     stage_item_input1: StageItemInput | None = None
     stage_item_input2: StageItemInput | None = None
     match_sets: list[MatchSet] = []
+    # Copied from the ranking applicable to this match's stage item wherever the match is
+    # hydrated with details; the default preserves play-out-all-sets behaviour elsewhere.
+    play_all_sets: bool = True
 
     @field_validator("match_sets", mode="before")
     @staticmethod
@@ -107,7 +133,7 @@ class Match(MatchInsertable):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def state(self) -> MatchState:
-        return derive_match_state(self.match_sets)
+        return derive_match_state(self.match_sets, play_all_sets=self.play_all_sets)
 
     @property
     def completed_sets(self) -> list["MatchSet"]:
@@ -126,7 +152,7 @@ class Match(MatchInsertable):
         )
 
     def get_winner(self) -> StageItemInput | None:
-        if derive_match_state(self.match_sets) is not MatchState.COMPLETED:
+        if self.state is not MatchState.COMPLETED:
             return None
 
         sets1 = self.sets_won_by_input1

--- a/backend/bracket/models/db/ranking.py
+++ b/backend/bracket/models/db/ranking.py
@@ -36,6 +36,7 @@ class RankingBase(BaseModel):
     max_points: int = 21
     last_set_max_points: int | None = None
     two_point_advantage: bool = True
+    play_all_sets: bool = True
     side_switch_every_n_points: int | None = None
     draws_allowed: bool = True
 
@@ -65,6 +66,9 @@ class RankingMatchPointsBody(BaseModel):
     max_points: int = 21
     last_set_max_points: int | None = None
     two_point_advantage: bool = True
+    # Best-of behaviour by default: only the points of the whole match count here, so there
+    # is no reason to play out dead rubbers.
+    play_all_sets: bool = False
     position: int | None = None
     side_switch_every_n_points: int | None = None
     draws_allowed: bool = True
@@ -77,6 +81,8 @@ class RankingSetPointsBody(BaseModel):
     max_points: int = 21
     last_set_max_points: int | None = None
     two_point_advantage: bool = True
+    # Every set's points count toward standings, so play them all by default.
+    play_all_sets: bool = True
     position: int | None = None
     side_switch_every_n_points: int | None = None
     draws_allowed: bool = True
@@ -90,6 +96,8 @@ class RankingSetPointsWithMatchBonusBody(BaseModel):
     max_points: int = 21
     last_set_max_points: int | None = None
     two_point_advantage: bool = True
+    # The match bonus dominates, so best-of behaviour is the expected default.
+    play_all_sets: bool = False
     position: int | None = None
     side_switch_every_n_points: int | None = None
     draws_allowed: bool = True

--- a/backend/bracket/schema.py
+++ b/backend/bracket/schema.py
@@ -315,6 +315,7 @@ rankings = Table(
     Column("max_points", Integer, nullable=False, server_default="21"),
     Column("last_set_max_points", Integer, nullable=True),
     Column("two_point_advantage", Boolean, nullable=False, server_default="true"),
+    Column("play_all_sets", Boolean, nullable=False, server_default="true"),
     Column("level_id", BigInteger, ForeignKey("levels.id"), nullable=True),
     Column("side_switch_every_n_points", Integer, nullable=True),
     Column("draws_allowed", Boolean, nullable=False, server_default="true"),

--- a/backend/bracket/sql/matches.py
+++ b/backend/bracket/sql/matches.py
@@ -9,7 +9,13 @@ from bracket.logic.match_sets.pointer import (
     apply_reset,
     apply_start,
 )
-from bracket.models.db.match import Match, MatchBody, MatchCreateBody, MatchWithDetails
+from bracket.models.db.match import (
+    Match,
+    MatchBody,
+    MatchCreateBody,
+    MatchWithDetails,
+    is_match_decided,
+)
 from bracket.models.db.tournament import Tournament
 from bracket.sql.match_sets import MATCH_SETS_SUBQUERY, sql_create_match_sets
 from bracket.utils.id_types import (
@@ -46,6 +52,25 @@ async def sql_delete_matches_for_stage_item_id(stage_item_id: StageItemId) -> No
         )
         """
     await database.execute(query=query, values={"stage_item_id": stage_item_id})
+
+
+async def sql_get_play_all_sets_for_match(match_id: MatchId) -> bool:
+    """Return the "play out all sets" flag of the ranking applicable to a match.
+
+    Falls back to True (play out all sets) when no ranking is found.
+    """
+    query = """
+        SELECT rankings.play_all_sets
+        FROM matches
+        JOIN rounds ON rounds.id = matches.round_id
+        JOIN stage_items ON stage_items.id = rounds.stage_item_id
+        JOIN rankings ON rankings.id = stage_items.ranking_id
+        WHERE matches.id = :match_id
+        """
+    result = await database.fetch_one(query=query, values={"match_id": match_id})
+    if result is None:
+        return True
+    return bool(result._mapping["play_all_sets"])
 
 
 async def sql_get_num_sets_for_round(round_id: RoundId) -> int:
@@ -279,6 +304,7 @@ MATCH_DETAILS_COLUMNS = f"""
     rankings.max_points AS max_points,
     rankings.last_set_max_points AS last_set_max_points,
     rankings.two_point_advantage AS two_point_advantage,
+    rankings.play_all_sets AS play_all_sets,
     rankings.draws_allowed AS draws_allowed,
     {MATCH_SETS_SUBQUERY}
 """
@@ -386,6 +412,19 @@ async def _lock_match_pointer(match_id: MatchId) -> tuple[int, bool, int]:
     )
 
 
+async def _is_match_decided(match_id: MatchId) -> bool:
+    """Whether one side already holds a best-of-n majority of this match's set wins.
+
+    Callers must hold the match pointer lock so the set states this reads are stable.
+    """
+    from bracket.sql.match_sets import get_sets_for_match
+
+    play_all_sets = await sql_get_play_all_sets_for_match(match_id)
+    if play_all_sets:
+        return False
+    return is_match_decided(await get_sets_for_match(match_id), play_all_sets)
+
+
 async def _update_match_pointer(
     match_id: MatchId, completed_set_count: int, current_set_in_progress: bool
 ) -> None:
@@ -406,7 +445,10 @@ async def _update_match_pointer(
 
 async def sql_start_match(match_id: MatchId) -> None:
     completed, in_progress, num_sets = await _lock_match_pointer(match_id)
-    new_completed, new_in_progress = apply_start(completed, in_progress, num_sets)
+    match_decided = await _is_match_decided(match_id)
+    new_completed, new_in_progress = apply_start(
+        completed, in_progress, num_sets, match_decided=match_decided
+    )
     await _update_match_pointer(match_id, new_completed, new_in_progress)
 
 

--- a/backend/bracket/sql/rankings.py
+++ b/backend/bracket/sql/rankings.py
@@ -54,6 +54,7 @@ def _row_to_ranking(row: Record) -> Ranking:
         max_points=m["max_points"],
         last_set_max_points=m.get("last_set_max_points"),
         two_point_advantage=m["two_point_advantage"],
+        play_all_sets=m["play_all_sets"],
         draws_allowed=m["draws_allowed"],
         level_id=m.get("level_id"),
         side_switch_every_n_points=m.get("side_switch_every_n_points"),
@@ -177,6 +178,7 @@ async def sql_update_ranking(
                 max_points = :max_points,
                 last_set_max_points = :last_set_max_points,
                 two_point_advantage = :two_point_advantage,
+                play_all_sets = :play_all_sets,
                 side_switch_every_n_points = :side_switch_every_n_points,
                 draws_allowed = :draws_allowed
             WHERE rankings.tournament_id = :tournament_id
@@ -192,6 +194,7 @@ async def sql_update_ranking(
             "max_points": ranking_body.max_points,
             "last_set_max_points": ranking_body.last_set_max_points,
             "two_point_advantage": ranking_body.two_point_advantage,
+            "play_all_sets": ranking_body.play_all_sets,
             "side_switch_every_n_points": ranking_body.side_switch_every_n_points,
             "draws_allowed": ranking_body.draws_allowed,
         },
@@ -247,12 +250,13 @@ async def sql_create_ranking(
         query="""
             INSERT INTO rankings
             (tournament_id, position, name, scoring_type, num_sets, max_points,
-             last_set_max_points, two_point_advantage, level_id, side_switch_every_n_points,
-             draws_allowed)
+             last_set_max_points, two_point_advantage, play_all_sets, level_id,
+             side_switch_every_n_points, draws_allowed)
             VALUES (
                 :tournament_id, :position, :name, :scoring_type, :num_sets, :max_points,
-                :last_set_max_points, :two_point_advantage, :level_id, :side_switch_every_n_points,
-                :draws_allowed
+                :last_set_max_points, :two_point_advantage, :play_all_sets, :level_id,
+                :side_switch_every_n_points, :draws_allowed
+
             )
             RETURNING id
         """,
@@ -265,6 +269,7 @@ async def sql_create_ranking(
             "max_points": ranking_body.max_points,
             "last_set_max_points": ranking_body.last_set_max_points,
             "two_point_advantage": ranking_body.two_point_advantage,
+            "play_all_sets": ranking_body.play_all_sets,
             "level_id": level_id,
             "side_switch_every_n_points": ranking_body.side_switch_every_n_points,
             "draws_allowed": ranking_body.draws_allowed,

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -488,6 +488,11 @@
             "title": "Match Sets",
             "type": "array"
           },
+          "play_all_sets": {
+            "default": true,
+            "title": "Play All Sets",
+            "type": "boolean"
+          },
           "referee_name": {
             "anyOf": [
               {
@@ -641,6 +646,7 @@
           "stage_item_input1",
           "stage_item_input2",
           "match_sets",
+          "play_all_sets",
           "state"
         ],
         "title": "Match",
@@ -1056,6 +1062,11 @@
             "title": "Num Sets",
             "type": "integer"
           },
+          "play_all_sets": {
+            "default": true,
+            "title": "Play All Sets",
+            "type": "boolean"
+          },
           "referee": {
             "anyOf": [
               {
@@ -1242,6 +1253,7 @@
           "stage_item_input1",
           "stage_item_input2",
           "match_sets",
+          "play_all_sets",
           "court",
           "referee",
           "level_id",
@@ -1382,6 +1394,11 @@
             "title": "Num Sets",
             "type": "integer"
           },
+          "play_all_sets": {
+            "default": true,
+            "title": "Play All Sets",
+            "type": "boolean"
+          },
           "referee": {
             "anyOf": [
               {
@@ -1562,6 +1579,7 @@
           "stage_item_input1",
           "stage_item_input2",
           "match_sets",
+          "play_all_sets",
           "level_id",
           "court",
           "referee",
@@ -1927,6 +1945,11 @@
             "title": "Num Sets",
             "type": "integer"
           },
+          "play_all_sets": {
+            "default": true,
+            "title": "Play All Sets",
+            "type": "boolean"
+          },
           "position": {
             "title": "Position",
             "type": "integer"
@@ -1976,6 +1999,7 @@
           "max_points",
           "last_set_max_points",
           "two_point_advantage",
+          "play_all_sets",
           "side_switch_every_n_points",
           "draws_allowed",
           "id",
@@ -2051,6 +2075,11 @@
             "title": "Num Sets",
             "type": "integer"
           },
+          "play_all_sets": {
+            "default": false,
+            "title": "Play All Sets",
+            "type": "boolean"
+          },
           "position": {
             "anyOf": [
               {
@@ -2108,6 +2137,7 @@
           "max_points",
           "last_set_max_points",
           "two_point_advantage",
+          "play_all_sets",
           "position",
           "side_switch_every_n_points",
           "draws_allowed"
@@ -2180,6 +2210,11 @@
             "title": "Num Sets",
             "type": "integer"
           },
+          "play_all_sets": {
+            "default": true,
+            "title": "Play All Sets",
+            "type": "boolean"
+          },
           "position": {
             "anyOf": [
               {
@@ -2221,6 +2256,7 @@
           "max_points",
           "last_set_max_points",
           "two_point_advantage",
+          "play_all_sets",
           "position",
           "side_switch_every_n_points",
           "draws_allowed"
@@ -2280,6 +2316,11 @@
             "title": "Num Sets",
             "type": "integer"
           },
+          "play_all_sets": {
+            "default": false,
+            "title": "Play All Sets",
+            "type": "boolean"
+          },
           "position": {
             "anyOf": [
               {
@@ -2322,6 +2363,7 @@
           "max_points",
           "last_set_max_points",
           "two_point_advantage",
+          "play_all_sets",
           "position",
           "side_switch_every_n_points",
           "draws_allowed"

--- a/backend/tests/integration_tests/api/match_set_verbs_test.py
+++ b/backend/tests/integration_tests/api/match_set_verbs_test.py
@@ -13,6 +13,7 @@ from bracket.models.db.stage_item_inputs import (
     StageItemInputCreateBodyFinal,
     StageItemInputInsertable,
 )
+from bracket.models.db.util import StageItemWithRounds
 from bracket.schema import rankings, tournaments
 from bracket.sql.shared import sql_delete_stage_item_with_foreign_keys
 from bracket.sql.stage_items import sql_create_stage_item_with_inputs
@@ -29,7 +30,7 @@ from bracket.utils.dummy_records import (
     DUMMY_TEAM4,
 )
 from bracket.utils.http import HTTPMethod
-from bracket.utils.id_types import MatchId
+from bracket.utils.id_types import MatchId, StageItemId, TournamentId
 from tests.integration_tests.api.shared import (
     complete_match,
     send_request,
@@ -903,18 +904,219 @@ async def test_score_edit_collapses_best_of_three_to_fewer_played_sets(
             await sql_delete_stage_item_with_foreign_keys(stage_item.id)
 
 
+@pytest.mark.asyncio(loop_scope="session")
+async def test_best_of_n_completes_match_at_set_majority(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """In a Bo3 with "play out all sets" off, winning two sets ends the match on the spot:
+    no dead rubber is started, ``completed_at`` is stamped, and the winner advances into the
+    elimination final through the ordinary reconciliation path."""
+    tournament_id = auth_context.tournament.id
+    async with (
+        _best_of_three_ranking(auth_context, play_all_sets=False),
+        _four_team_elimination(auth_context) as stage_item_id,
+    ):
+        bracket = await _get_stage_item_details(tournament_id, stage_item_id)
+        semi = bracket.rounds[0].matches[0]
+        winner_input_id = semi.stage_item_input1_id
+        assert len(semi.match_sets) == 3
+
+        first = await complete_match(
+            auth_context, semi.id, semi.match_sets[0].id, score1=21, score2=15
+        )
+        assert first["data"]["state"] == "IN_PROGRESS"
+        assert first["data"]["completed_at"] is None
+
+        decided = await complete_match(
+            auth_context, semi.id, semi.match_sets[1].id, score1=21, score2=10
+        )
+        assert decided["data"]["state"] == "COMPLETED"
+        assert decided["data"]["completed_at"] is not None
+        assert decided["data"]["play_all_sets"] is False
+        assert decided["data"]["match_sets"][2]["state"] == "NOT_STARTED"
+
+        bracket = await _get_stage_item_details(tournament_id, stage_item_id)
+        final = bracket.rounds[1].matches[0]
+        assert final.stage_item_input1_id == winner_input_id
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_best_of_n_start_rejected_on_decided_match(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    tournament_id = auth_context.tournament.id
+    async with (
+        _best_of_three_ranking(auth_context, play_all_sets=False),
+        _four_team_elimination(auth_context) as stage_item_id,
+    ):
+        bracket = await _get_stage_item_details(tournament_id, stage_item_id)
+        semi = bracket.rounds[0].matches[0]
+        await complete_match(auth_context, semi.id, semi.match_sets[0].id, score1=21, score2=15)
+        await complete_match(auth_context, semi.id, semi.match_sets[1].id, score1=21, score2=10)
+
+        response = await send_tournament_request(
+            HTTPMethod.POST, f"matches/{semi.id}/start", auth_context
+        )
+        assert response == {"detail": "Cannot start: the match is already decided"}
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_best_of_n_reopen_regresses_early_ended_match(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Reopening the decisive set of an early-ended match puts it back in progress with the
+    remaining set startable again."""
+    tournament_id = auth_context.tournament.id
+    async with (
+        _best_of_three_ranking(auth_context, play_all_sets=False),
+        _four_team_elimination(auth_context) as stage_item_id,
+    ):
+        bracket = await _get_stage_item_details(tournament_id, stage_item_id)
+        semi = bracket.rounds[0].matches[0]
+        await complete_match(auth_context, semi.id, semi.match_sets[0].id, score1=21, score2=15)
+        await complete_match(auth_context, semi.id, semi.match_sets[1].id, score1=21, score2=10)
+
+        reopened = await send_tournament_request(
+            HTTPMethod.POST, f"matches/{semi.id}/reopen", auth_context
+        )
+        assert reopened["data"]["state"] == "IN_PROGRESS"
+        assert reopened["data"]["completed_at"] is None
+        assert reopened["data"]["match_sets"][1]["state"] == "IN_PROGRESS"
+
+        # Flip the reopened set so the match stands 1-1 after ending it: the third set
+        # must be startable again.
+        await send_tournament_request(
+            HTTPMethod.POST,
+            f"matches/{semi.id}/sets/{semi.match_sets[1].id}/score-edit",
+            auth_context,
+            json={"stage_item_input1_score": 10, "stage_item_input2_score": 21},
+        )
+        levelled = await send_tournament_request(
+            HTTPMethod.POST, f"matches/{semi.id}/end", auth_context
+        )
+        assert levelled["data"]["state"] == "IN_PROGRESS"
+
+        third_started = await send_tournament_request(
+            HTTPMethod.POST, f"matches/{semi.id}/start", auth_context
+        )
+        assert third_started["data"]["match_sets"][2]["state"] == "IN_PROGRESS"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_best_of_n_score_edit_undecides_early_ended_match(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Editing a set score so the majority evaporates regresses the early-ended match to
+    in-progress via derivation; no set rows are deleted."""
+    tournament_id = auth_context.tournament.id
+    async with (
+        _best_of_three_ranking(auth_context, play_all_sets=False),
+        _four_team_elimination(auth_context) as stage_item_id,
+    ):
+        bracket = await _get_stage_item_details(tournament_id, stage_item_id)
+        semi = bracket.rounds[0].matches[0]
+        await complete_match(auth_context, semi.id, semi.match_sets[0].id, score1=21, score2=15)
+        await complete_match(auth_context, semi.id, semi.match_sets[1].id, score1=21, score2=10)
+
+        undecided = await send_tournament_request(
+            HTTPMethod.POST,
+            f"matches/{semi.id}/sets/{semi.match_sets[1].id}/score-edit",
+            auth_context,
+            json={"stage_item_input1_score": 10, "stage_item_input2_score": 10},
+        )
+        assert undecided["data"]["state"] == "IN_PROGRESS"
+        assert undecided["data"]["completed_at"] is None
+        assert len(undecided["data"]["match_sets"]) == 3
+        assert undecided["data"]["match_sets"][2]["state"] == "NOT_STARTED"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_best_of_n_surplus_completed_sets_keep_counting(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """A history-rewriting edit that makes the match "really" decided after two sets leaves the
+    surplus third set recorded and counting toward set statistics; the winner is unaffected."""
+    tournament_id = auth_context.tournament.id
+    async with (
+        _best_of_three_ranking(auth_context, play_all_sets=False),
+        _four_team_elimination(auth_context) as stage_item_id,
+    ):
+        bracket = await _get_stage_item_details(tournament_id, stage_item_id)
+        semi = bracket.rounds[0].matches[0]
+        winner_input_id = semi.stage_item_input1_id
+
+        # A full three-setter: input1 wins sets 1 and 3, input2 wins set 2.
+        await complete_match(auth_context, semi.id, semi.match_sets[0].id, score1=21, score2=15)
+        await complete_match(auth_context, semi.id, semi.match_sets[1].id, score1=10, score2=21)
+        await complete_match(auth_context, semi.id, semi.match_sets[2].id, score1=21, score2=10)
+
+        # Correction: input1 actually won set 2 as well, so the match was decided after two
+        # sets and set 3 is surplus history.
+        edited = await send_tournament_request(
+            HTTPMethod.POST,
+            f"matches/{semi.id}/sets/{semi.match_sets[1].id}/score-edit",
+            auth_context,
+            json={"stage_item_input1_score": 21, "stage_item_input2_score": 19},
+        )
+        assert edited["data"]["state"] == "COMPLETED"
+        assert edited["data"]["completed_at"] is not None
+        assert len(edited["data"]["match_sets"]) == 3
+        assert all(s["state"] == "COMPLETED" for s in edited["data"]["match_sets"])
+
+        # The surplus set still counts toward set statistics: the winner is 3-0 up in sets.
+        bracket = await _get_stage_item_details(tournament_id, stage_item_id)
+        winner_input = next(i for i in bracket.inputs if i.id == winner_input_id)
+        assert winner_input.set_difference == 3
+
+        final = bracket.rounds[1].matches[0]
+        assert final.stage_item_input1_id == winner_input_id
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_play_all_sets_on_still_requires_every_set(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """With "play out all sets" on (the pre-existing behaviour), a 2-0 lead in a Bo3 does not
+    complete the match; the third set must be played."""
+    tournament_id = auth_context.tournament.id
+    async with (
+        _best_of_three_ranking(auth_context, play_all_sets=True),
+        _four_team_elimination(auth_context) as stage_item_id,
+    ):
+        bracket = await _get_stage_item_details(tournament_id, stage_item_id)
+        semi = bracket.rounds[0].matches[0]
+        await complete_match(auth_context, semi.id, semi.match_sets[0].id, score1=21, score2=15)
+        two_up = await complete_match(
+            auth_context, semi.id, semi.match_sets[1].id, score1=21, score2=10
+        )
+        assert two_up["data"]["state"] == "IN_PROGRESS"
+        assert two_up["data"]["completed_at"] is None
+        assert two_up["data"]["play_all_sets"] is True
+
+        third = await complete_match(
+            auth_context, semi.id, semi.match_sets[2].id, score1=21, score2=10
+        )
+        assert third["data"]["state"] == "COMPLETED"
+
+
 @asynccontextmanager
-async def _best_of_three_ranking(auth_context: AuthContext) -> AsyncIterator[None]:
+async def _best_of_three_ranking(
+    auth_context: AuthContext, *, play_all_sets: bool = True
+) -> AsyncIterator[None]:
     """Temporarily configure the session-scoped ranking as best-of-3."""
     ranking_id = auth_context.ranking.id
     await database.execute(
-        query=rankings.update().where(rankings.c.id == ranking_id).values(num_sets=3),
+        query=rankings.update()
+        .where(rankings.c.id == ranking_id)
+        .values(num_sets=3, play_all_sets=play_all_sets),
     )
     try:
         yield
     finally:
         await database.execute(
-            query=rankings.update().where(rankings.c.id == ranking_id).values(num_sets=1),
+            query=rankings.update()
+            .where(rankings.c.id == ranking_id)
+            .values(num_sets=1, play_all_sets=True),
         )
 
 
@@ -931,6 +1133,47 @@ async def _draws_disallowed_ranking(auth_context: AuthContext) -> AsyncIterator[
         await database.execute(
             query=rankings.update().where(rankings.c.id == ranking_id).values(draws_allowed=True),
         )
+
+
+@asynccontextmanager
+async def _four_team_elimination(auth_context: AuthContext) -> AsyncIterator[StageItemId]:
+    """A 4-team single elimination stage item (two semis feeding a final), built and torn down."""
+    tournament_id = auth_context.tournament.id
+    async with (
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as t1,
+        inserted_team(DUMMY_TEAM2.model_copy(update={"tournament_id": tournament_id})) as t2,
+        inserted_team(DUMMY_TEAM3.model_copy(update={"tournament_id": tournament_id})) as t3,
+        inserted_team(DUMMY_TEAM4.model_copy(update={"tournament_id": tournament_id})) as t4,
+        inserted_stage(DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})) as stage,
+    ):
+        stage_item = await sql_create_stage_item_with_inputs(
+            tournament_id,
+            StageItemWithInputsCreate(
+                stage_id=stage.id,
+                name="Elimination",
+                team_count=4,
+                type=StageType.SINGLE_ELIMINATION,
+                ranking_id=auth_context.ranking.id,
+                inputs=[
+                    StageItemInputCreateBodyFinal(slot=1, team_id=t1.id),
+                    StageItemInputCreateBodyFinal(slot=2, team_id=t2.id),
+                    StageItemInputCreateBodyFinal(slot=3, team_id=t3.id),
+                    StageItemInputCreateBodyFinal(slot=4, team_id=t4.id),
+                ],
+            ),
+        )
+        await build_matches_for_stage_item(stage_item, tournament_id)
+        try:
+            yield stage_item.id
+        finally:
+            await sql_delete_stage_item_with_foreign_keys(stage_item.id)
+
+
+async def _get_stage_item_details(
+    tournament_id: TournamentId, stage_item_id: StageItemId
+) -> StageItemWithRounds:
+    details = await get_full_tournament_details(tournament_id)
+    return next(si for s in details for si in s.stage_items if si.id == stage_item_id)
 
 
 @asynccontextmanager

--- a/backend/tests/integration_tests/api/match_sets_test.py
+++ b/backend/tests/integration_tests/api/match_sets_test.py
@@ -86,7 +86,7 @@ async def test_multi_set_play_flow(
                 HTTPMethod.PUT,
                 f"rankings/{ranking_id}?force=true",
                 auth_context,
-                json=RankingMatchPointsBody(num_sets=3).model_dump(mode="json"),
+                json=RankingMatchPointsBody(num_sets=3, play_all_sets=True).model_dump(mode="json"),
             )
 
             # Re-fetch the match via a no-op score edit to see the resized set list.
@@ -129,7 +129,7 @@ async def test_multi_set_play_flow(
                 HTTPMethod.PUT,
                 f"rankings/{ranking_id}?force=true",
                 auth_context,
-                json=RankingMatchPointsBody(num_sets=1).model_dump(mode="json"),
+                json=RankingMatchPointsBody(num_sets=1, play_all_sets=True).model_dump(mode="json"),
             )
 
 
@@ -168,7 +168,7 @@ async def test_num_sets_change_requires_force_when_active_and_resizes(
         ) as match_inserted,
     ):
         ranking_id = auth_context.ranking.id
-        body = RankingMatchPointsBody(num_sets=3).model_dump(mode="json")
+        body = RankingMatchPointsBody(num_sets=3, play_all_sets=True).model_dump(mode="json")
 
         try:
             # A completed set blocks reducing/changing num_sets without force.
@@ -201,5 +201,5 @@ async def test_num_sets_change_requires_force_when_active_and_resizes(
                 HTTPMethod.PUT,
                 f"rankings/{ranking_id}?force=true",
                 auth_context,
-                json=RankingMatchPointsBody(num_sets=1).model_dump(mode="json"),
+                json=RankingMatchPointsBody(num_sets=1, play_all_sets=True).model_dump(mode="json"),
             )

--- a/backend/tests/integration_tests/api/rankings_test.py
+++ b/backend/tests/integration_tests/api/rankings_test.py
@@ -62,6 +62,7 @@ async def test_rankings_endpoint(
                     "max_points": 21,
                     "last_set_max_points": None,
                     "two_point_advantage": True,
+                    "play_all_sets": True,
                     "draws_allowed": True,
                     "match_points": {
                         "win_points": "1.0",
@@ -139,6 +140,71 @@ async def test_create_ranking_set_points_with_match_bonus(
     assert bonus_ranking.set_points_with_bonus is not None
     assert bonus_ranking.set_points_with_bonus.match_bonus_points == Decimal("2.0")
     await sql_delete_ranking(tournament_id, bonus_ranking.id)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    ("scoring_type", "expected_play_all_sets"),
+    [
+        ("MATCH_POINTS", False),
+        ("SET_POINTS", True),
+        ("SET_POINTS_WITH_MATCH_BONUS", False),
+    ],
+)
+async def test_create_ranking_play_all_sets_default_per_scoring_type(
+    startup_and_shutdown_uvicorn_server: None,
+    auth_context: AuthContext,
+    scoring_type: str,
+    expected_play_all_sets: bool,
+) -> None:
+    response = await send_tournament_request(
+        HTTPMethod.POST,
+        "rankings",
+        auth_context,
+        json={"scoring_type": scoring_type},
+    )
+    assert response.get("success") is True, response
+
+    tournament_id = auth_context.tournament.id
+    rankings_list = await get_all_rankings_in_tournament(tournament_id)
+    created = next(r for r in rankings_list if r.position != 0)
+    try:
+        assert created.scoring_type == ScoringType(scoring_type)
+        assert created.play_all_sets is expected_play_all_sets
+    finally:
+        await sql_delete_ranking(tournament_id, created.id)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_ranking_round_trips_play_all_sets(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    body = {
+        "scoring_type": "MATCH_POINTS",
+        "num_sets": 3,
+        "play_all_sets": True,
+    }
+    async with inserted_ranking(
+        DUMMY_RANKING1.model_copy(update={"tournament_id": auth_context.tournament.id})
+    ) as ranking_inserted:
+        response = await send_tournament_request(
+            HTTPMethod.PUT, f"rankings/{ranking_inserted.id}", auth_context, json=body
+        )
+        assert response["success"] is True
+        updated_rankings = await get_all_rankings_in_tournament(auth_context.tournament.id)
+        updated = next(r for r in updated_rankings if r.id == ranking_inserted.id)
+        assert updated.play_all_sets is True
+
+        response = await send_tournament_request(
+            HTTPMethod.PUT,
+            f"rankings/{ranking_inserted.id}",
+            auth_context,
+            json={**body, "play_all_sets": False},
+        )
+        assert response["success"] is True
+        updated_rankings = await get_all_rankings_in_tournament(auth_context.tournament.id)
+        updated = next(r for r in updated_rankings if r.id == ranking_inserted.id)
+        assert updated.play_all_sets is False
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/backend/tests/unit_tests/match_set_pointer_test.py
+++ b/backend/tests/unit_tests/match_set_pointer_test.py
@@ -26,6 +26,28 @@ def test_derive_match_state_from_pointer(
     assert derive_match_state_from_pointer(completed, num_sets, in_progress) is expected
 
 
+@pytest.mark.parametrize(
+    ("completed", "num_sets", "in_progress", "match_decided", "expected"),
+    [
+        # A decided best-of-n match is COMPLETED once no set is in progress.
+        (2, 3, False, True, MatchState.COMPLETED),
+        # Undecided (split or drawn sets): still in progress.
+        (2, 3, False, False, MatchState.IN_PROGRESS),
+        # A set in progress keeps the match in progress even at majority.
+        (2, 3, True, True, MatchState.IN_PROGRESS),
+    ],
+)
+def test_derive_match_state_from_pointer_best_of_n(
+    completed: int, num_sets: int, in_progress: bool, match_decided: bool, expected: MatchState
+) -> None:
+    assert (
+        derive_match_state_from_pointer(
+            completed, num_sets, in_progress, match_decided=match_decided
+        )
+        is expected
+    )
+
+
 def test_apply_start_from_not_started() -> None:
     assert apply_start(0, False, 3) == (0, True)
 
@@ -42,6 +64,15 @@ def test_apply_start_rejects_when_already_in_progress() -> None:
 def test_apply_start_rejects_when_all_sets_completed() -> None:
     with pytest.raises(IllegalMatchTransitionError):
         apply_start(3, False, 3)
+
+
+def test_apply_start_rejects_when_match_is_decided() -> None:
+    with pytest.raises(IllegalMatchTransitionError, match="decided"):
+        apply_start(2, False, 3, match_decided=True)
+
+
+def test_apply_start_between_sets_when_not_decided() -> None:
+    assert apply_start(2, False, 3, match_decided=False) == (2, True)
 
 
 def test_apply_end_completes_current_set() -> None:

--- a/backend/tests/unit_tests/match_sets_test.py
+++ b/backend/tests/unit_tests/match_sets_test.py
@@ -51,6 +51,55 @@ def test_derive_match_state(sets: list[MatchSet], expected: MatchState) -> None:
     assert derive_match_state(sets) is expected
 
 
+def _completed_set(score1: int, score2: int) -> MatchSet:
+    return _set(MatchSetState.COMPLETED, score1, score2)
+
+
+_NOT_STARTED = _set(MatchSetState.NOT_STARTED)
+_IN_PROGRESS = _set(MatchSetState.IN_PROGRESS)
+
+
+@pytest.mark.parametrize(
+    ("sets", "expected"),
+    [
+        # Majority reached in a Bo3: decided without playing the dead rubber.
+        ([_completed_set(21, 10), _completed_set(21, 15), _NOT_STARTED], MatchState.COMPLETED),
+        # One set apiece: not decided yet.
+        ([_completed_set(21, 10), _completed_set(10, 21), _NOT_STARTED], MatchState.IN_PROGRESS),
+        # A drawn set counts toward neither side: 1 win is not a Bo3 majority.
+        ([_completed_set(21, 10), _completed_set(10, 10), _NOT_STARTED], MatchState.IN_PROGRESS),
+        # A set in progress always keeps the match in progress, even at majority.
+        ([_completed_set(21, 10), _completed_set(21, 15), _IN_PROGRESS], MatchState.IN_PROGRESS),
+        # Surplus completed sets (history rewritten by edits) don't undo completion.
+        (
+            [_completed_set(10, 21), _completed_set(21, 15), _completed_set(21, 15)],
+            MatchState.COMPLETED,
+        ),
+        # Bo5: 3 wins decide; 2 wins plus a draw do not.
+        (
+            [_completed_set(21, 1), _completed_set(21, 1), _completed_set(21, 1)]
+            + [_NOT_STARTED, _NOT_STARTED],
+            MatchState.COMPLETED,
+        ),
+        (
+            [_completed_set(21, 1), _completed_set(21, 1), _completed_set(10, 10)]
+            + [_NOT_STARTED, _NOT_STARTED],
+            MatchState.IN_PROGRESS,
+        ),
+        # Single-set matches behave as before regardless of the flag.
+        ([_completed_set(21, 10)], MatchState.COMPLETED),
+        ([_NOT_STARTED], MatchState.NOT_STARTED),
+    ],
+)
+def test_derive_match_state_best_of_n(sets: list[MatchSet], expected: MatchState) -> None:
+    assert derive_match_state(sets, play_all_sets=False) is expected
+
+
+def test_derive_match_state_play_all_sets_requires_every_set() -> None:
+    sets = [_completed_set(21, 10), _completed_set(21, 15), _NOT_STARTED]
+    assert derive_match_state(sets, play_all_sets=True) is MatchState.IN_PROGRESS
+
+
 def _match_with_sets(sets: list[MatchSet]) -> Match:
     return Match(
         id=MatchId(1),
@@ -106,6 +155,18 @@ def test_get_winner_three_sets_majority() -> None:
     assert match.get_winner() is match.stage_item_input1
     match2 = _match_with_inputs([_completed(10, 21), _completed(21, 5), _completed(19, 21)])
     assert match2.get_winner() is match2.stage_item_input2
+
+
+def test_match_state_uses_play_all_sets_flag() -> None:
+    sets = [_completed(21, 10), _completed(21, 15), _set(MatchSetState.NOT_STARTED)]
+    best_of_three = _match_with_inputs(sets).model_copy(update={"play_all_sets": False})
+    assert best_of_three.state is MatchState.COMPLETED
+    assert best_of_three.get_winner() is best_of_three.stage_item_input1
+
+    play_out_all = _match_with_inputs(sets)
+    assert play_out_all.play_all_sets is True
+    assert play_out_all.state is MatchState.IN_PROGRESS
+    assert play_out_all.get_winner() is None
 
 
 def test_derived_state_property_matches_helper() -> None:

--- a/backend/tests/unit_tests/ranking_model_test.py
+++ b/backend/tests/unit_tests/ranking_model_test.py
@@ -180,6 +180,29 @@ def test_migration_add_draws_allowed_exists_and_chains_from_head() -> None:
     assert callable(migration.downgrade)
 
 
+def test_schema_rankings_has_play_all_sets_column() -> None:
+    from bracket.schema import rankings
+
+    assert "play_all_sets" in rankings.c.keys()
+
+
+def test_migration_add_play_all_sets_exists_and_chains_from_draws_allowed() -> None:
+    import importlib.util
+    from pathlib import Path
+
+    versions_dir = Path(__file__).parent.parent.parent / "alembic" / "versions"
+    files = list(versions_dir.glob("*add_play_all_sets_to_rankings*.py"))
+    assert files, "No add_play_all_sets_to_rankings migration file found"
+    path = files[0]
+    spec = importlib.util.spec_from_file_location("migration", path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    assert migration.down_revision == "b6e3f9a2c7d5"
+    assert callable(migration.upgrade)
+    assert callable(migration.downgrade)
+
+
 def test_schema_subtype_tables_exist() -> None:
     from bracket.schema import (
         ranking_match_points,

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -244,6 +244,8 @@
     "planning_of_matches_legend": "Planung der Spiele",
     "planning_spotlight_description": "Spielplanung ändern",
     "planning_title": "Planung",
+    "play_all_sets_description": "Wenn deaktiviert, endet ein Spiel, sobald eine Seite die Mehrheit der Sätze gewonnen hat.",
+    "play_all_sets_label": "Alle Sätze ausspielen",
     "player_name_input_placeholder": "Bester Spieler aller Zeiten",
     "players_spotlight_description": "Spieler ansehen, hinzufügen oder löschen",
     "players_title": "Spieler",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -244,6 +244,8 @@
     "planning_of_matches_legend": "Planning of matches",
     "planning_spotlight_description": "Change planning of matches",
     "planning_title": "Planning",
+    "play_all_sets_description": "When off, a match ends as soon as one side has won a majority of sets.",
+    "play_all_sets_label": "Play out all sets",
     "player_name_input_placeholder": "Best Player Ever",
     "players_spotlight_description": "View, add or delete players",
     "players_title": "players",

--- a/frontend/src/components/brackets/match.tsx
+++ b/frontend/src/components/brackets/match.tsx
@@ -16,6 +16,7 @@ import {
 } from '@components/utils/match';
 import { RefereeDisplay } from '@components/utils/referee';
 import { TournamentMinimal } from '@components/utils/tournament';
+import { getVisibleSets } from '@logic/score_tracking';
 import {
   MatchSet,
   MatchWithDetails,
@@ -118,7 +119,7 @@ export default function Match({
 
   const multiSetScores = (side: 's1' | 's2') => (
     <div style={{ display: 'flex', gap: '2px', justifyContent: 'flex-end', flexWrap: 'wrap' }}>
-      {match.match_sets.map((set) => scoreCell(set, side))}
+      {getVisibleSets(match).map((set) => scoreCell(set, side))}
     </div>
   );
 

--- a/frontend/src/components/matches/schedule_row.tsx
+++ b/frontend/src/components/matches/schedule_row.tsx
@@ -11,6 +11,7 @@ import {
 } from '@components/utils/match';
 import { RefereeDisplay } from '@components/utils/referee';
 import { getScoreColors } from '@logic/colors';
+import { getVisibleSets } from '@logic/score_tracking';
 import { LevelResponse, MatchSet, MatchWithDetails } from '@openapi';
 import { stringToColour } from '@services/lookups';
 import { getSetScoreColors } from '../../utils/match_sets';
@@ -65,7 +66,7 @@ export function ScheduleRow({
 
   const multiSetScoreCell = (side: 's1' | 's2') => (
     <div style={{ display: 'flex', gap: '3px', justifyContent: 'flex-end' }}>
-      {match.match_sets.map((set) => setScoreChip(set, side))}
+      {getVisibleSets(match).map((set) => setScoreChip(set, side))}
     </div>
   );
 

--- a/frontend/src/components/modals/match_modal.tsx
+++ b/frontend/src/components/modals/match_modal.tsx
@@ -382,7 +382,10 @@ function MatchModalForm({
   const isMultiSet = match.match_sets.length > 1;
   const hasInProgressSet = match.match_sets.some((set) => set.state === 'IN_PROGRESS');
   const completedSetCount = match.match_sets.filter((set) => set.state === 'COMPLETED').length;
-  const canStart = !hasInProgressSet && completedSetCount < match.match_sets.length;
+  // A COMPLETED match may still have unplayed sets (best-of-n decided early); the backend
+  // refuses to start those, so don't offer it.
+  const canStart =
+    !hasInProgressSet && completedSetCount < match.match_sets.length && match.state !== 'COMPLETED';
   const canEnd = hasInProgressSet;
   const canReopen = completedSetCount > 0;
 

--- a/frontend/src/components/scheduling/schedule_grid.tsx
+++ b/frontend/src/components/scheduling/schedule_grid.tsx
@@ -45,6 +45,7 @@ import {
 } from '@logic/planning/layout';
 import { FocusTarget, GridMatchRef, PlannerEvent, SelectionState } from '@logic/planning/selection';
 import { ZOOM_PX_PER_MINUTE, ZoomLevel } from '@logic/planning/zoom';
+import { getVisibleSets } from '@logic/score_tracking';
 import { Court, MatchSet, MatchWithDetails } from '@openapi';
 import { MatchLookupEntry, getStageItemLookup } from '@services/lookups';
 import { getSetScoreColors, getSetsWon } from '../../utils/match_sets';
@@ -291,7 +292,7 @@ function MatchCard({
     <Box
       style={{ marginLeft: 'auto', flexShrink: 0, display: 'flex', gap: 3, alignItems: 'center' }}
     >
-      {match.match_sets.map((set: MatchSet) => {
+      {getVisibleSets(match).map((set: MatchSet) => {
         const colours = getSetScoreColors(set);
         const bg = side === 's1' ? colours.s1 : colours.s2;
         const value = side === 's1' ? set.stage_item_input1_score : set.stage_item_input2_score;

--- a/frontend/src/components/score_tracking/views.tsx
+++ b/frontend/src/components/score_tracking/views.tsx
@@ -34,6 +34,7 @@ import { getScoreColors } from '@logic/colors';
 import {
   getDisplayScores,
   getScoreTrackingViewState,
+  getVisibleSets,
   isEndSetDisabled,
   nextScoresAfterAdjust,
 } from '@logic/score_tracking';
@@ -95,7 +96,7 @@ function MatchSetScores({
   if (isMultiSet) {
     return (
       <div style={{ display: 'flex', gap: '3px', justifyContent: 'flex-end' }}>
-        {match.match_sets.map((set) => (
+        {getVisibleSets(match).map((set) => (
           <SetScoreChip key={set.id} set={set} side={side} />
         ))}
       </div>
@@ -326,7 +327,9 @@ export function ScoreTrackingMatchView({
   const matchData = responseIsValid(swrResponse) ? swrResponse.data!.data : null;
   const n = matchData?.side_switch_every_n_points ?? null;
 
-  const viewState = matchData ? getScoreTrackingViewState(matchData.match_sets) : null;
+  const viewState = matchData
+    ? getScoreTrackingViewState(matchData.match_sets, matchData.state)
+    : null;
   const activeSet = viewState?.kind === 'playing' ? viewState.set : null;
   const combinedScore = activeSet
     ? activeSet.stage_item_input1_score + activeSet.stage_item_input2_score

--- a/frontend/src/components/utils/rankings.test.ts
+++ b/frontend/src/components/utils/rankings.test.ts
@@ -4,7 +4,7 @@ import { Ranking } from '@openapi';
 
 import { Translator } from './types';
 
-import { getRankingTitle } from './rankings';
+import { getPlayAllSetsDefault, getRankingTitle } from './rankings';
 
 const t = ((key: string) => (key === 'ranking_title' ? 'Ranking' : key)) as unknown as Translator;
 
@@ -27,6 +27,22 @@ function makeRanking(overrides: Partial<Ranking>): Ranking {
     ...overrides,
   } as Ranking;
 }
+
+describe('getPlayAllSetsDefault', () => {
+  // Mirrors the backend's per-scoring-type creation defaults: only "set points" scoring
+  // gives every set intrinsic value, so only there do all sets play out by default.
+  it('defaults to best-of behaviour for MATCH_POINTS', () => {
+    expect(getPlayAllSetsDefault('MATCH_POINTS')).toBe(false);
+  });
+
+  it('defaults to playing out all sets for SET_POINTS', () => {
+    expect(getPlayAllSetsDefault('SET_POINTS')).toBe(true);
+  });
+
+  it('defaults to best-of behaviour for SET_POINTS_WITH_MATCH_BONUS', () => {
+    expect(getPlayAllSetsDefault('SET_POINTS_WITH_MATCH_BONUS')).toBe(false);
+  });
+});
 
 describe('getRankingTitle', () => {
   it('uses the custom name when one is set', () => {

--- a/frontend/src/components/utils/rankings.ts
+++ b/frontend/src/components/utils/rankings.ts
@@ -1,6 +1,15 @@
-import { Ranking } from '@openapi';
+import { Ranking, ScoringType } from '@openapi';
 
 import { Translator } from './types';
+
+/**
+ * The default for "Play out all sets" per scoring type, mirroring the backend's creation
+ * defaults: only "set points" scoring gives every set intrinsic standings value, so only
+ * there do all sets play out by default.
+ */
+export function getPlayAllSetsDefault(scoringType: ScoringType): boolean {
+  return scoringType === 'SET_POINTS';
+}
 
 /**
  * The label shown for a ranking. Uses the ranking's custom name when one is set,

--- a/frontend/src/logic/score_tracking.test.ts
+++ b/frontend/src/logic/score_tracking.test.ts
@@ -6,6 +6,7 @@ import {
   getDisplayScores,
   getNextMatchOnCourt,
   getScoreTrackingViewState,
+  getVisibleSets,
   isEndSetDisabled,
   nextScoresAfterAdjust,
 } from './score_tracking';
@@ -76,6 +77,59 @@ describe('getScoreTrackingViewState', () => {
   it('returns completed for single set COMPLETED', () => {
     const sets = [makeSet({ set_number: 1, state: 'COMPLETED' })];
     expect(getScoreTrackingViewState(sets)).toEqual({ kind: 'completed' });
+  });
+
+  it('trusts a COMPLETED match over remaining not-started sets (best-of-n early end)', () => {
+    // A Bo3 decided 2-0: the backend derives COMPLETED even though set 3 was never played.
+    // The tracker must not offer "start next set" on a decided match.
+    const sets = [
+      makeSet({ set_number: 1, state: 'COMPLETED', stage_item_input1_score: 21 }),
+      makeSet({ set_number: 2, state: 'COMPLETED', stage_item_input1_score: 21 }),
+      makeSet({ set_number: 3, state: 'NOT_STARTED' }),
+    ];
+    expect(getScoreTrackingViewState(sets, 'COMPLETED')).toEqual({ kind: 'completed' });
+  });
+
+  it('keeps between_sets when the match is not completed', () => {
+    const set1 = makeSet({ set_number: 1, state: 'COMPLETED' });
+    const set2 = makeSet({ set_number: 2, state: 'NOT_STARTED' });
+    expect(getScoreTrackingViewState([set1, set2], 'IN_PROGRESS')).toEqual({
+      kind: 'between_sets',
+      completed: set1,
+      next: set2,
+      allSets: [set1, set2],
+    });
+  });
+});
+
+describe('getVisibleSets', () => {
+  it('hides unplayed sets on a completed match', () => {
+    // A Bo3 won 2-0 shows two sets, period.
+    const played = [
+      makeSet({ set_number: 1, state: 'COMPLETED', stage_item_input1_score: 21 }),
+      makeSet({ set_number: 2, state: 'COMPLETED', stage_item_input1_score: 21 }),
+    ];
+    const unplayed = makeSet({ set_number: 3, state: 'NOT_STARTED' });
+    expect(getVisibleSets({ state: 'COMPLETED', match_sets: [...played, unplayed] })).toEqual(
+      played
+    );
+  });
+
+  it('shows all sets while the match is still in progress', () => {
+    const sets = [
+      makeSet({ set_number: 1, state: 'COMPLETED', stage_item_input1_score: 21 }),
+      makeSet({ set_number: 2, state: 'IN_PROGRESS' }),
+      makeSet({ set_number: 3, state: 'NOT_STARTED' }),
+    ];
+    expect(getVisibleSets({ state: 'IN_PROGRESS', match_sets: sets })).toEqual(sets);
+  });
+
+  it('shows all sets on a fully played completed match', () => {
+    const sets = [
+      makeSet({ set_number: 1, state: 'COMPLETED', stage_item_input1_score: 21 }),
+      makeSet({ set_number: 2, state: 'COMPLETED', stage_item_input1_score: 21 }),
+    ];
+    expect(getVisibleSets({ state: 'COMPLETED', match_sets: sets })).toEqual(sets);
   });
 });
 

--- a/frontend/src/logic/score_tracking.ts
+++ b/frontend/src/logic/score_tracking.ts
@@ -1,4 +1,4 @@
-import { MatchSet, MatchWithDetails } from '@openapi';
+import { MatchSet, MatchState, MatchWithDetails } from '@openapi';
 
 export type ScoreTrackingViewState =
   | { kind: 'not_started' }
@@ -6,7 +6,14 @@ export type ScoreTrackingViewState =
   | { kind: 'between_sets'; completed: MatchSet; next: MatchSet; allSets: MatchSet[] }
   | { kind: 'completed' };
 
-export function getScoreTrackingViewState(sets: MatchSet[]): ScoreTrackingViewState {
+export function getScoreTrackingViewState(
+  sets: MatchSet[],
+  matchState?: MatchState
+): ScoreTrackingViewState {
+  // A COMPLETED match is final even when not every set was played (best-of-n mode ends the
+  // match at a set-win majority), so never offer a next set on it.
+  if (matchState === 'COMPLETED') return { kind: 'completed' };
+
   const inProgress = sets.find((s) => s.state === 'IN_PROGRESS');
   if (inProgress) return { kind: 'playing', set: inProgress };
 
@@ -20,6 +27,16 @@ export function getScoreTrackingViewState(sets: MatchSet[]): ScoreTrackingViewSt
     return { kind: 'not_started' };
   }
   return { kind: 'completed' };
+}
+
+// Unplayed sets on a completed match were never played (best-of-n ended the match early), so
+// score displays hide them: a Bo3 won 2-0 shows two sets.
+export function getVisibleSets<S extends Pick<MatchSet, 'state'>>(match: {
+  state: MatchState;
+  match_sets: S[];
+}): S[] {
+  if (match.state !== 'COMPLETED') return match.match_sets;
+  return match.match_sets.filter((s) => s.state !== 'NOT_STARTED');
 }
 
 export function getDisplayScores(

--- a/frontend/src/openapi/types.gen.ts
+++ b/frontend/src/openapi/types.gen.ts
@@ -298,6 +298,10 @@ export type Match = {
    */
   match_sets: Array<MatchSet>;
   /**
+   * Play All Sets
+   */
+  play_all_sets: boolean;
+  /**
    * Referee Name
    */
   referee_name: string | null;
@@ -561,6 +565,10 @@ export type MatchWithDetails = {
    */
   num_sets: number;
   /**
+   * Play All Sets
+   */
+  play_all_sets: boolean;
+  /**
    * Referee
    */
   referee: StageItemInputTentative | StageItemInputFinal | StageItemInputEmpty | null;
@@ -680,6 +688,10 @@ export type MatchWithDetailsDefinitive = {
    * Num Sets
    */
   num_sets: number;
+  /**
+   * Play All Sets
+   */
+  play_all_sets: boolean;
   /**
    * Referee
    */
@@ -962,6 +974,10 @@ export type Ranking = {
    */
   num_sets: number;
   /**
+   * Play All Sets
+   */
+  play_all_sets: boolean;
+  /**
    * Position
    */
   position: number;
@@ -1013,6 +1029,10 @@ export type RankingMatchPointsBody = {
    * Num Sets
    */
   num_sets: number;
+  /**
+   * Play All Sets
+   */
+  play_all_sets: boolean;
   /**
    * Position
    */
@@ -1078,6 +1098,10 @@ export type RankingSetPointsBody = {
    */
   num_sets: number;
   /**
+   * Play All Sets
+   */
+  play_all_sets: boolean;
+  /**
    * Position
    */
   position: number | null;
@@ -1123,6 +1147,10 @@ export type RankingSetPointsWithMatchBonusBody = {
    * Num Sets
    */
   num_sets: number;
+  /**
+   * Play All Sets
+   */
+  play_all_sets: boolean;
   /**
    * Position
    */
@@ -2471,6 +2499,10 @@ export type MatchWritable = {
    */
   match_sets: Array<MatchSet>;
   /**
+   * Play All Sets
+   */
+  play_all_sets: boolean;
+  /**
    * Referee Name
    */
   referee_name: string | null;
@@ -2579,6 +2611,10 @@ export type MatchWithDetailsWritable = {
    * Num Sets
    */
   num_sets: number;
+  /**
+   * Play All Sets
+   */
+  play_all_sets: boolean;
   /**
    * Referee
    */
@@ -2698,6 +2734,10 @@ export type MatchWithDetailsDefinitiveWritable = {
    * Num Sets
    */
   num_sets: number;
+  /**
+   * Play All Sets
+   */
+  play_all_sets: boolean;
   /**
    * Referee
    */

--- a/frontend/src/pages/tournaments/[id]/rankings.tsx
+++ b/frontend/src/pages/tournaments/[id]/rankings.tsx
@@ -31,7 +31,7 @@ import TournamentLayout from '@pages/tournaments/_tournament_layout';
 import { getRankings, getStages, getTournamentById } from '@services/adapter';
 import { createRanking, deleteRanking, editRanking } from '@services/ranking';
 
-import { getRankingTitle } from '@components/utils/rankings';
+import { getPlayAllSetsDefault, getRankingTitle } from '@components/utils/rankings';
 
 function RankingDeleteButton({
   t,
@@ -91,6 +91,7 @@ function EditRankingForm({
       max_points: ranking.max_points,
       last_set_max_points: ranking.last_set_max_points ?? 15,
       two_point_advantage: ranking.two_point_advantage,
+      play_all_sets: ranking.play_all_sets,
       draws_allowed: ranking.draws_allowed,
       position: ranking.position,
       side_switch_enabled: ranking.side_switch_every_n_points != null,
@@ -116,6 +117,7 @@ function EditRankingForm({
           values.max_points,
           values.num_sets > 2 ? values.last_set_max_points : null,
           values.two_point_advantage,
+          values.play_all_sets,
           values.draws_allowed,
           values.name,
           values.win_points,
@@ -156,6 +158,14 @@ function EditRankingForm({
               },
             ]}
             {...form.getInputProps('scoring_type')}
+            onChange={(value) => {
+              if (value == null) return;
+              const scoringType = value as ScoringType;
+              form.setFieldValue('scoring_type', scoringType);
+              // The scoring type implies whether dead rubbers are worth playing, so switching
+              // it re-applies that type's default (still overridable before saving).
+              form.setFieldValue('play_all_sets', getPlayAllSetsDefault(scoringType));
+            }}
           />
           {form.values.scoring_type === 'MATCH_POINTS' && (
             <>
@@ -198,6 +208,14 @@ function EditRankingForm({
             <Text c="red" size="sm" mt="xs">
               {t('even_sets_single_elim_error')}
             </Text>
+          )}
+          {form.values.num_sets > 1 && (
+            <Checkbox
+              mt="lg"
+              label={t('play_all_sets_label')}
+              description={t('play_all_sets_description')}
+              {...form.getInputProps('play_all_sets', { type: 'checkbox' })}
+            />
           )}
           <NumberInput
             mt="1rem"

--- a/frontend/src/services/ranking.tsx
+++ b/frontend/src/services/ranking.tsx
@@ -25,6 +25,9 @@ export async function editRanking(
   max_points: number,
   last_set_max_points: number | null,
   two_point_advantage: boolean,
+  // Both flags must always be sent: the backend's per-scoring-type body defaults would
+  // otherwise silently overwrite the stored values on save.
+  play_all_sets: boolean,
   draws_allowed: boolean,
   name: string,
   win_points?: string,
@@ -41,6 +44,7 @@ export async function editRanking(
     max_points,
     last_set_max_points,
     two_point_advantage,
+    play_all_sets,
     draws_allowed,
   };
   if (scoring_type === 'MATCH_POINTS') {


### PR DESCRIPTION
Rankings gain a non-null "play_all_sets" boolean (existing rows migrate to
true; creation defaults per scoring type: false for MATCH_POINTS and
SET_POINTS_WITH_MATCH_BONUS, true for SET_POINTS). When it is off on a
multi-set ranking, match state derivation treats the match as COMPLETED the
moment one side has won floor(num_sets / 2) + 1 sets and no set is in
progress; drawn sets count toward neither side.

Match state stays fully derived: early completion flows through the existing
reconciliation path (standings, elimination advancement, completed_at), and
reopening or score-editing away the majority regresses the match to
in-progress with the remaining sets startable again. Starting a set on a
decided match is refused with the existing illegal-transition error. Recorded
sets are never deleted; surplus completed sets keep counting toward set/point
statistics.

The flag is copied onto match detail responses like the other set
configuration fields (OpenAPI schema and frontend client regenerated). The
ranking form gets a "Play out all sets" checkbox for multi-set rankings that
resets to the scoring type's default on type switch and always round-trips on
save. Score tracking trusts a COMPLETED match (no next-set action) and all
score displays hide unplayed sets on completed matches. New strings added to
the en and de locales.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XRduXECjS3naf8MuB7ucnK