### PR TITLE
Exclude inactive teams from referee duty; clear assignments on deactivation

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -19,7 +19,7 @@ from bracket.models.db.match import (
     MatchWithDetailsDefinitive,
     SchedulerWeights,
 )
-from bracket.models.db.stage_item_inputs import StageItemInputEmpty
+from bracket.models.db.stage_item_inputs import StageItemInputEmpty, StageItemInputFinal
 from bracket.models.db.tournament import Tournament
 from bracket.models.db.util import StageItemWithRounds, StageWithStageItems
 from bracket.sql.courts import get_all_courts_in_tournament
@@ -184,13 +184,16 @@ def _referee_slots_by_stage(
     later stage's slot (e.g. "1st of the group stage") names a team that is still unknown while
     an earlier stage is being played, so it must never be picked to referee an earlier match.
     Within a stage, unresolved slots are allowed exactly as they are for playing slots; they
-    simply resolve to a team later. Slots are returned sorted for deterministic candidate
-    ordering.
+    simply resolve to a team later. A Final slot whose team is inactive is excluded universally
+    -- an inactive team never referees, in any stage type (issue #282). Slots are returned sorted
+    for deterministic candidate ordering.
     """
     by_stage: dict[StageId, list[StageItemInputId]] = defaultdict(list)
     for stage in stages:
         for stage_item in stage.stage_items:
             for input_ in stage_item.inputs:
+                if isinstance(input_, StageItemInputFinal) and not input_.team.active:
+                    continue
                 by_stage[stage.id].append(input_.id)
     return {stage_id: sorted(slot_ids) for stage_id, slot_ids in by_stage.items()}
 

--- a/backend/bracket/routes/teams.py
+++ b/backend/bracket/routes/teams.py
@@ -45,6 +45,7 @@ from bracket.sql.players import (
     get_player_team_ids,
     insert_player,
 )
+from bracket.sql.referees import sql_clear_referee_assignments_for_team
 from bracket.sql.stage_item_inputs import get_stage_item_ids_for_team
 from bracket.sql.stage_items import get_stage_item
 from bracket.sql.teams import (
@@ -163,6 +164,14 @@ async def update_team_by_id(
         for stage_item_id in await get_stage_item_ids_for_team(tournament_id, team.id):
             stage_item = await get_stage_item(tournament_id, stage_item_id)
             await reconcile_stage_item(tournament_id, stage_item)
+
+        if not team_body.active:
+            # Inactive teams are excluded from referee duty universally (issue #282); proactively
+            # clear any not-yet-started match where this team is still assigned as referee. An
+            # in-progress match's referee is left untouched. The freed slot is left empty for an
+            # organizer to fill via "auto-assign referee" rather than auto-backfilled here, since
+            # that's a heavyweight solve better left an explicit, visible action.
+            await sql_clear_referee_assignments_for_team(tournament_id, team.id)
 
     return SingleTeamResponse(
         data=assert_some(

--- a/backend/bracket/sql/referees.py
+++ b/backend/bracket/sql/referees.py
@@ -1,5 +1,5 @@
 from bracket.database import database
-from bracket.utils.id_types import MatchId, StageItemInputId, TournamentId
+from bracket.utils.id_types import MatchId, StageItemInputId, TeamId, TournamentId
 
 
 async def sql_set_match_abstract_referee_slot(match_id: MatchId, slot: int) -> None:
@@ -64,3 +64,27 @@ async def sql_clear_match_referee(match_id: MatchId) -> None:
         WHERE matches.id = :match_id
         """
     await database.execute(query=query, values={"match_id": match_id})
+
+
+async def sql_clear_referee_assignments_for_team(
+    tournament_id: TournamentId, team_id: TeamId
+) -> None:
+    """Proactively un-assign a deactivated team from every not-yet-started match it referees.
+
+    Mirrors the Mexicano round-recalculation precedent (issue #261): a deactivation reacts
+    immediately rather than waiting for the next unrelated change. "Not yet started" uses the
+    same match-progress-pointer condition as elsewhere (e.g. sql/tournament_issues.py): no set
+    completed and no set in progress. In-progress matches keep their referee untouched.
+    """
+    query = """
+        UPDATE matches
+        SET referee_stage_item_input_id = NULL
+        WHERE matches.referee_stage_item_input_id IN (
+            SELECT id FROM stage_item_inputs
+            WHERE stage_item_inputs.team_id = :team_id
+            AND stage_item_inputs.tournament_id = :tournament_id
+        )
+        AND matches.completed_set_count = 0
+        AND NOT matches.current_set_in_progress
+        """
+    await database.execute(query=query, values={"team_id": team_id, "tournament_id": tournament_id})

--- a/backend/tests/integration_tests/api/auto_assign_referees_test.py
+++ b/backend/tests/integration_tests/api/auto_assign_referees_test.py
@@ -7,7 +7,7 @@ from bracket.models.db.stage_item_inputs import (
     StageItemInputCreateBodyFinal,
     StageItemInputCreateBodyTentative,
 )
-from bracket.schema import stage_item_inputs, tournaments
+from bracket.schema import stage_item_inputs, teams, tournaments
 from bracket.sql.referees import sql_set_match_referee_slot
 from bracket.sql.shared import sql_delete_stage_item_with_foreign_keys
 from bracket.sql.stage_items import sql_create_stage_item_with_inputs
@@ -282,6 +282,77 @@ async def test_auto_assign_referees_assigns_placeholder_matches(
     assert all(
         m.referee_stage_item_input_id in slots_by_stage[stage_two.id] for m in placeholder_matches
     )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_auto_assign_referees_excludes_inactive_team(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """An inactive team is never picked as referee, even when it's the only same-stage
+    candidate for a match (issue #282): that match is left unassigned rather than handed to it.
+    """
+    tid = auth_context.tournament.id
+
+    # Schedule with referees disabled so "schedule_matches" itself assigns none (it would
+    # otherwise assign referees too, before this test gets a chance to deactivate t3), then
+    # enable referees and deactivate t3 so only the standalone auto-assign endpoint is exercised.
+    async with (
+        inserted_court(DUMMY_COURT1.model_copy(update={"tournament_id": tid})),
+        inserted_stage(DUMMY_STAGE1.model_copy(update={"tournament_id": tid})) as stage,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t1,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t2,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tid})) as t3,
+    ):
+        si = await _setup_round_robin_3teams(tid, stage.id, t1.id, t2.id, t3.id)
+        await send_tournament_request(HTTPMethod.POST, "schedule_matches", auth_context)
+
+        await database.execute(query=teams.update().where(teams.c.id == t3.id).values(active=False))
+        await database.execute(
+            query=tournaments.update().where(tournaments.c.id == tid).values(referees_enabled=True)
+        )
+        try:
+            t3_slot_id = await database.fetch_val(
+                query=stage_item_inputs.select().where(stage_item_inputs.c.team_id == t3.id),
+                column="id",
+            )
+
+            response = await send_tournament_request(HTTPMethod.POST, _ENDPOINT, auth_context)
+
+            stages_after = await get_full_tournament_details(tid)
+            await sql_delete_stage_item_with_foreign_keys(si.id)
+        finally:
+            await database.execute(
+                query=tournaments.update()
+                .where(tournaments.c.id == tid)
+                .values(referees_enabled=False)
+            )
+
+    assert response == SUCCESS_RESPONSE
+
+    scheduled_after = [
+        m
+        for s in stages_after
+        for si_ in s.stage_items
+        for r in si_.rounds
+        for m in r.matches
+        if m.court_id is not None and m.start_time is not None
+    ]
+    assert len(scheduled_after) == 3
+
+    # t3's slot is never assigned as referee anywhere.
+    assert all(m.referee_stage_item_input_id != t3_slot_id for m in scheduled_after)
+
+    # The T1-vs-T2 match's only same-stage candidate is t3 (inactive), so it's left unassigned;
+    # the other two matches each have an active third team available and get one.
+    t1_vs_t2 = next(
+        m
+        for m in scheduled_after
+        if {m.stage_item_input1.team_id, m.stage_item_input2.team_id} == {t1.id, t2.id}  # type: ignore[union-attr]
+    )
+    others = [m for m in scheduled_after if m.id != t1_vs_t2.id]
+    assert t1_vs_t2.referee_stage_item_input_id is None
+    assert len(others) == 2
+    assert all(m.referee_stage_item_input_id is not None for m in others)
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/backend/tests/integration_tests/api/referees_test.py
+++ b/backend/tests/integration_tests/api/referees_test.py
@@ -3,7 +3,7 @@ from contextlib import AbstractAsyncContextManager
 import pytest
 
 from bracket.database import database
-from bracket.models.db.match import Match
+from bracket.models.db.match import Match, MatchSetState
 from bracket.models.db.stage_item_inputs import (
     StageItemInputEmpty,
     StageItemInputFinal,
@@ -380,6 +380,163 @@ async def test_patch_match_both_referee_fields_rejected(
         )
         assert "detail" in response
         assert "success" not in response
+
+        await assert_row_count_and_clear(matches, 1)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_patch_match_referee_slot_inactive_team_rejected(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """A referee slot belonging to an inactive team is rejected: inactive teams are excluded
+    from referee duty universally (issue #282), the manual path honouring the same rule as the
+    auto-scheduler and the frontend dropdown.
+    """
+    tournament_id = auth_context.tournament.id
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
+        ) as stage_inserted,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage_inserted.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item_inserted,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item_inserted.id})
+        ) as round_inserted,
+        inserted_team(DUMMY_TEAM1.model_copy(update={"tournament_id": tournament_id})) as team1,
+        inserted_team(DUMMY_TEAM2.model_copy(update={"tournament_id": tournament_id})) as team2,
+        inserted_team(
+            DUMMY_TEAM3.model_copy(update={"tournament_id": tournament_id, "active": False})
+        ) as team3,
+        _final_input(tournament_id, stage_item_inserted.id, 0, team1.id) as input1,
+        _final_input(tournament_id, stage_item_inserted.id, 1, team2.id) as input2,
+        _final_input(tournament_id, stage_item_inserted.id, 2, team3.id) as referee_input,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_inserted.id,
+                    "stage_item_input1_id": input1.id,
+                    "stage_item_input2_id": input2.id,
+                    "court_id": None,
+                }
+            )
+        ) as match_inserted,
+    ):
+        response = await send_tournament_request(
+            HTTPMethod.PUT,
+            f"matches/{match_inserted.id}",
+            auth_context,
+            None,
+            {"round_id": round_inserted.id, "referee_stage_item_input_id": referee_input.id},
+        )
+        assert "detail" in response
+        assert "success" not in response
+
+        match_after = await fetch_one_parsed_certain(
+            database, Match, query=matches.select().where(matches.c.id == match_inserted.id)
+        )
+        assert match_after.referee_stage_item_input_id is None
+
+        await assert_row_count_and_clear(matches, 1)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_deactivating_team_clears_not_started_referee_assignment(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """Deactivating a team proactively clears its referee assignment on a not-yet-started
+    match, mirroring the existing Mexicano round-recalculation precedent (issue #282).
+    """
+    tournament_id = auth_context.tournament.id
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
+        ) as stage_inserted,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage_inserted.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item_inserted,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item_inserted.id})
+        ) as round_inserted,
+        inserted_team(DUMMY_TEAM3.model_copy(update={"tournament_id": tournament_id})) as team3,
+        _final_input(tournament_id, stage_item_inserted.id, 2, team3.id) as referee_input,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_inserted.id,
+                    "stage_item_input1_id": None,
+                    "stage_item_input2_id": None,
+                    "court_id": None,
+                    "referee_stage_item_input_id": referee_input.id,
+                }
+            )
+        ) as match_inserted,
+    ):
+        await send_tournament_request(
+            HTTPMethod.PUT,
+            f"teams/{team3.id}",
+            auth_context,
+            json={"name": team3.name, "active": False, "player_ids": []},
+        )
+
+        match_after = await fetch_one_parsed_certain(
+            database, Match, query=matches.select().where(matches.c.id == match_inserted.id)
+        )
+        assert match_after.referee_stage_item_input_id is None
+
+        await assert_row_count_and_clear(matches, 1)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_deactivating_team_keeps_in_progress_referee_assignment(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    """An in-progress match's referee assignment is left untouched by deactivation: only
+    not-yet-started matches are proactively un-assigned (issue #282).
+    """
+    tournament_id = auth_context.tournament.id
+    async with (
+        inserted_stage(
+            DUMMY_STAGE1.model_copy(update={"tournament_id": tournament_id})
+        ) as stage_inserted,
+        inserted_stage_item(
+            DUMMY_STAGE_ITEM1.model_copy(
+                update={"stage_id": stage_inserted.id, "ranking_id": auth_context.ranking.id}
+            )
+        ) as stage_item_inserted,
+        inserted_round(
+            DUMMY_ROUND1.model_copy(update={"stage_item_id": stage_item_inserted.id})
+        ) as round_inserted,
+        inserted_team(DUMMY_TEAM3.model_copy(update={"tournament_id": tournament_id})) as team3,
+        _final_input(tournament_id, stage_item_inserted.id, 2, team3.id) as referee_input,
+        inserted_match(
+            DUMMY_MATCH1.model_copy(
+                update={
+                    "round_id": round_inserted.id,
+                    "stage_item_input1_id": None,
+                    "stage_item_input2_id": None,
+                    "court_id": None,
+                    "referee_stage_item_input_id": referee_input.id,
+                }
+            ),
+            set_state=MatchSetState.IN_PROGRESS,
+        ) as match_inserted,
+    ):
+        await send_tournament_request(
+            HTTPMethod.PUT,
+            f"teams/{team3.id}",
+            auth_context,
+            json={"name": team3.name, "active": False, "player_ids": []},
+        )
+
+        match_after = await fetch_one_parsed_certain(
+            database, Match, query=matches.select().where(matches.c.id == match_inserted.id)
+        )
+        assert match_after.referee_stage_item_input_id == referee_input.id
 
         await assert_row_count_and_clear(matches, 1)
 

--- a/frontend/src/components/modals/match_modal.tsx
+++ b/frontend/src/components/modals/match_modal.tsx
@@ -20,7 +20,7 @@ import { SWRResponse } from 'swr';
 
 import { ConfirmModal } from '@components/modals/confirm_modal';
 import { formatMatchInput1, formatMatchInput2 } from '@components/utils/match';
-import { formatStageItemInput } from '@components/utils/stage_item_input';
+import { formatStageItemInput, isEligibleRefereeSlot } from '@components/utils/stage_item_input';
 import { TournamentMinimal } from '@components/utils/tournament';
 import { CONFLICT_COLOURS, levelSwatchColour } from '@logic/colors';
 import { computeConflictFlags } from '@logic/planning/conflicts';
@@ -263,7 +263,8 @@ function MatchModalForm({
   // Group A" placeholders, and still-empty positions), mirroring how playing slots are picked.
   // Slots are restricted to the match's stage — not just its level — because a later stage's slot
   // names a participant who is still unknown while this match is played; the backend enforces the
-  // same rule (see eligible_referee_slot_ids).
+  // same rule (see eligible_referee_slot_ids). An inactive team is also excluded universally,
+  // mirroring the backend's isEligibleRefereeSlot-equivalent filter.
   const matchStageId = matchEntry?.stage.id;
   const ownInputIds = new Set(
     [match.stage_item_input1_id, match.stage_item_input2_id].filter((id) => id != null)
@@ -274,6 +275,7 @@ function MatchModalForm({
         .flatMap((stage) => stage.stage_items)
         .flatMap((stageItem) => stageItem.inputs)
         .filter((input) => !ownInputIds.has(input.id))
+        .filter(isEligibleRefereeSlot)
         .map((input) => ({
           value: `${input.id}`,
           label: formatStageItemInput(input, stageItemsLookup) ?? t('empty_slot'),

--- a/frontend/src/components/utils/stage_item_input.test.ts
+++ b/frontend/src/components/utils/stage_item_input.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { StageItemInputEmpty, StageItemInputFinal, StageItemInputTentative, Team } from '@openapi';
+
+import { isEligibleRefereeSlot } from './stage_item_input';
+
+const baseInput = {
+  id: 1,
+  slot: 0,
+  stage_item_id: 1,
+  tournament_id: 1,
+  points: '0',
+  wins: 0,
+  draws: 0,
+  losses: 0,
+  set_difference: 0,
+  point_difference: 0,
+};
+
+function makeTeam(overrides: Partial<Team>): Team {
+  return {
+    id: 1,
+    tournament_id: 1,
+    created: '2026-01-01T00:00:00Z',
+    name: 'Team 1',
+    active: true,
+    elo_score: '0',
+    swiss_score: '0',
+    wins: 0,
+    draws: 0,
+    losses: 0,
+    logo_path: null,
+    level_id: null,
+    ...overrides,
+  } as Team;
+}
+
+function makeFinalInput(active: boolean): StageItemInputFinal {
+  return {
+    ...baseInput,
+    team_id: 1,
+    winner_from_stage_item_id: null,
+    winner_position: null,
+    team: makeTeam({ active }),
+  };
+}
+
+function makeTentativeInput(): StageItemInputTentative {
+  return {
+    ...baseInput,
+    team_id: null,
+    winner_from_stage_item_id: 1,
+    winner_position: 1,
+  };
+}
+
+function makeEmptyInput(): StageItemInputEmpty {
+  return {
+    ...baseInput,
+    team_id: null,
+    winner_from_stage_item_id: null,
+    winner_position: null,
+  };
+}
+
+describe('isEligibleRefereeSlot', () => {
+  it('excludes a Final slot whose team is inactive', () => {
+    expect(isEligibleRefereeSlot(makeFinalInput(false))).toBe(false);
+  });
+
+  it('includes a Final slot whose team is active', () => {
+    expect(isEligibleRefereeSlot(makeFinalInput(true))).toBe(true);
+  });
+
+  it('includes a Tentative slot (team not yet known)', () => {
+    expect(isEligibleRefereeSlot(makeTentativeInput())).toBe(true);
+  });
+
+  it('includes an Empty slot (team not yet known)', () => {
+    expect(isEligibleRefereeSlot(makeEmptyInput())).toBe(true);
+  });
+});

--- a/frontend/src/components/utils/stage_item_input.tsx
+++ b/frontend/src/components/utils/stage_item_input.tsx
@@ -52,3 +52,10 @@ export function formatStageItemInput(
   }
   return null;
 }
+
+// Inactive teams are excluded from referee duty universally, across every stage type (issue
+// #282): a resolved (Final) slot naming an inactive team is never a referee candidate. Tentative
+// and Empty slots don't yet name a team, so they stay eligible exactly as they do for playing.
+export function isEligibleRefereeSlot(stage_item_input: StageItemInput) {
+  return !('team' in stage_item_input) || stage_item_input.team.active;
+}


### PR DESCRIPTION
## Summary

Implements ["Implement universal referee-eligibility exclusion + proactive un-assignment"](https://github.com/pspeter/bracket/issues/282), a child ticket of ["Inactive team semantics: design spec + implementation"](https://github.com/pspeter/bracket/issues/279).

- Inactive teams are now excluded from referee eligibility universally, across every stage type: `_referee_slots_by_stage` (`backend/bracket/logic/planning/matches.py`) — the single source of truth shared by the CP-SAT auto-scheduler, the assign-missing-referees pass, and manual single-match validation — now drops any `StageItemInputFinal` slot whose team is inactive.
- Deactivating a team (`PUT /teams/{id}`) now proactively clears its referee assignment on not-yet-started matches (`sql_clear_referee_assignments_for_team` in `backend/bracket/sql/referees.py`, wired into `backend/bracket/routes/teams.py`), mirroring the existing Mexicano round-recalculation precedent (#261). In-progress matches are left untouched, using the same "not started" SQL condition (`completed_set_count = 0 AND NOT current_set_in_progress`) already used in `sql/tournament_issues.py`.
- The freed slot is left empty for an organizer to fill via "auto-assign referee" rather than auto-backfilled inline — that's a heavyweight CP-SAT solve better left an explicit, visible action. Noted for the closing ADR ticket (#285).
- Frontend: `refereeSlotOptions` in `match_modal.tsx` now filters through a new `isEligibleRefereeSlot` helper (`frontend/src/components/utils/stage_item_input.tsx`), so the manual referee dropdown mirrors the backend rule.

## Test plan

- [x] Backend: new integration tests in `auto_assign_referees_test.py` (excludes inactive team from auto-assign candidates) and `referees_test.py` (manual assignment to an inactive team's slot is rejected; deactivation clears a not-started match's referee; an in-progress match's referee is left untouched)
- [x] `ENVIRONMENT=CI uv run pytest .` — 577 passed
- [x] `uv run ruff format --check .` / `uv run ruff check .` / `uv run mypy .` / `uv run pyrefly check` / `uv run pylint bracket tests cli.py` — all clean
- [x] Frontend: new unit test `stage_item_input.test.ts` for `isEligibleRefereeSlot`
- [x] `pnpm test` (tsc + prettier + vitest) — 292 tests passed
- [x] Manually verified end-to-end with a real backend + frontend + headless browser (Rodney): deactivated a team mid-tournament, confirmed its existing referee assignment on a not-started match was cleared, that the manual referee dropdown no longer lists it, and that "Assign missing referees" never re-assigns it

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GJabMgbQFo7Mz5JmmkCHG3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJabMgbQFo7Mz5JmmkCHG3)_